### PR TITLE
fix(interpolation): serialize loop items as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **F047**: ForEach loop items serialize using Go's default format instead of JSON
+  - Template interpolation now uses JSON marshalling for complex types in `{{.loop.Item}}`
+  - Primitive values (string, int, float, bool) pass through unchanged for backward compatibility
+  - Added `SerializeLoopItem()` helper in `pkg/interpolation` for type-aware serialization
+  - Fixes workflows using `for_each` with `call_workflow` receiving malformed data format
 - **Bug-48**: Cannot run two workflows simultaneously
   - Replaced BadgerDB with SQLite WAL mode for concurrent access
   - Multiple `awf` processes can now execute workflows in parallel

--- a/docs/reference/interpolation.md
+++ b/docs/reference/interpolation.md
@@ -122,6 +122,46 @@ process_single:
     echo "First: {{.loop.first}}, Last: {{.loop.last}}"
 ```
 
+#### Loop Item JSON Serialization
+
+When `{{.loop.item}}` contains complex types (objects, arrays), it is automatically serialized to JSON:
+
+- **Objects** → JSON object: `{"name":"value","nested":{"key":"data"}}`
+- **Arrays** → JSON array: `[1,2,3]` or `["a","b","c"]`
+- **Strings** → Pass through unchanged: `"main.go"` stays as `main.go` (not quoted)
+- **Numbers** → Converted to string: `42` becomes `"42"`, `3.14` becomes `"3.14"`
+- **Booleans** → Converted to string: `true` becomes `"true"`, `false` becomes `"false"`
+
+This is especially useful when passing loop items to `call_workflow`:
+
+```yaml
+# Parent workflow with objects
+process_reviews:
+  type: step
+  command: |
+    echo '[{"file":"main.go","type":"fix"},{"file":"test.go","type":"chore"}]'
+  capture:
+    stdout: reviews_json
+  on_success: loop_reviews
+
+loop_reviews:
+  type: for_each
+  items: "{{.states.process_reviews.output}}"
+  body:
+    - call_child_workflow
+
+call_child_workflow:
+  type: call_workflow
+  workflow: review-file
+  inputs:
+    review: "{{.loop.item}}"  # Passed as valid JSON object to child
+
+# Child workflow receives properly formatted JSON
+# {{.inputs.review}} = {"file":"main.go","type":"fix"}
+```
+
+**Note**: String items pass through unchanged without JSON quoting. Numbers and booleans are converted to their string representations.
+
 ### Nested Loop Parent Access
 
 For nested loops, access outer loop context via `{{.loop.parent}}`:

--- a/docs/user-guide/workflow-syntax.md
+++ b/docs/user-guide/workflow-syntax.md
@@ -520,6 +520,69 @@ Sub-workflow errors propagate to the parent:
 - If sub-workflow times out, parent receives timeout error and follows `on_failure`
 - If sub-workflow definition is not found, execution fails with `undefined_subworkflow` error
 
+### Using Call Workflow in Loops
+
+Combine `for_each` with `call_workflow` to process multiple items in parallel sub-workflows. Loop items (especially complex objects) are automatically serialized to JSON:
+
+```yaml
+# Example: Process multiple files across sub-workflows
+prepare_items:
+  type: step
+  command: |
+    echo '[
+      {"file":"main.go","language":"Go"},
+      {"file":"app.py","language":"Python"},
+      {"file":"index.js","language":"JavaScript"}
+    ]'
+  capture:
+    stdout: items_json
+  on_success: process_files
+
+process_files:
+  type: for_each
+  items: "{{.states.prepare_items.output}}"
+  body:
+    - analyze_file
+
+analyze_file:
+  type: call_workflow
+  call_workflow:
+    workflow: analyze-source-file
+    inputs:
+      # {{.loop.item}} is automatically JSON-serialized for complex types
+      file_info: "{{.loop.item}}"
+    outputs:
+      analysis: file_analysis
+  on_success: next
+
+next:
+  type: terminal
+```
+
+Child workflow receives properly formatted JSON input:
+```yaml
+name: analyze-source-file
+
+inputs:
+  - name: file_info
+    type: string  # Receives JSON string
+
+states:
+  initial: parse
+  parse:
+    type: step
+    command: |
+      # Parse JSON input safely
+      echo '{{.inputs.file_info}}' | jq -r '.file'
+    on_success: done
+  done:
+    type: terminal
+
+outputs:
+  - name: file_analysis
+    from: states.parse.output
+```
+
 ---
 
 ## Retry Configuration

--- a/pkg/interpolation/resolver_test.go
+++ b/pkg/interpolation/resolver_test.go
@@ -957,3 +957,1669 @@ func TestLoopData_Index1_Method(t *testing.T) {
 		})
 	}
 }
+
+// Item: T004
+// Feature: F047
+func TestTemplateResolver_WithJSONFunction_HappyPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		inputs   map[string]any
+		want     string
+	}{
+		{
+			name:     "string primitive passes through",
+			template: `{{json .inputs.val}}`,
+			inputs:   map[string]any{"val": "hello"},
+			want:     `"hello"`,
+		},
+		{
+			name:     "integer as JSON",
+			template: `{{json .inputs.val}}`,
+			inputs:   map[string]any{"val": 42},
+			want:     `42`,
+		},
+		{
+			name:     "float as JSON",
+			template: `{{json .inputs.val}}`,
+			inputs:   map[string]any{"val": 3.14},
+			want:     `3.14`,
+		},
+		{
+			name:     "boolean true as JSON",
+			template: `{{json .inputs.val}}`,
+			inputs:   map[string]any{"val": true},
+			want:     `true`,
+		},
+		{
+			name:     "boolean false as JSON",
+			template: `{{json .inputs.val}}`,
+			inputs:   map[string]any{"val": false},
+			want:     `false`,
+		},
+		{
+			name:     "simple map as JSON object",
+			template: `{{json .inputs.val}}`,
+			inputs: map[string]any{
+				"val": map[string]any{"name": "Alice", "age": 30},
+			},
+			want: `{"age":30,"name":"Alice"}`,
+		},
+		{
+			name:     "simple slice as JSON array",
+			template: `{{json .inputs.val}}`,
+			inputs: map[string]any{
+				"val": []any{"a", "b", "c"},
+			},
+			want: `["a","b","c"]`,
+		},
+		{
+			name:     "nested map structure",
+			template: `{{json .inputs.val}}`,
+			inputs: map[string]any{
+				"val": map[string]any{
+					"user": map[string]any{
+						"name": "Bob",
+						"tags": []any{"dev", "admin"},
+					},
+				},
+			},
+			want: `{"user":{"name":"Bob","tags":["dev","admin"]}}`,
+		},
+		{
+			name:     "map with mixed types",
+			template: `{{json .inputs.val}}`,
+			inputs: map[string]any{
+				"val": map[string]any{
+					"name":   "Service",
+					"count":  5,
+					"active": true,
+					"score":  98.5,
+				},
+			},
+			want: `{"active":true,"count":5,"name":"Service","score":98.5}`,
+		},
+		{
+			name:     "slice of maps",
+			template: `{{json .inputs.val}}`,
+			inputs: map[string]any{
+				"val": []any{
+					map[string]any{"id": 1, "name": "first"},
+					map[string]any{"id": 2, "name": "second"},
+				},
+			},
+			want: `[{"id":1,"name":"first"},{"id":2,"name":"second"}]`,
+		},
+	}
+
+	resolver := interpolation.NewTemplateResolver()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			for k, v := range tt.inputs {
+				ctx.Inputs[k] = v
+			}
+
+			got, err := resolver.Resolve(tt.template, ctx)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// Item: T004
+// Feature: F047
+func TestTemplateResolver_WithJSONFunction_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		inputs   map[string]any
+		want     string
+	}{
+		{
+			name:     "nil value",
+			template: `{{json .inputs.val}}`,
+			inputs:   map[string]any{"val": nil},
+			want:     `null`,
+		},
+		{
+			name:     "empty map",
+			template: `{{json .inputs.val}}`,
+			inputs:   map[string]any{"val": map[string]any{}},
+			want:     `{}`,
+		},
+		{
+			name:     "empty slice",
+			template: `{{json .inputs.val}}`,
+			inputs:   map[string]any{"val": []any{}},
+			want:     `[]`,
+		},
+		{
+			name:     "empty string",
+			template: `{{json .inputs.val}}`,
+			inputs:   map[string]any{"val": ""},
+			want:     `""`,
+		},
+		{
+			name:     "zero integer",
+			template: `{{json .inputs.val}}`,
+			inputs:   map[string]any{"val": 0},
+			want:     `0`,
+		},
+		{
+			name:     "zero float",
+			template: `{{json .inputs.val}}`,
+			inputs:   map[string]any{"val": 0.0},
+			want:     `0`,
+		},
+		{
+			name:     "string with unicode",
+			template: `{{json .inputs.val}}`,
+			inputs:   map[string]any{"val": "Hello 世界 🌍"},
+			want:     `"Hello 世界 🌍"`,
+		},
+		{
+			name:     "string with special chars",
+			template: `{{json .inputs.val}}`,
+			inputs:   map[string]any{"val": `line1\nline2\ttab`},
+			want:     `"line1\\nline2\\ttab"`,
+		},
+		{
+			name:     "string with quotes",
+			template: `{{json .inputs.val}}`,
+			inputs:   map[string]any{"val": `she said "hello"`},
+			want:     `"she said \"hello\""`,
+		},
+		{
+			name:     "deeply nested structure",
+			template: `{{json .inputs.val}}`,
+			inputs: map[string]any{
+				"val": map[string]any{
+					"level1": map[string]any{
+						"level2": map[string]any{
+							"level3": []any{1, 2, 3},
+						},
+					},
+				},
+			},
+			want: `{"level1":{"level2":{"level3":[1,2,3]}}}`,
+		},
+		{
+			name:     "array with null elements",
+			template: `{{json .inputs.val}}`,
+			inputs:   map[string]any{"val": []any{1, nil, 3}},
+			want:     `[1,null,3]`,
+		},
+		{
+			name:     "negative numbers",
+			template: `{{json .inputs.val}}`,
+			inputs:   map[string]any{"val": -42},
+			want:     `-42`,
+		},
+	}
+
+	resolver := interpolation.NewTemplateResolver()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			for k, v := range tt.inputs {
+				ctx.Inputs[k] = v
+			}
+
+			got, err := resolver.Resolve(tt.template, ctx)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// Item: T004
+// Feature: F047
+func TestTemplateResolver_WithJSONFunction_LoopItem(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		item     any
+		want     string
+	}{
+		{
+			name:     "loop item map as JSON",
+			template: `{{json .loop.Item}}`,
+			item:     map[string]any{"name": "S1", "type": "fix"},
+			want:     `{"name":"S1","type":"fix"}`,
+		},
+		{
+			name:     "loop item with nested structure",
+			template: `{{json .loop.Item}}`,
+			item: map[string]any{
+				"name":  "S1",
+				"files": []any{"a.go", "b.go"},
+			},
+			want: `{"files":["a.go","b.go"],"name":"S1"}`,
+		},
+		{
+			name:     "loop item string primitive",
+			template: `{{json .loop.Item}}`,
+			item:     "simple-string",
+			want:     `"simple-string"`,
+		},
+		{
+			name:     "loop item integer",
+			template: `{{json .loop.Item}}`,
+			item:     123,
+			want:     `123`,
+		},
+		{
+			name:     "loop item in workflow input context",
+			template: `item={{json .loop.Item}}`,
+			item: map[string]any{
+				"id":     1,
+				"status": "pending",
+			},
+			want: `item={"id":1,"status":"pending"}`,
+		},
+	}
+
+	resolver := interpolation.NewTemplateResolver()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			ctx.Loop = &interpolation.LoopData{
+				Item: tt.item,
+			}
+
+			got, err := resolver.Resolve(tt.template, ctx)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// Item: T004
+// Feature: F047
+func TestTemplateResolver_WithJSONFunction_CombinedWithOtherFunctions(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	t.Run("json with escape in same template", func(t *testing.T) {
+		ctx := interpolation.NewContext()
+		ctx.Inputs["data"] = map[string]any{"key": "value"}
+		ctx.Inputs["file"] = "test file.txt"
+
+		template := `echo {{json .inputs.data}} > {{escape .inputs.file}}`
+		got, err := resolver.Resolve(template, ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, `echo {"key":"value"} > 'test file.txt'`, got)
+	})
+
+	t.Run("multiple json calls in template", func(t *testing.T) {
+		ctx := interpolation.NewContext()
+		ctx.Inputs["obj1"] = map[string]any{"a": 1}
+		ctx.Inputs["obj2"] = map[string]any{"b": 2}
+
+		template := `{{json .inputs.obj1}} {{json .inputs.obj2}}`
+		got, err := resolver.Resolve(template, ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, `{"a":1} {"b":2}`, got)
+	})
+}
+
+// Item: T004
+// Feature: F047
+func TestTemplateResolver_WithJSONFunction_ErrorHandling(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	t.Run("undefined variable with json function", func(t *testing.T) {
+		ctx := interpolation.NewContext()
+
+		template := `{{json .inputs.missing}}`
+		_, err := resolver.Resolve(template, ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing")
+	})
+
+	t.Run("json function with no arguments", func(t *testing.T) {
+		ctx := interpolation.NewContext()
+
+		template := `{{json}}`
+		_, err := resolver.Resolve(template, ctx)
+
+		require.Error(t, err)
+	})
+}
+
+// Item: T006
+// Feature: F047
+func TestTemplateResolver_WithJSONFunction_UnmarshallableTypes(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	t.Run("channel type cannot be marshaled", func(t *testing.T) {
+		ctx := interpolation.NewContext()
+		ch := make(chan int)
+		ctx.Inputs["val"] = ch
+
+		template := `{{json .inputs.val}}`
+		_, err := resolver.Resolve(template, ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "json")
+	})
+
+	t.Run("function type cannot be marshaled", func(t *testing.T) {
+		ctx := interpolation.NewContext()
+		fn := func() {}
+		ctx.Inputs["val"] = fn
+
+		template := `{{json .inputs.val}}`
+		_, err := resolver.Resolve(template, ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "json")
+	})
+
+	t.Run("complex number type cannot be marshaled", func(t *testing.T) {
+		ctx := interpolation.NewContext()
+		ctx.Inputs["val"] = complex(1, 2)
+
+		template := `{{json .inputs.val}}`
+		_, err := resolver.Resolve(template, ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "json")
+	})
+}
+
+// =============================================================================
+// F047: Loop Item JSON Serialization Tests - Component T005
+// =============================================================================
+
+// TestTemplateResolver_LoopItemJSON_Map verifies that map items are serialized to JSON
+// Item: T005
+// Feature: F047
+func TestTemplateResolver_LoopItemJSON_Map(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	tests := []struct {
+		name     string
+		item     any
+		template string
+		want     string
+	}{
+		{
+			name: "simple map",
+			item: map[string]any{
+				"name": "S1",
+				"type": "fix",
+			},
+			template: "{{.loop.Item}}",
+			want:     `{"name":"S1","type":"fix"}`,
+		},
+		{
+			name: "map with nested array",
+			item: map[string]any{
+				"name":  "S1",
+				"type":  "fix",
+				"files": []string{"a.go", "b.go"},
+			},
+			template: "{{.loop.Item}}",
+			want:     `{"files":["a.go","b.go"],"name":"S1","type":"fix"}`,
+		},
+		{
+			name: "map with nested object",
+			item: map[string]any{
+				"task": map[string]any{
+					"id":   123,
+					"done": true,
+				},
+			},
+			template: "{{.loop.Item}}",
+			want:     `{"task":{"done":true,"id":123}}`,
+		},
+		{
+			name: "map with mixed types",
+			item: map[string]any{
+				"str":   "hello",
+				"num":   42,
+				"float": 3.14,
+				"bool":  true,
+				"null":  nil,
+			},
+			template: "{{.loop.Item}}",
+			want:     `{"bool":true,"float":3.14,"null":null,"num":42,"str":"hello"}`,
+		},
+		{
+			name:     "empty map",
+			item:     map[string]any{},
+			template: "{{.loop.Item}}",
+			want:     `{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			ctx.Loop = &interpolation.LoopData{
+				Item:   tt.item,
+				Index:  0,
+				First:  true,
+				Last:   false,
+				Length: 1,
+			}
+
+			got, err := resolver.Resolve(tt.template, ctx)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.want, got, "Loop item should be serialized to JSON")
+		})
+	}
+}
+
+// TestTemplateResolver_LoopItemJSON_Slice verifies that slice items are serialized to JSON
+// Item: T005
+// Feature: F047
+func TestTemplateResolver_LoopItemJSON_Slice(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	tests := []struct {
+		name     string
+		item     any
+		template string
+		want     string
+	}{
+		{
+			name:     "string array",
+			item:     []string{"a", "b", "c"},
+			template: "{{.loop.Item}}",
+			want:     `["a","b","c"]`,
+		},
+		{
+			name:     "integer array",
+			item:     []int{1, 2, 3},
+			template: "{{.loop.Item}}",
+			want:     `[1,2,3]`,
+		},
+		{
+			name:     "mixed type array",
+			item:     []any{"str", 42, true, nil},
+			template: "{{.loop.Item}}",
+			want:     `["str",42,true,null]`,
+		},
+		{
+			name: "array of objects",
+			item: []map[string]any{
+				{"id": 1, "name": "Alice"},
+				{"id": 2, "name": "Bob"},
+			},
+			template: "{{.loop.Item}}",
+			want:     `[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}]`,
+		},
+		{
+			name:     "empty array",
+			item:     []any{},
+			template: "{{.loop.Item}}",
+			want:     `[]`,
+		},
+		{
+			name:     "nested arrays",
+			item:     []any{[]int{1, 2}, []int{3, 4}},
+			template: "{{.loop.Item}}",
+			want:     `[[1,2],[3,4]]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			ctx.Loop = &interpolation.LoopData{
+				Item:   tt.item,
+				Index:  0,
+				First:  true,
+				Last:   false,
+				Length: 1,
+			}
+
+			got, err := resolver.Resolve(tt.template, ctx)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.want, got, "Loop item should be serialized to JSON")
+		})
+	}
+}
+
+// TestTemplateResolver_LoopItemJSON_BackwardCompatibility verifies primitives still work
+// Item: T005
+// Feature: F047
+func TestTemplateResolver_LoopItemJSON_BackwardCompatibility(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	tests := []struct {
+		name     string
+		item     any
+		template string
+		want     string
+	}{
+		{
+			name:     "string item unchanged",
+			item:     "hello",
+			template: "{{.loop.Item}}",
+			want:     "hello",
+		},
+		{
+			name:     "integer item",
+			item:     42,
+			template: "{{.loop.Item}}",
+			want:     "42",
+		},
+		{
+			name:     "float item",
+			item:     3.14,
+			template: "{{.loop.Item}}",
+			want:     "3.14",
+		},
+		{
+			name:     "boolean true",
+			item:     true,
+			template: "{{.loop.Item}}",
+			want:     "true",
+		},
+		{
+			name:     "boolean false",
+			item:     false,
+			template: "{{.loop.Item}}",
+			want:     "false",
+		},
+		{
+			name:     "nil item",
+			item:     nil,
+			template: "{{.loop.Item}}",
+			want:     "null",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			ctx.Loop = &interpolation.LoopData{
+				Item:   tt.item,
+				Index:  0,
+				First:  true,
+				Last:   false,
+				Length: 1,
+			}
+
+			got, err := resolver.Resolve(tt.template, ctx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got, "Primitive types should pass through unchanged")
+		})
+	}
+}
+
+// TestTemplateResolver_LoopItemJSON_AllFields verifies all loop fields are preserved
+// Item: T005
+// Feature: F047
+func TestTemplateResolver_LoopItemJSON_AllFields(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	tests := []struct {
+		name     string
+		loop     *interpolation.LoopData
+		template string
+		want     string
+	}{
+		{
+			name: "map item with all loop fields",
+			loop: &interpolation.LoopData{
+				Item:   map[string]any{"name": "task1"},
+				Index:  2,
+				First:  false,
+				Last:   false,
+				Length: 5,
+			},
+			template: "{{.loop.Index}},{{.loop.First}},{{.loop.Last}},{{.loop.Length}},{{.loop.Item}}",
+			want:     `2,false,false,5,{"name":"task1"}`,
+		},
+		{
+			name: "slice item with index and length",
+			loop: &interpolation.LoopData{
+				Item:   []string{"a", "b"},
+				Index:  1,
+				First:  false,
+				Last:   true,
+				Length: 2,
+			},
+			template: "Item {{.loop.Index}}: {{.loop.Item}}",
+			want:     `Item 1: ["a","b"]`,
+		},
+		{
+			name: "first item serialization",
+			loop: &interpolation.LoopData{
+				Item:   map[string]string{"status": "first"},
+				Index:  0,
+				First:  true,
+				Last:   false,
+				Length: 3,
+			},
+			template: "{{if .loop.First}}First: {{.loop.Item}}{{end}}",
+			want:     `First: {"status":"first"}`,
+		},
+		{
+			name: "last item serialization",
+			loop: &interpolation.LoopData{
+				Item:   map[string]string{"status": "last"},
+				Index:  2,
+				First:  false,
+				Last:   true,
+				Length: 3,
+			},
+			template: "{{if .loop.Last}}Last: {{.loop.Item}}{{end}}",
+			want:     `Last: {"status":"last"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			ctx.Loop = tt.loop
+
+			got, err := resolver.Resolve(tt.template, ctx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got, "All loop fields should be preserved after serialization")
+		})
+	}
+}
+
+// TestTemplateResolver_LoopItemJSON_EdgeCases verifies edge cases in serialization
+// Item: T005
+// Feature: F047
+func TestTemplateResolver_LoopItemJSON_EdgeCases(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	tests := []struct {
+		name     string
+		item     any
+		template string
+		want     string
+	}{
+		{
+			name:     "zero integer",
+			item:     0,
+			template: "{{.loop.Item}}",
+			want:     "0",
+		},
+		{
+			name:     "empty string",
+			item:     "",
+			template: "{{.loop.Item}}",
+			want:     "",
+		},
+		{
+			name:     "zero float",
+			item:     0.0,
+			template: "{{.loop.Item}}",
+			want:     "0",
+		},
+		{
+			name: "map with empty string value",
+			item: map[string]any{
+				"key": "",
+			},
+			template: "{{.loop.Item}}",
+			want:     `{"key":""}`,
+		},
+		{
+			name: "map with zero values",
+			item: map[string]any{
+				"zero_int":   0,
+				"zero_float": 0.0,
+				"false_bool": false,
+			},
+			template: "{{.loop.Item}}",
+			want:     `{"false_bool":false,"zero_float":0,"zero_int":0}`,
+		},
+		{
+			name: "deeply nested structure",
+			item: map[string]any{
+				"level1": map[string]any{
+					"level2": map[string]any{
+						"level3": []any{"deep", "value"},
+					},
+				},
+			},
+			template: "{{.loop.Item}}",
+			want:     `{"level1":{"level2":{"level3":["deep","value"]}}}`,
+		},
+		{
+			name: "unicode characters",
+			item: map[string]any{
+				"emoji":   "🚀",
+				"chinese": "你好",
+				"arabic":  "مرحبا",
+			},
+			template: "{{.loop.Item}}",
+			want:     `{"arabic":"مرحبا","chinese":"你好","emoji":"🚀"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			ctx.Loop = &interpolation.LoopData{
+				Item:   tt.item,
+				Index:  0,
+				First:  true,
+				Last:   false,
+				Length: 1,
+			}
+
+			got, err := resolver.Resolve(tt.template, ctx)
+			require.NoError(t, err)
+
+			// For JSON-serialized items, use JSONEq; for primitives use Equal
+			if tt.want != "" && (tt.want[0] == '{' || tt.want[0] == '[') {
+				assert.JSONEq(t, tt.want, got)
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+// TestTemplateResolver_LoopItemJSON_WithoutLoop verifies behavior when loop is nil
+// Item: T005
+// Feature: F047
+func TestTemplateResolver_LoopItemJSON_WithoutLoop(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	ctx := interpolation.NewContext()
+	// ctx.Loop is nil
+
+	template := "{{.inputs.name}}"
+	ctx.Inputs["name"] = "test"
+
+	got, err := resolver.Resolve(template, ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "test", got, "Should work normally when loop is nil")
+}
+
+// TestTemplateResolver_LoopItemJSON_MultipleReferences verifies item can be used multiple times
+// Item: T005
+// Feature: F047
+func TestTemplateResolver_LoopItemJSON_MultipleReferences(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	ctx := interpolation.NewContext()
+	ctx.Loop = &interpolation.LoopData{
+		Item: map[string]any{
+			"name": "task",
+			"id":   123,
+		},
+		Index:  0,
+		First:  true,
+		Last:   false,
+		Length: 1,
+	}
+
+	// Reference .loop.Item multiple times in same template
+	template := "First: {{.loop.Item}} | Second: {{.loop.Item}}"
+
+	got, err := resolver.Resolve(template, ctx)
+	require.NoError(t, err)
+
+	expectedJSON := `{"id":123,"name":"task"}`
+	expected := "First: " + expectedJSON + " | Second: " + expectedJSON
+
+	assert.Equal(t, expected, got, "Item should be consistently serialized")
+}
+
+// TestTemplateResolver_LoopItemJSON_CombinedWithOtherNamespaces verifies serialization with other data
+// Item: T005
+// Feature: F047
+func TestTemplateResolver_LoopItemJSON_CombinedWithOtherNamespaces(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	ctx := interpolation.NewContext()
+	ctx.Inputs = map[string]any{"workflow": "test"}
+	ctx.States = map[string]interpolation.StepStateData{
+		"step1": {Output: "result"},
+	}
+	ctx.Loop = &interpolation.LoopData{
+		Item: map[string]any{
+			"file": "data.json",
+		},
+		Index:  0,
+		First:  true,
+		Last:   false,
+		Length: 1,
+	}
+
+	template := "Workflow: {{.inputs.workflow}}, Step: {{.states.step1.Output}}, Item: {{.loop.Item}}"
+
+	got, err := resolver.Resolve(template, ctx)
+	require.NoError(t, err)
+	assert.Equal(t, `Workflow: test, Step: result, Item: {"file":"data.json"}`, got)
+}
+
+// ============================================================================
+// T007: Unit Tests for Automatic Loop Item Serialization
+// ============================================================================
+// These tests verify that loop items are automatically serialized to JSON
+// when used in templates, without requiring explicit | json filter.
+// Item: T007
+// Feature: F047
+
+// TestTemplateResolver_AutomaticSerialization_ComplexStructures verifies
+// automatic JSON serialization for deeply nested and complex data structures.
+// Item: T007
+// Feature: F047
+func TestTemplateResolver_AutomaticSerialization_ComplexStructures(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	tests := []struct {
+		name     string
+		item     any
+		template string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name: "three-level nested map",
+			item: map[string]any{
+				"level1": map[string]any{
+					"level2": map[string]any{
+						"level3": map[string]any{
+							"value": "deep",
+						},
+					},
+				},
+			},
+			template: "{{.loop.Item}}",
+			want:     `{"level1":{"level2":{"level3":{"value":"deep"}}}}`,
+			wantErr:  false,
+		},
+		{
+			name: "four-level nested array",
+			item: []any{
+				[]any{
+					[]any{
+						[]any{"deep", "value"},
+					},
+				},
+			},
+			template: "{{.loop.Item}}",
+			want:     `[[[["deep","value"]]]]`,
+			wantErr:  false,
+		},
+		{
+			name: "mixed nested map and array",
+			item: map[string]any{
+				"users": []map[string]any{
+					{
+						"name": "Alice",
+						"tags": []string{"admin", "developer"},
+						"meta": map[string]any{
+							"lastLogin": "2024-01-01",
+							"roles":     []string{"owner", "editor"},
+						},
+					},
+					{
+						"name": "Bob",
+						"tags": []string{"user"},
+						"meta": map[string]any{
+							"lastLogin": "2024-01-02",
+							"roles":     []string{"viewer"},
+						},
+					},
+				},
+			},
+			template: "{{.loop.Item}}",
+			want:     `{"users":[{"meta":{"lastLogin":"2024-01-01","roles":["owner","editor"]},"name":"Alice","tags":["admin","developer"]},{"meta":{"lastLogin":"2024-01-02","roles":["viewer"]},"name":"Bob","tags":["user"]}]}`,
+			wantErr:  false,
+		},
+		{
+			name: "large nested structure with multiple types",
+			item: map[string]any{
+				"config": map[string]any{
+					"database": map[string]any{
+						"host":     "localhost",
+						"port":     5432,
+						"ssl":      true,
+						"replicas": []string{"replica1", "replica2"},
+					},
+					"cache": map[string]any{
+						"enabled":    true,
+						"ttl":        3600,
+						"maxEntries": 1000,
+						"backends":   []string{"redis", "memcached"},
+					},
+				},
+				"features": []map[string]any{
+					{"name": "feature1", "enabled": true, "weight": 0.5},
+					{"name": "feature2", "enabled": false, "weight": 0.3},
+				},
+			},
+			template: "Config: {{.loop.Item}}",
+			want:     `Config: {"config":{"cache":{"backends":["redis","memcached"],"enabled":true,"maxEntries":1000,"ttl":3600},"database":{"host":"localhost","port":5432,"replicas":["replica1","replica2"],"ssl":true}},"features":[{"enabled":true,"name":"feature1","weight":0.5},{"enabled":false,"name":"feature2","weight":0.3}]}`,
+			wantErr:  false,
+		},
+		{
+			name: "array of arrays with mixed types",
+			item: []any{
+				[]any{"string", 42, true},
+				[]any{3.14, false, "another"},
+				[]any{nil, map[string]any{"nested": "value"}},
+			},
+			template: "Items: {{.loop.Item}}",
+			want:     `Items: [["string",42,true],[3.14,false,"another"],[null,{"nested":"value"}]]`,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			ctx.Loop = &interpolation.LoopData{
+				Item:   tt.item,
+				Index:  0,
+				First:  true,
+				Last:   false,
+				Length: 1,
+			}
+
+			got, err := resolver.Resolve(tt.template, ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			// Use JSONEq for pure JSON outputs, Equal for outputs with text prefixes
+			if tt.want != "" && (tt.want[0] == '{' || tt.want[0] == '[') {
+				assert.JSONEq(t, tt.want, got, "Complex structure should be serialized to JSON")
+			} else {
+				assert.Equal(t, tt.want, got, "Complex structure should be serialized to JSON")
+			}
+		})
+	}
+}
+
+// TestTemplateResolver_AutomaticSerialization_WithConditionals verifies
+// automatic serialization works correctly within template conditionals.
+// Item: T007
+// Feature: F047
+func TestTemplateResolver_AutomaticSerialization_WithConditionals(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	tests := []struct {
+		name     string
+		loop     *interpolation.LoopData
+		template string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name: "if with First - serialize map",
+			loop: &interpolation.LoopData{
+				Item:   map[string]any{"id": 1, "name": "first"},
+				Index:  0,
+				First:  true,
+				Last:   false,
+				Length: 3,
+			},
+			template: `{{if .loop.First}}First item: {{.loop.Item}}{{end}}`,
+			want:     `First item: {"id":1,"name":"first"}`,
+			wantErr:  false,
+		},
+		{
+			name: "if with Last - serialize array",
+			loop: &interpolation.LoopData{
+				Item:   []string{"final", "item"},
+				Index:  2,
+				First:  false,
+				Last:   true,
+				Length: 3,
+			},
+			template: `{{if .loop.Last}}Last: {{.loop.Item}}{{end}}`,
+			want:     `Last: ["final","item"]`,
+			wantErr:  false,
+		},
+		{
+			name: "if-else with complex object",
+			loop: &interpolation.LoopData{
+				Item: map[string]any{
+					"status": "active",
+					"count":  42,
+				},
+				Index:  1,
+				First:  false,
+				Last:   false,
+				Length: 3,
+			},
+			template: `{{if .loop.First}}First{{else}}Middle: {{.loop.Item}}{{end}}`,
+			want:     `Middle: {"count":42,"status":"active"}`,
+			wantErr:  false,
+		},
+		{
+			name: "nested if with serialization",
+			loop: &interpolation.LoopData{
+				Item: map[string]any{
+					"type": "critical",
+					"data": map[string]any{
+						"severity": "high",
+						"tags":     []string{"urgent", "prod"},
+					},
+				},
+				Index:  0,
+				First:  true,
+				Last:   true,
+				Length: 1,
+			},
+			template: `{{if .loop.First}}{{if .loop.Last}}Only item: {{.loop.Item}}{{end}}{{end}}`,
+			want:     `Only item: {"data":{"severity":"high","tags":["urgent","prod"]},"type":"critical"}`,
+			wantErr:  false,
+		},
+		{
+			name: "conditional with index comparison",
+			loop: &interpolation.LoopData{
+				Item:   []int{10, 20, 30},
+				Index:  2,
+				First:  false,
+				Last:   true,
+				Length: 3,
+			},
+			template: `{{if gt .loop.Index 1}}Item: {{.loop.Item}}{{end}}`,
+			want:     `Item: [10,20,30]`,
+			wantErr:  false,
+		},
+		{
+			name: "multiple conditionals with same item",
+			loop: &interpolation.LoopData{
+				Item: map[string]string{
+					"key": "value",
+				},
+				Index:  0,
+				First:  true,
+				Last:   false,
+				Length: 2,
+			},
+			template: `{{if .loop.First}}Start: {{.loop.Item}}{{end}} | {{if not .loop.Last}}Next: {{.loop.Item}}{{end}}`,
+			want:     `Start: {"key":"value"} | Next: {"key":"value"}`,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			ctx.Loop = tt.loop
+
+			got, err := resolver.Resolve(tt.template, ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got, "Conditional should properly serialize loop item")
+		})
+	}
+}
+
+// TestTemplateResolver_AutomaticSerialization_WithRangeLoops verifies
+// automatic serialization within range loops in templates.
+// Item: T007
+// Feature: F047
+func TestTemplateResolver_AutomaticSerialization_WithRangeLoops(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	tests := []struct {
+		name     string
+		inputs   map[string]any
+		loop     *interpolation.LoopData
+		template string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name: "range over array with loop item serialization",
+			inputs: map[string]any{
+				"items": []string{"a", "b", "c"},
+			},
+			loop: &interpolation.LoopData{
+				Item:   map[string]any{"id": 1, "value": "test"},
+				Index:  0,
+				First:  true,
+				Last:   false,
+				Length: 1,
+			},
+			template: `{{range .inputs.items}}[{{.}}] {{end}}Item: {{.loop.Item}}`,
+			want:     `[a] [b] [c] Item: {"id":1,"value":"test"}`,
+			wantErr:  false,
+		},
+		{
+			name: "loop item within range block",
+			inputs: map[string]any{
+				"numbers": []int{1, 2, 3},
+			},
+			loop: &interpolation.LoopData{
+				Item:   []int{10, 20, 30},
+				Index:  1,
+				First:  false,
+				Last:   false,
+				Length: 5,
+			},
+			template: `Start{{range $i, $v := .inputs.numbers}} {{$i}}:{{$v}}{{end}} Loop: {{.loop.Item}}`,
+			want:     `Start 0:1 1:2 2:3 Loop: [10,20,30]`,
+			wantErr:  false,
+		},
+		{
+			name: "nested range with complex loop item",
+			inputs: map[string]any{
+				"outer": []string{"x", "y"},
+			},
+			loop: &interpolation.LoopData{
+				Item: map[string]any{
+					"nested": map[string]any{
+						"data": []string{"a", "b"},
+					},
+				},
+				Index:  0,
+				First:  true,
+				Last:   false,
+				Length: 1,
+			},
+			template: `{{range .inputs.outer}}{{.}}-{{end}}Item: {{.loop.Item}}`,
+			want:     `x-y-Item: {"nested":{"data":["a","b"]}}`,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			ctx.Inputs = tt.inputs
+			ctx.Loop = tt.loop
+
+			got, err := resolver.Resolve(tt.template, ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got, "Range loop should work with serialized loop item")
+		})
+	}
+}
+
+// TestTemplateResolver_AutomaticSerialization_StructTypes verifies
+// automatic serialization for custom struct types.
+// Item: T007
+// Feature: F047
+func TestTemplateResolver_AutomaticSerialization_StructTypes(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	// Define test structs
+	type Address struct {
+		Street  string `json:"street"`
+		City    string `json:"city"`
+		ZipCode string `json:"zipCode"`
+	}
+
+	type Person struct {
+		Name    string  `json:"name"`
+		Age     int     `json:"age"`
+		Email   string  `json:"email"`
+		Address Address `json:"address"`
+	}
+
+	type Task struct {
+		ID       int      `json:"id"`
+		Title    string   `json:"title"`
+		Tags     []string `json:"tags"`
+		Done     bool     `json:"done"`
+		Priority *int     `json:"priority,omitempty"`
+	}
+
+	tests := []struct {
+		name     string
+		item     any
+		template string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name: "simple struct",
+			item: Person{
+				Name:  "Alice",
+				Age:   30,
+				Email: "alice@example.com",
+				Address: Address{
+					Street:  "123 Main St",
+					City:    "Springfield",
+					ZipCode: "12345",
+				},
+			},
+			template: "{{.loop.Item}}",
+			want:     `{"name":"Alice","age":30,"email":"alice@example.com","address":{"street":"123 Main St","city":"Springfield","zipCode":"12345"}}`,
+			wantErr:  false,
+		},
+		{
+			name: "struct with slice",
+			item: Task{
+				ID:    1,
+				Title: "Complete tests",
+				Tags:  []string{"urgent", "testing"},
+				Done:  false,
+			},
+			template: "Task: {{.loop.Item}}",
+			want:     `Task: {"id":1,"title":"Complete tests","tags":["urgent","testing"],"done":false}`,
+			wantErr:  false,
+		},
+		{
+			name: "struct with pointer field (nil)",
+			item: Task{
+				ID:       2,
+				Title:    "Review PR",
+				Tags:     []string{"code-review"},
+				Done:     true,
+				Priority: nil,
+			},
+			template: "{{.loop.Item}}",
+			want:     `{"id":2,"title":"Review PR","tags":["code-review"],"done":true}`,
+			wantErr:  false,
+		},
+		{
+			name: "struct with pointer field (non-nil)",
+			item: func() Task {
+				priority := 5
+				return Task{
+					ID:       3,
+					Title:    "Fix bug",
+					Tags:     []string{"bug", "critical"},
+					Done:     false,
+					Priority: &priority,
+				}
+			}(),
+			template: "{{.loop.Item}}",
+			want:     `{"id":3,"title":"Fix bug","tags":["bug","critical"],"done":false,"priority":5}`,
+			wantErr:  false,
+		},
+		{
+			name: "array of structs",
+			item: []Person{
+				{
+					Name:  "Bob",
+					Age:   25,
+					Email: "bob@example.com",
+					Address: Address{
+						Street:  "456 Oak Ave",
+						City:    "Portland",
+						ZipCode: "67890",
+					},
+				},
+				{
+					Name:  "Carol",
+					Age:   35,
+					Email: "carol@example.com",
+					Address: Address{
+						Street:  "789 Pine Rd",
+						City:    "Seattle",
+						ZipCode: "11111",
+					},
+				},
+			},
+			template: "People: {{.loop.Item}}",
+			want:     `People: [{"name":"Bob","age":25,"email":"bob@example.com","address":{"street":"456 Oak Ave","city":"Portland","zipCode":"67890"}},{"name":"Carol","age":35,"email":"carol@example.com","address":{"street":"789 Pine Rd","city":"Seattle","zipCode":"11111"}}]`,
+			wantErr:  false,
+		},
+		{
+			name:     "empty struct",
+			item:     struct{}{},
+			template: "{{.loop.Item}}",
+			want:     `{}`,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			ctx.Loop = &interpolation.LoopData{
+				Item:   tt.item,
+				Index:  0,
+				First:  true,
+				Last:   false,
+				Length: 1,
+			}
+
+			got, err := resolver.Resolve(tt.template, ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			// Use JSONEq for pure JSON outputs, Equal for outputs with text prefixes
+			if tt.want != "" && (tt.want[0] == '{' || tt.want[0] == '[') {
+				assert.JSONEq(t, tt.want, got, "Struct should be serialized to JSON")
+			} else {
+				assert.Equal(t, tt.want, got, "Struct should be serialized to JSON")
+			}
+		})
+	}
+}
+
+// TestTemplateResolver_AutomaticSerialization_InterfaceValues verifies
+// automatic serialization for interface{} values containing various types.
+// Item: T007
+// Feature: F047
+func TestTemplateResolver_AutomaticSerialization_InterfaceValues(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	tests := []struct {
+		name     string
+		item     any
+		template string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "interface with string value",
+			item:     any("hello world"),
+			template: "{{.loop.Item}}",
+			want:     "hello world",
+			wantErr:  false,
+		},
+		{
+			name:     "interface with int value",
+			item:     any(42),
+			template: "{{.loop.Item}}",
+			want:     "42",
+			wantErr:  false,
+		},
+		{
+			name:     "interface with bool value",
+			item:     any(true),
+			template: "{{.loop.Item}}",
+			want:     "true",
+			wantErr:  false,
+		},
+		{
+			name:     "interface with nil value",
+			item:     any(nil),
+			template: "{{.loop.Item}}",
+			want:     "null",
+			wantErr:  false,
+		},
+		{
+			name: "interface with map value",
+			item: any(map[string]any{
+				"key":   "value",
+				"count": 10,
+			}),
+			template: "{{.loop.Item}}",
+			want:     `{"count":10,"key":"value"}`,
+			wantErr:  false,
+		},
+		{
+			name:     "interface with slice value",
+			item:     any([]any{1, "two", true, nil}),
+			template: "{{.loop.Item}}",
+			want:     `[1,"two",true,null]`,
+			wantErr:  false,
+		},
+		{
+			name: "interface containing interface slice",
+			item: any([]any{
+				any("string"),
+				any(123),
+				any(map[string]any{"nested": "value"}),
+			}),
+			template: "Data: {{.loop.Item}}",
+			want:     `Data: ["string",123,{"nested":"value"}]`,
+			wantErr:  false,
+		},
+		{
+			name: "interface with deeply nested any types",
+			item: any(map[string]any{
+				"level1": any(map[string]any{
+					"level2": any([]any{
+						any("deep"),
+						any(42),
+					}),
+				}),
+			}),
+			template: "{{.loop.Item}}",
+			want:     `{"level1":{"level2":["deep",42]}}`,
+			wantErr:  false,
+		},
+		{
+			name: "interface with mixed concrete and interface types",
+			item: any(map[string]any{
+				"concrete": "value",
+				"boxed":    any(123),
+				"nested":   any(map[string]string{"key": "val"}),
+			}),
+			template: "{{.loop.Item}}",
+			want:     `{"boxed":123,"concrete":"value","nested":{"key":"val"}}`,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			ctx.Loop = &interpolation.LoopData{
+				Item:   tt.item,
+				Index:  0,
+				First:  true,
+				Last:   false,
+				Length: 1,
+			}
+
+			got, err := resolver.Resolve(tt.template, ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			// Use JSONEq for complex types, Equal for primitives
+			if tt.want != "" && (tt.want[0] == '{' || tt.want[0] == '[') {
+				assert.JSONEq(t, tt.want, got, "Interface value should be serialized correctly")
+			} else {
+				assert.Equal(t, tt.want, got, "Interface value should be serialized correctly")
+			}
+		})
+	}
+}
+
+// TestTemplateResolver_AutomaticSerialization_PointerTypes verifies
+// automatic serialization for pointer types and nil pointers.
+// Item: T007
+// Feature: F047
+func TestTemplateResolver_AutomaticSerialization_PointerTypes(t *testing.T) {
+	resolver := interpolation.NewTemplateResolver()
+
+	tests := []struct {
+		name     string
+		item     any
+		template string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name: "pointer to string",
+			item: func() *string {
+				s := "hello"
+				return &s
+			}(),
+			template: "{{.loop.Item}}",
+			want:     `"hello"`,
+			wantErr:  false,
+		},
+		{
+			name: "pointer to int",
+			item: func() *int {
+				i := 42
+				return &i
+			}(),
+			template: "{{.loop.Item}}",
+			want:     `42`,
+			wantErr:  false,
+		},
+		{
+			name: "pointer to bool",
+			item: func() *bool {
+				b := true
+				return &b
+			}(),
+			template: "{{.loop.Item}}",
+			want:     `true`,
+			wantErr:  false,
+		},
+		{
+			name:     "nil pointer to string",
+			item:     (*string)(nil),
+			template: "{{.loop.Item}}",
+			want:     `null`,
+			wantErr:  false,
+		},
+		{
+			name:     "nil pointer to int",
+			item:     (*int)(nil),
+			template: "{{.loop.Item}}",
+			want:     `null`,
+			wantErr:  false,
+		},
+		{
+			name: "pointer to map",
+			item: func() *map[string]any {
+				m := map[string]any{
+					"key":   "value",
+					"count": 10,
+				}
+				return &m
+			}(),
+			template: "{{.loop.Item}}",
+			want:     `{"count":10,"key":"value"}`,
+			wantErr:  false,
+		},
+		{
+			name: "pointer to slice",
+			item: func() *[]string {
+				s := []string{"a", "b", "c"}
+				return &s
+			}(),
+			template: "{{.loop.Item}}",
+			want:     `["a","b","c"]`,
+			wantErr:  false,
+		},
+		{
+			name: "pointer to struct",
+			item: func() any {
+				type Data struct {
+					ID   int    `json:"id"`
+					Name string `json:"name"`
+				}
+				d := Data{ID: 1, Name: "test"}
+				return &d
+			}(),
+			template: "{{.loop.Item}}",
+			want:     `{"id":1,"name":"test"}`,
+			wantErr:  false,
+		},
+		{
+			name: "map containing pointers",
+			item: func() map[string]any {
+				str := "value"
+				num := 42
+				return map[string]any{
+					"strPtr": &str,
+					"numPtr": &num,
+					"nilPtr": (*string)(nil),
+				}
+			}(),
+			template: "{{.loop.Item}}",
+			want:     `{"nilPtr":null,"numPtr":42,"strPtr":"value"}`,
+			wantErr:  false,
+		},
+		{
+			name: "slice containing pointers",
+			item: func() []any {
+				s1 := "first"
+				s2 := "second"
+				return []any{&s1, &s2, (*string)(nil)}
+			}(),
+			template: "{{.loop.Item}}",
+			want:     `["first","second",null]`,
+			wantErr:  false,
+		},
+		{
+			name: "pointer to pointer (double indirection)",
+			item: func() any {
+				s := "nested"
+				p := &s
+				return &p
+			}(),
+			template: "{{.loop.Item}}",
+			want:     `"nested"`,
+			wantErr:  false,
+		},
+		{
+			name: "struct with pointer fields",
+			item: func() any {
+				type Config struct {
+					Name    string  `json:"name"`
+					Timeout *int    `json:"timeout,omitempty"`
+					Enabled *bool   `json:"enabled,omitempty"`
+					Host    *string `json:"host,omitempty"`
+				}
+				timeout := 30
+				enabled := true
+				return Config{
+					Name:    "test-config",
+					Timeout: &timeout,
+					Enabled: &enabled,
+					Host:    nil,
+				}
+			}(),
+			template: "{{.loop.Item}}",
+			want:     `{"name":"test-config","timeout":30,"enabled":true}`,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			ctx.Loop = &interpolation.LoopData{
+				Item:   tt.item,
+				Index:  0,
+				First:  true,
+				Last:   false,
+				Length: 1,
+			}
+
+			got, err := resolver.Resolve(tt.template, ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			// Use JSONEq for all cases as pointers to primitives will be JSON-encoded
+			if tt.want == "null" {
+				assert.Equal(t, tt.want, got, "Nil pointer should serialize to null")
+			} else {
+				assert.JSONEq(t, tt.want, got, "Pointer should be dereferenced and serialized")
+			}
+		})
+	}
+}

--- a/pkg/interpolation/serializer.go
+++ b/pkg/interpolation/serializer.go
@@ -1,0 +1,68 @@
+package interpolation
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+// SerializeLoopItem converts a loop item value to a string representation.
+// For primitive types (string, int, float, bool), returns the value as-is.
+// For complex types (maps, slices, structs), marshals to JSON.
+// Returns error if JSON marshaling fails (e.g., circular references, unsupported types).
+//
+// This function is used to ensure loop items in templates are properly serialized
+// when passed to sub-workflows via call_workflow.
+func SerializeLoopItem(item any) (string, error) {
+	// Handle nil explicitly
+	if item == nil {
+		return "null", nil
+	}
+
+	// Type switch: primitives pass through, complex types get JSON marshaled
+	switch v := item.(type) {
+	case string:
+		// Strings pass through unchanged (backward compatibility)
+		return v, nil
+
+	case bool:
+		return fmt.Sprintf("%t", v), nil
+
+	case float32:
+		// Use strconv.FormatFloat for efficient formatting without scientific notation
+		// 'f' format avoids scientific notation, -1 precision uses minimum needed digits
+		return strconv.FormatFloat(float64(v), 'f', -1, 32), nil
+
+	case float64:
+		// Use strconv.FormatFloat for efficient formatting without scientific notation
+		// 'f' format avoids scientific notation, -1 precision uses minimum needed digits
+		return strconv.FormatFloat(v, 'f', -1, 64), nil
+
+	default:
+		// Use reflection to check if value is any integer type
+		// This handles int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64
+		rv := reflect.ValueOf(item)
+		kind := rv.Kind()
+		if kind >= reflect.Int && kind <= reflect.Int64 {
+			// Signed integer types
+			return fmt.Sprintf("%d", rv.Int()), nil
+		}
+		if kind >= reflect.Uint && kind <= reflect.Uint64 {
+			// Unsigned integer types
+			return fmt.Sprintf("%d", rv.Uint()), nil
+		}
+
+		// Complex types (maps, slices, structs): marshal to JSON
+		jsonBytes, err := json.Marshal(v)
+		if err != nil {
+			// Graceful degradation per ADR-004: return descriptive type name
+			// instead of memory address (which is not useful for workflow inputs)
+			// This handles unsupported types like channels, functions
+			// Note: Callers should implement their own logging if needed
+			typeName := reflect.TypeOf(v).String()
+			return fmt.Sprintf("<unsupported:%s>", typeName), nil
+		}
+		return string(jsonBytes), nil
+	}
+}

--- a/pkg/interpolation/serializer_test.go
+++ b/pkg/interpolation/serializer_test.go
@@ -1,0 +1,707 @@
+package interpolation_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vanoix/awf/pkg/interpolation"
+)
+
+// Item: T001
+// Feature: F047
+
+// TestSerializeLoopItem_Primitives verifies that primitive types pass through unchanged.
+// These are the common scalar types that don't need JSON marshaling.
+func TestSerializeLoopItem_Primitives(t *testing.T) {
+	tests := []struct {
+		name string
+		item any
+		want string
+	}{
+		{
+			name: "string unchanged",
+			item: "hello",
+			want: "hello",
+		},
+		{
+			name: "empty string",
+			item: "",
+			want: "",
+		},
+		{
+			name: "string with spaces",
+			item: "hello world",
+			want: "hello world",
+		},
+		{
+			name: "string with special characters",
+			item: "hello@world.com",
+			want: "hello@world.com",
+		},
+		{
+			name: "integer",
+			item: 42,
+			want: "42",
+		},
+		{
+			name: "integer zero",
+			item: 0,
+			want: "0",
+		},
+		{
+			name: "negative integer",
+			item: -100,
+			want: "-100",
+		},
+		{
+			name: "float64",
+			item: 3.14,
+			want: "3.14",
+		},
+		{
+			name: "float64 zero",
+			item: 0.0,
+			want: "0",
+		},
+		{
+			name: "negative float",
+			item: -2.5,
+			want: "-2.5",
+		},
+		{
+			name: "bool true",
+			item: true,
+			want: "true",
+		},
+		{
+			name: "bool false",
+			item: false,
+			want: "false",
+		},
+		{
+			name: "nil",
+			item: nil,
+			want: "null",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := interpolation.SerializeLoopItem(tt.item)
+			require.NoError(t, err, "SerializeLoopItem should not error for primitive types")
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestSerializeLoopItem_Maps verifies that map[string]any gets marshaled to JSON objects.
+// This is the primary use case from F047 bug report.
+func TestSerializeLoopItem_Maps(t *testing.T) {
+	tests := []struct {
+		name string
+		item any
+		want string
+	}{
+		{
+			name: "simple map",
+			item: map[string]any{"name": "S1"},
+			want: `{"name":"S1"}`,
+		},
+		{
+			name: "map with multiple fields",
+			item: map[string]any{
+				"name": "S1",
+				"type": "fix",
+			},
+			want: `{"name":"S1","type":"fix"}`,
+		},
+		{
+			name: "map with mixed types",
+			item: map[string]any{
+				"name":  "S1",
+				"count": 42,
+				"valid": true,
+			},
+			want: `{"count":42,"name":"S1","valid":true}`,
+		},
+		{
+			name: "empty map",
+			item: map[string]any{},
+			want: `{}`,
+		},
+		{
+			name: "map with nil value",
+			item: map[string]any{"value": nil},
+			want: `{"value":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := interpolation.SerializeLoopItem(tt.item)
+			require.NoError(t, err, "SerializeLoopItem should not error for maps")
+
+			// Parse both as JSON to compare structure (order-independent)
+			var gotJSON, wantJSON any
+			require.NoError(t, json.Unmarshal([]byte(got), &gotJSON))
+			require.NoError(t, json.Unmarshal([]byte(tt.want), &wantJSON))
+			assert.Equal(t, wantJSON, gotJSON)
+		})
+	}
+}
+
+// TestSerializeLoopItem_Slices verifies that slices get marshaled to JSON arrays.
+func TestSerializeLoopItem_Slices(t *testing.T) {
+	tests := []struct {
+		name string
+		item any
+		want string
+	}{
+		{
+			name: "slice of strings",
+			item: []string{"a", "b", "c"},
+			want: `["a","b","c"]`,
+		},
+		{
+			name: "slice of integers",
+			item: []int{1, 2, 3},
+			want: `[1,2,3]`,
+		},
+		{
+			name: "slice of any",
+			item: []any{"hello", 42, true},
+			want: `["hello",42,true]`,
+		},
+		{
+			name: "empty slice",
+			item: []any{},
+			want: `[]`,
+		},
+		{
+			name: "slice with nil",
+			item: []any{nil},
+			want: `[null]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := interpolation.SerializeLoopItem(tt.item)
+			require.NoError(t, err, "SerializeLoopItem should not error for slices")
+			assert.JSONEq(t, tt.want, got)
+		})
+	}
+}
+
+// TestSerializeLoopItem_Nested verifies deeply nested structures serialize correctly.
+// This tests the exact use case from F047: objects with nested arrays.
+func TestSerializeLoopItem_Nested(t *testing.T) {
+	tests := []struct {
+		name string
+		item any
+		want string
+	}{
+		{
+			name: "map with slice value (F047 exact case)",
+			item: map[string]any{
+				"name":  "S1",
+				"type":  "fix",
+				"files": []string{"a.go"},
+			},
+			want: `{"name":"S1","type":"fix","files":["a.go"]}`,
+		},
+		{
+			name: "slice of maps",
+			item: []any{
+				map[string]any{"name": "S1"},
+				map[string]any{"name": "S2"},
+			},
+			want: `[{"name":"S1"},{"name":"S2"}]`,
+		},
+		{
+			name: "deeply nested map",
+			item: map[string]any{
+				"level1": map[string]any{
+					"level2": map[string]any{
+						"value": "deep",
+					},
+				},
+			},
+			want: `{"level1":{"level2":{"value":"deep"}}}`,
+		},
+		{
+			name: "deeply nested slice",
+			item: []any{
+				[]any{
+					[]any{1, 2},
+				},
+			},
+			want: `[[[1,2]]]`,
+		},
+		{
+			name: "complex mixed nesting",
+			item: map[string]any{
+				"items": []any{
+					map[string]any{
+						"name":  "item1",
+						"tags":  []string{"a", "b"},
+						"count": 5,
+					},
+					map[string]any{
+						"name":  "item2",
+						"tags":  []string{"c"},
+						"count": 3,
+					},
+				},
+			},
+			want: `{"items":[{"name":"item1","tags":["a","b"],"count":5},{"name":"item2","tags":["c"],"count":3}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := interpolation.SerializeLoopItem(tt.item)
+			require.NoError(t, err, "SerializeLoopItem should not error for nested structures")
+			assert.JSONEq(t, tt.want, got)
+		})
+	}
+}
+
+// TestSerializeLoopItem_Structs verifies that custom structs serialize to JSON.
+func TestSerializeLoopItem_Structs(t *testing.T) {
+	type Person struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+
+	type Task struct {
+		Title     string   `json:"title"`
+		Completed bool     `json:"completed"`
+		Tags      []string `json:"tags,omitempty"`
+	}
+
+	tests := []struct {
+		name string
+		item any
+		want string
+	}{
+		{
+			name: "simple struct",
+			item: Person{Name: "Alice", Age: 30},
+			want: `{"name":"Alice","age":30}`,
+		},
+		{
+			name: "struct with slice",
+			item: Task{
+				Title:     "Fix bug",
+				Completed: true,
+				Tags:      []string{"urgent", "backend"},
+			},
+			want: `{"title":"Fix bug","completed":true,"tags":["urgent","backend"]}`,
+		},
+		{
+			name: "struct with omitempty",
+			item: Task{
+				Title:     "Review PR",
+				Completed: false,
+			},
+			want: `{"title":"Review PR","completed":false}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := interpolation.SerializeLoopItem(tt.item)
+			require.NoError(t, err, "SerializeLoopItem should not error for structs")
+			assert.JSONEq(t, tt.want, got)
+		})
+	}
+}
+
+// TestSerializeLoopItem_Unicode verifies special characters and unicode handle correctly.
+func TestSerializeLoopItem_Unicode(t *testing.T) {
+	tests := []struct {
+		name string
+		item any
+		want string
+	}{
+		{
+			name: "map with unicode",
+			item: map[string]any{"greeting": "hello 世界"},
+			want: `{"greeting":"hello 世界"}`,
+		},
+		{
+			name: "map with emoji",
+			item: map[string]any{"status": "✅ done"},
+			want: `{"status":"✅ done"}`,
+		},
+		{
+			name: "map with special chars",
+			item: map[string]any{
+				"path":    "/tmp/file.txt",
+				"command": "echo 'hello'",
+			},
+			want: `{"path":"/tmp/file.txt","command":"echo 'hello'"}`,
+		},
+		{
+			name: "map with newlines and tabs",
+			item: map[string]any{"text": "line1\nline2\ttabbed"},
+			want: `{"text":"line1\nline2\ttabbed"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := interpolation.SerializeLoopItem(tt.item)
+			require.NoError(t, err, "SerializeLoopItem should not error for unicode")
+			assert.JSONEq(t, tt.want, got)
+		})
+	}
+}
+
+// TestSerializeLoopItem_EdgeCases verifies boundary conditions and special values.
+func TestSerializeLoopItem_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		item any
+		want string
+	}{
+		{
+			name: "zero-value map",
+			item: map[string]any{},
+			want: `{}`,
+		},
+		{
+			name: "zero-value slice",
+			item: []any{},
+			want: `[]`,
+		},
+		{
+			name: "nil slice",
+			item: []any(nil),
+			want: `null`,
+		},
+		{
+			name: "nil map",
+			item: map[string]any(nil),
+			want: `null`,
+		},
+		{
+			name: "map with all zero values",
+			item: map[string]any{
+				"str":   "",
+				"num":   0,
+				"bool":  false,
+				"null":  nil,
+				"slice": []any{},
+				"map":   map[string]any{},
+			},
+			want: `{"str":"","num":0,"bool":false,"null":null,"slice":[],"map":{}}`,
+		},
+		{
+			name: "very large integer",
+			item: 9223372036854775807, // max int64
+			want: "9223372036854775807",
+		},
+		{
+			name: "very small integer",
+			item: -9223372036854775808, // min int64
+			want: "-9223372036854775808",
+		},
+		{
+			name: "scientific notation float",
+			item: 1.23e10,
+			want: "12300000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := interpolation.SerializeLoopItem(tt.item)
+			require.NoError(t, err, "SerializeLoopItem should not error for edge cases")
+
+			// For JSON values, use JSONEq; for primitives, use string equality
+			if tt.want[0] == '{' || tt.want[0] == '[' || tt.want == "null" {
+				assert.JSONEq(t, tt.want, got)
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+// TestSerializeLoopItem_JSONUnmarshalled tests the exact output from loop_executor.ParseItems().
+// This reproduces the F047 bug scenario: JSON unmarshal -> SerializeLoopItem -> should get original JSON.
+func TestSerializeLoopItem_JSONUnmarshalled(t *testing.T) {
+	tests := []struct {
+		name     string
+		jsonIn   string // Original JSON from ParseItems
+		wantJSON string // Expected JSON output
+	}{
+		{
+			name:     "F047 reproduction case",
+			jsonIn:   `[{"name":"S1","type":"fix","files":["a.go"]}]`,
+			wantJSON: `{"name":"S1","type":"fix","files":["a.go"]}`,
+		},
+		{
+			name:     "multiple items array",
+			jsonIn:   `[{"name":"S1"},{"name":"S2"}]`,
+			wantJSON: `{"name":"S1"}`, // First item
+		},
+		{
+			name:     "complex nested structure",
+			jsonIn:   `[{"data":{"nested":{"value":42}}}]`,
+			wantJSON: `{"data":{"nested":{"value":42}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate ParseItems behavior: unmarshal JSON array
+			var items []any
+			err := json.Unmarshal([]byte(tt.jsonIn), &items)
+			require.NoError(t, err, "Test setup: unmarshal JSON")
+			require.NotEmpty(t, items, "Test setup: array should have items")
+
+			// Take first item (simulating loop iteration)
+			item := items[0]
+
+			// This is the call that was broken in F047
+			got, err := interpolation.SerializeLoopItem(item)
+			require.NoError(t, err, "SerializeLoopItem should not error")
+
+			// Verify we get valid JSON back, not "map[...]" format
+			assert.JSONEq(t, tt.wantJSON, got, "Should produce valid JSON, not Go map format")
+		})
+	}
+}
+
+// TestSerializeLoopItem_Errors verifies error handling for unsupported types.
+// Per ADR-004, we should gracefully degrade rather than panic.
+func TestSerializeLoopItem_Errors(t *testing.T) {
+	tests := []struct {
+		name      string
+		item      any
+		wantErr   bool
+		wantValue string // Expected fallback value if applicable
+	}{
+		{
+			name:    "channel type (unsupported by json.Marshal)",
+			item:    make(chan int),
+			wantErr: false, // Graceful degradation per ADR-004
+		},
+		{
+			name:    "function type (unsupported by json.Marshal)",
+			item:    func() {},
+			wantErr: false, // Graceful degradation per ADR-004
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := interpolation.SerializeLoopItem(tt.item)
+
+			if tt.wantErr {
+				assert.Error(t, err, "Should return error for unsupported types")
+			} else {
+				// Per ADR-004: graceful degradation
+				assert.NoError(t, err, "Should not error (graceful degradation)")
+				assert.NotEmpty(t, got, "Should return non-empty fallback value")
+			}
+		})
+	}
+}
+
+// TestSerializeLoopItem_BackwardCompatibility ensures existing string-based loops still work.
+// This is critical: primitive types must pass through unchanged to avoid breaking existing workflows.
+func TestSerializeLoopItem_BackwardCompatibility(t *testing.T) {
+	tests := []struct {
+		name string
+		item any
+		want string
+	}{
+		{
+			name: "string item unchanged",
+			item: "simple-string",
+			want: "simple-string",
+		},
+		{
+			name: "string with JSON-like content unchanged",
+			item: `{"already":"json"}`,
+			want: `{"already":"json"}`,
+		},
+		{
+			name: "numeric string unchanged",
+			item: "123",
+			want: "123",
+		},
+		{
+			name: "boolean string unchanged",
+			item: "true",
+			want: "true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := interpolation.SerializeLoopItem(tt.item)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got, "Primitive strings must pass through unchanged")
+		})
+	}
+}
+
+// Item: T002
+// Feature: F047
+
+// TestSerializeLoopItem_ErrorHandling_GracefulDegradation verifies that when json.Marshal fails,
+// the function falls back gracefully without logging (per PR-65 Component S1: avoid bypassing structured logging).
+func TestSerializeLoopItem_ErrorHandling_GracefulDegradation(t *testing.T) {
+	tests := []struct {
+		name string
+		item any
+	}{
+		{
+			name: "channel type falls back",
+			item: make(chan int),
+		},
+		{
+			name: "function type falls back",
+			item: func() {},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Call the function
+			got, err := interpolation.SerializeLoopItem(tt.item)
+
+			// Verify graceful degradation (no error, non-empty result)
+			assert.NoError(t, err, "Should not return error (graceful degradation per ADR-004)")
+			assert.NotEmpty(t, got, "Should return non-empty fallback value")
+		})
+	}
+}
+
+// TestSerializeLoopItem_ErrorHandling_SuccessfulSerialization verifies
+// that serialization succeeds normally for supported complex types.
+func TestSerializeLoopItem_ErrorHandling_SuccessfulSerialization(t *testing.T) {
+	tests := []struct {
+		name string
+		item any
+	}{
+		{
+			name: "map serializes successfully",
+			item: map[string]any{"key": "value"},
+		},
+		{
+			name: "slice serializes successfully",
+			item: []string{"a", "b", "c"},
+		},
+		{
+			name: "struct serializes successfully",
+			item: struct {
+				Name string `json:"name"`
+			}{Name: "test"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Call the function
+			got, err := interpolation.SerializeLoopItem(tt.item)
+
+			// Verify successful serialization
+			require.NoError(t, err)
+			require.NotEmpty(t, got)
+		})
+	}
+}
+
+// TestSerializeLoopItem_ErrorHandling_FallbackValue verifies that the fallback
+// returns descriptive type names instead of memory addresses.
+// Component S3: Improved fallback to use reflect.TypeOf(v).String() for clarity.
+func TestSerializeLoopItem_ErrorHandling_FallbackValue(t *testing.T) {
+	tests := []struct {
+		name         string
+		item         any
+		wantContains string // The fallback should contain this substring
+	}{
+		{
+			name:         "channel fallback contains type name",
+			item:         make(chan int),
+			wantContains: "chan int", // Descriptive type name
+		},
+		{
+			name:         "function fallback contains func keyword",
+			item:         func() {},
+			wantContains: "func()", // Descriptive type name
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Call the function
+			got, err := interpolation.SerializeLoopItem(tt.item)
+
+			// Verify graceful degradation
+			require.NoError(t, err)
+			require.NotEmpty(t, got)
+
+			// Verify fallback format uses descriptive type names
+			assert.Contains(t, got, tt.wantContains,
+				"Fallback value should contain descriptive type name")
+			assert.Contains(t, got, "<unsupported:",
+				"Fallback value should be wrapped in <unsupported:...> format")
+		})
+	}
+}
+
+// TestSerializeLoopItem_ErrorHandling_MultipleCalls verifies that multiple
+// failed serializations all gracefully degrade.
+func TestSerializeLoopItem_ErrorHandling_MultipleCalls(t *testing.T) {
+	// Make multiple calls with unsupported types
+	items := []any{
+		make(chan int),
+		func() {},
+		make(chan string),
+	}
+
+	for _, item := range items {
+		got, err := interpolation.SerializeLoopItem(item)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+	}
+}
+
+// TestSerializeLoopItem_ErrorHandling_PrimitivesNeverLog verifies that
+// primitive types never trigger warning logs (they use the type switch fast path).
+func TestSerializeLoopItem_ErrorHandling_PrimitivesNeverLog(t *testing.T) {
+	// Capture log output
+	var logBuf bytes.Buffer
+	originalOutput := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(originalOutput)
+
+	primitives := []any{
+		"string",
+		42,
+		3.14,
+		true,
+		nil,
+	}
+
+	for _, item := range primitives {
+		_, err := interpolation.SerializeLoopItem(item)
+		require.NoError(t, err)
+	}
+
+	// Verify NO logs were produced
+	logOutput := logBuf.String()
+	assert.Empty(t, logOutput,
+		"Primitives should never produce logs (they use fast path)")
+}

--- a/pkg/interpolation/template_resolver.go
+++ b/pkg/interpolation/template_resolver.go
@@ -2,6 +2,8 @@ package interpolation
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"text/template"
 )
@@ -27,7 +29,8 @@ func (r *TemplateResolver) Resolve(tmplStr string, ctx *Context) (string, error)
 	tmpl := template.New("cmd").
 		Option("missingkey=error").
 		Funcs(template.FuncMap{
-			"escape": ShellEscape,
+			"escape": escapeTemplateFunc,
+			"json":   jsonTemplateFunc,
 		})
 
 	// Parse template
@@ -57,7 +60,9 @@ func (r *TemplateResolver) buildTemplateData(ctx *Context) map[string]any {
 		data["error"] = ctx.Error
 	}
 	if ctx.Loop != nil {
-		data["loop"] = ctx.Loop
+		// Serialize loop item using SerializeLoopItem for proper JSON representation
+		serializedLoop := r.serializeLoopData(ctx.Loop)
+		data["loop"] = serializedLoop
 	}
 	return data
 }
@@ -90,4 +95,74 @@ func (r *TemplateResolver) wrapExecutionError(err error, tmpl string) error {
 	}
 
 	return &ParseError{Template: tmpl, Cause: err}
+}
+
+// escapeTemplateFunc wraps ShellEscape to handle both strings and serializableItem.
+// This function is used in templates via {{escape .var}} syntax.
+func escapeTemplateFunc(v any) string {
+	// Handle serializableItem by extracting its serialized string
+	if item, ok := v.(serializableItem); ok {
+		return ShellEscape(item.String())
+	}
+	// Handle regular strings
+	if s, ok := v.(string); ok {
+		return ShellEscape(s)
+	}
+	// Fallback for other types: convert to string first
+	return ShellEscape(fmt.Sprintf("%v", v))
+}
+
+// jsonTemplateFunc serializes a value to JSON format.
+// This function is used in templates via {{json .var}} syntax.
+func jsonTemplateFunc(v any) (string, error) {
+	jsonBytes, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(jsonBytes), nil
+}
+
+// serializableItem wraps a loop item value and provides automatic JSON serialization
+// when printed in templates, while preserving the original value for the {{json}} function.
+type serializableItem struct {
+	original   any
+	serialized string
+}
+
+// String implements fmt.Stringer, which Go templates use for {{.value}} printing.
+// This ensures loop items are serialized to JSON automatically.
+func (s serializableItem) String() string {
+	return s.serialized
+}
+
+// MarshalJSON implements json.Marshaler to ensure the original value is used
+// when the {{json}} function is applied, avoiding double-encoding.
+func (s serializableItem) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.original)
+}
+
+// serializeLoopData creates a copy of LoopData with the Item field wrapped
+// in serializableItem for proper JSON representation in templates.
+func (r *TemplateResolver) serializeLoopData(loop *LoopData) *LoopData {
+	// Serialize the item using SerializeLoopItem
+	// SerializeLoopItem never returns an error (it handles failures internally via graceful degradation)
+	// nolint:errcheck // SerializeLoopItem always returns nil error
+	serialized, _ := SerializeLoopItem(loop.Item)
+
+	// Wrap the item in serializableItem to provide both automatic serialization
+	// via String() and correct JSON encoding via MarshalJSON()
+	wrappedItem := serializableItem{
+		original:   loop.Item,
+		serialized: serialized,
+	}
+
+	// Create a copy of LoopData with all fields preserved
+	return &LoopData{
+		Item:   wrappedItem,
+		Index:  loop.Index,
+		First:  loop.First,
+		Last:   loop.Last,
+		Length: loop.Length,
+		Parent: loop.Parent,
+	}
 }

--- a/tests/fixtures/workflows/loop-json-child.yaml
+++ b/tests/fixtures/workflows/loop-json-child.yaml
@@ -1,0 +1,54 @@
+# F047 Test Fixture: Child workflow for loop JSON serialization testing
+name: loop-json-child
+version: "1.0.0"
+
+inputs:
+  - name: item
+    type: string
+    required: true
+  - name: index
+    type: integer
+    required: false
+    default: 0
+
+outputs:
+  - name: validation_result
+    from: states.validate.output
+
+states:
+  initial: validate
+  validate:
+    type: step
+    command: |
+      set -e
+      item='{{.inputs.item}}'
+      index={{.inputs.index}}
+
+      # Check if item starts with "map[" (Go map format - FAIL)
+      case "$item" in
+        map\[*)
+          echo "VALIDATION_FAILED: Item at index $index is Go map format: $item"
+          exit 1
+          ;;
+      esac
+
+      # Validate JSON syntax using jq
+      if ! echo "$item" | jq empty 2>/dev/null; then
+        echo "VALIDATION_FAILED: Item at index $index is not valid JSON: $item"
+        exit 1
+      fi
+
+      # Extract fields to verify structure
+      name=$(echo "$item" | jq -r '.name // empty')
+      type=$(echo "$item" | jq -r '.type // empty')
+      files=$(echo "$item" | jq -r '.files // empty')
+
+      echo "VALIDATION_SUCCESS: Item $index is valid JSON - name=$name, type=$type, files_count=$(echo "$files" | jq 'length')"
+    on_success: done
+    on_failure: error
+  done:
+    type: terminal
+    status: success
+  error:
+    type: terminal
+    status: failure

--- a/tests/fixtures/workflows/loop-json-serialization.yaml
+++ b/tests/fixtures/workflows/loop-json-serialization.yaml
@@ -1,0 +1,48 @@
+# F047 Test Fixture: for_each validating JSON serialization of loop items
+name: loop-json-serialization
+version: "1.0.0"
+
+inputs:
+  - name: items_json
+    type: string
+    required: false
+    default: '[{"name":"S1","type":"fix","files":["a.go","b.go"]},{"name":"S2","type":"feat","files":["c.go"]}]'
+
+states:
+  initial: loop_items
+  loop_items:
+    type: for_each
+    items: "{{.inputs.items_json}}"
+    body:
+      - validate_item
+    on_complete: done
+  validate_item:
+    type: step
+    command: |
+      item='{{.loop.Item}}'
+      index={{.loop.Index}}
+
+      # Check if item starts with "map[" (Go map format - FAIL)
+      case "$item" in
+        map\[*)
+          echo "VALIDATION_FAILED: Item at index $index is Go map format: $item" >&2
+          exit 1
+          ;;
+      esac
+
+      # Validate JSON syntax using jq
+      if ! echo "$item" | jq empty 2>/dev/null; then
+        echo "VALIDATION_FAILED: Item at index $index is not valid JSON: $item" >&2
+        exit 1
+      fi
+
+      # Extract fields to verify structure
+      name=$(echo "$item" | jq -r '.name // empty')
+      type=$(echo "$item" | jq -r '.type // empty')
+      files_count=$(echo "$item" | jq -r '.files | length // 0')
+
+      echo "VALIDATION_SUCCESS: Item $index is valid JSON - name=$name, type=$type, files_count=$files_count"
+    on_success: loop_items
+  done:
+    type: terminal
+    status: success

--- a/tests/fixtures/workflows/test-loop-simple.yaml
+++ b/tests/fixtures/workflows/test-loop-simple.yaml
@@ -1,0 +1,18 @@
+name: test-loop-simple
+version: "1.0.0"
+
+states:
+  initial: loop_items
+  loop_items:
+    type: for_each
+    items: '[{"name":"S1"},{"name":"S2"}]'
+    body:
+      - echo_item
+    on_complete: done
+  echo_item:
+    type: step
+    command: 'echo "Item: {{.loop.Item}}"'
+    on_success: loop_items
+  done:
+    type: terminal
+    status: success

--- a/tests/integration/changelog_test.go
+++ b/tests/integration/changelog_test.go
@@ -1,0 +1,323 @@
+package integration
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Item: T012
+// Feature: F047
+// Tests comprehensive validation of CHANGELOG.md entry for F047 bug fix
+
+// TestChangelog_F047Entry_HappyPath validates complete F047 documentation
+func TestChangelog_F047Entry_HappyPath(t *testing.T) {
+	// Arrange: Read CHANGELOG.md
+	changelogPath := "../../CHANGELOG.md"
+	content, err := os.ReadFile(changelogPath)
+	if err != nil {
+		t.Fatalf("Failed to read CHANGELOG.md: %v", err)
+	}
+
+	changelog := string(content)
+
+	// Act & Assert: Verify F047 entry exists
+	if !strings.Contains(changelog, "**F047**") {
+		t.Error("CHANGELOG.md missing F047 entry in Fixed section")
+	}
+
+	// Assert: Entry must be complete (no TODO markers)
+	if strings.Contains(changelog, "[TODO:") {
+		t.Error("CHANGELOG.md F047 entry is incomplete (contains TODO marker)")
+	}
+
+	// Assert: Entry must describe the JSON serialization fix
+	requiredKeywords := []string{
+		"loop",
+		"JSON",
+		"serialize",
+	}
+
+	for _, keyword := range requiredKeywords {
+		if !strings.Contains(strings.ToLower(changelog), strings.ToLower(keyword)) {
+			t.Errorf("CHANGELOG.md F047 entry missing required keyword: %q", keyword)
+		}
+	}
+}
+
+// TestChangelog_F047Entry_InFixedSection validates F047 is in correct section
+func TestChangelog_F047Entry_InFixedSection(t *testing.T) {
+	// Arrange: Read CHANGELOG.md
+	changelogPath := "../../CHANGELOG.md"
+	content, err := os.ReadFile(changelogPath)
+	if err != nil {
+		t.Fatalf("Failed to read CHANGELOG.md: %v", err)
+	}
+
+	changelog := string(content)
+
+	// Act: Find Fixed section and F047 entry
+	fixedSectionRegex := regexp.MustCompile(`(?s)### Fixed\s+(.*?)\s+###`)
+	matches := fixedSectionRegex.FindStringSubmatch(changelog)
+
+	// Assert: Fixed section exists
+	if len(matches) < 2 {
+		t.Fatal("CHANGELOG.md missing '### Fixed' section")
+	}
+
+	fixedSection := matches[1]
+
+	// Assert: F047 is in Fixed section
+	if !strings.Contains(fixedSection, "**F047**") {
+		t.Error("F047 entry not found in '### Fixed' section (should be under bug fixes)")
+	}
+}
+
+// TestChangelog_F047Entry_FollowsFormat validates entry follows Keep a Changelog format
+func TestChangelog_F047Entry_FollowsFormat(t *testing.T) {
+	// Arrange: Read CHANGELOG.md
+	changelogPath := "../../CHANGELOG.md"
+	content, err := os.ReadFile(changelogPath)
+	if err != nil {
+		t.Fatalf("Failed to read CHANGELOG.md: %v", err)
+	}
+
+	changelog := string(content)
+
+	// Act: Extract F047 entry
+	f047Regex := regexp.MustCompile(`- \*\*F047\*\*:[^\n]+`)
+	matches := f047Regex.FindString(changelog)
+
+	// Assert: Entry exists with proper format
+	if matches == "" {
+		t.Fatal("F047 entry not found or does not follow format: - **F047**: description")
+	}
+
+	// Assert: Entry has description (not just label)
+	if strings.TrimSpace(matches) == "- **F047**:" {
+		t.Error("F047 entry missing description after label")
+	}
+}
+
+// TestChangelog_F047Entry_HasBulletPoints validates sub-bullets exist
+func TestChangelog_F047Entry_HasBulletPoints(t *testing.T) {
+	// Arrange: Read CHANGELOG.md
+	changelogPath := "../../CHANGELOG.md"
+	content, err := os.ReadFile(changelogPath)
+	if err != nil {
+		t.Fatalf("Failed to read CHANGELOG.md: %v", err)
+	}
+
+	changelog := string(content)
+
+	// Act: Find F047 entry and following lines
+	lines := strings.Split(changelog, "\n")
+	f047Index := -1
+	for i, line := range lines {
+		if strings.Contains(line, "**F047**") {
+			f047Index = i
+			break
+		}
+	}
+
+	// Assert: F047 entry found
+	if f047Index == -1 {
+		t.Fatal("F047 entry not found in CHANGELOG.md")
+	}
+
+	// Assert: Next line(s) should have indented bullet points with details
+	hasSubBullets := false
+	for i := f047Index + 1; i < len(lines) && i < f047Index+5; i++ {
+		line := lines[i]
+		// Check for indented bullet (2 spaces + dash)
+		if strings.HasPrefix(line, "  -") || strings.HasPrefix(line, "  *") {
+			hasSubBullets = true
+			break
+		}
+		// Stop at next main bullet or section
+		if strings.HasPrefix(line, "- ") || strings.HasPrefix(line, "##") {
+			break
+		}
+	}
+
+	if !hasSubBullets {
+		t.Error("F047 entry should have sub-bullets with implementation details (following pattern of Bug-48 and JSONStore entries)")
+	}
+}
+
+// TestChangelog_F047Entry_MentionsTemplateInterpolation validates technical context
+func TestChangelog_F047Entry_MentionsTemplateInterpolation(t *testing.T) {
+	// Arrange: Read CHANGELOG.md
+	changelogPath := "../../CHANGELOG.md"
+	content, err := os.ReadFile(changelogPath)
+	if err != nil {
+		t.Fatalf("Failed to read CHANGELOG.md: %v", err)
+	}
+
+	changelog := string(content)
+
+	// Act & Assert: Verify technical terms related to the fix
+	technicalTerms := []string{
+		"template", // Template interpolation is the fix location
+		"{{",       // Template syntax is relevant
+	}
+
+	// At least one technical term should be present
+	foundTechnicalTerm := false
+	for _, term := range technicalTerms {
+		if strings.Contains(strings.ToLower(changelog), strings.ToLower(term)) {
+			foundTechnicalTerm = true
+			break
+		}
+	}
+
+	if !foundTechnicalTerm {
+		t.Error("F047 entry should mention template-related context (e.g., 'template', '{{.loop.Item}}')")
+	}
+}
+
+// TestChangelog_F047Entry_NoTypos validates common typos are absent
+func TestChangelog_F047Entry_NoTypos(t *testing.T) {
+	// Arrange: Read CHANGELOG.md
+	changelogPath := "../../CHANGELOG.md"
+	content, err := os.ReadFile(changelogPath)
+	if err != nil {
+		t.Fatalf("Failed to read CHANGELOG.md: %v", err)
+	}
+
+	changelog := string(content)
+
+	// Act: Find F047 section
+	lines := strings.Split(changelog, "\n")
+	f047Index := -1
+	var f047Section strings.Builder
+
+	for i, line := range lines {
+		if strings.Contains(line, "**F047**") {
+			f047Index = i
+		}
+		if f047Index >= 0 && i >= f047Index {
+			f047Section.WriteString(line + "\n")
+			// Stop at next main bullet or section
+			if i > f047Index && (strings.HasPrefix(line, "- **") || strings.HasPrefix(line, "##")) {
+				break
+			}
+		}
+	}
+
+	f047Text := f047Section.String()
+
+	// Assert: Check for common typos
+	commonTypos := map[string]string{
+		"seralize":  "serialize",
+		"seralized": "serialized",
+		"templat ":  "template",
+		"fo_each":   "for_each",
+		"forech":    "for_each",
+		"jsn":       "JSON",
+		"go map":    "Go map", // lowercase 'go' when referring to language
+	}
+
+	for typo, correct := range commonTypos {
+		if strings.Contains(strings.ToLower(f047Text), strings.ToLower(typo)) {
+			t.Errorf("F047 entry contains potential typo %q (should be %q)", typo, correct)
+		}
+	}
+}
+
+// TestChangelog_F047Entry_EdgeCase_NotDuplicated validates no duplicate entries
+func TestChangelog_F047Entry_EdgeCase_NotDuplicated(t *testing.T) {
+	// Arrange: Read CHANGELOG.md
+	changelogPath := "../../CHANGELOG.md"
+	content, err := os.ReadFile(changelogPath)
+	if err != nil {
+		t.Fatalf("Failed to read CHANGELOG.md: %v", err)
+	}
+
+	changelog := string(content)
+
+	// Act: Count F047 occurrences
+	count := strings.Count(changelog, "**F047**")
+
+	// Assert: Should appear exactly once
+	if count == 0 {
+		t.Error("F047 entry not found in CHANGELOG.md")
+	} else if count > 1 {
+		t.Errorf("F047 entry appears %d times (should appear exactly once)", count)
+	}
+}
+
+// TestChangelog_F047Entry_EdgeCase_NotInWrongSection validates F047 not in Added/Changed
+func TestChangelog_F047Entry_EdgeCase_NotInWrongSection(t *testing.T) {
+	// Arrange: Read CHANGELOG.md
+	changelogPath := "../../CHANGELOG.md"
+	content, err := os.ReadFile(changelogPath)
+	if err != nil {
+		t.Fatalf("Failed to read CHANGELOG.md: %v", err)
+	}
+
+	changelog := string(content)
+
+	// Act: Check Added and Changed sections don't contain F047
+	addedSectionRegex := regexp.MustCompile(`(?s)### Added\s+(.*?)\s+###`)
+	changedSectionRegex := regexp.MustCompile(`(?s)### Changed\s+(.*?)\s+###`)
+
+	addedMatches := addedSectionRegex.FindStringSubmatch(changelog)
+	changedMatches := changedSectionRegex.FindStringSubmatch(changelog)
+
+	// Assert: F047 should NOT be in Added section
+	if len(addedMatches) >= 2 && strings.Contains(addedMatches[1], "**F047**") {
+		t.Error("F047 is a bug fix and should not be in '### Added' section")
+	}
+
+	// Assert: F047 should NOT be in Changed section
+	if len(changedMatches) >= 2 && strings.Contains(changedMatches[1], "**F047**") {
+		t.Error("F047 is a bug fix and should not be in '### Changed' section")
+	}
+}
+
+// TestChangelog_F047Entry_ErrorHandling_MissingFile validates graceful handling
+func TestChangelog_F047Entry_ErrorHandling_MissingFile(t *testing.T) {
+	// Arrange: Use non-existent path
+	changelogPath := "../../NONEXISTENT_CHANGELOG.md"
+
+	// Act: Try to read
+	_, err := os.ReadFile(changelogPath)
+
+	// Assert: Should get error (this test validates our test setup)
+	if err == nil {
+		t.Error("Expected error when reading non-existent file, got nil")
+	}
+}
+
+// TestChangelog_UnreleasedSection_Exists validates Unreleased section exists
+func TestChangelog_UnreleasedSection_Exists(t *testing.T) {
+	// Arrange: Read CHANGELOG.md
+	changelogPath := "../../CHANGELOG.md"
+	content, err := os.ReadFile(changelogPath)
+	if err != nil {
+		t.Fatalf("Failed to read CHANGELOG.md: %v", err)
+	}
+
+	changelog := string(content)
+
+	// Act & Assert: Unreleased section must exist
+	if !strings.Contains(changelog, "## [Unreleased]") {
+		t.Error("CHANGELOG.md missing '## [Unreleased]' section (required by Keep a Changelog format)")
+	}
+
+	// Assert: Fixed section must exist under Unreleased
+	unreleasedRegex := regexp.MustCompile(`(?sm)## \[Unreleased\](.*?)(?:^## |\z)`)
+	matches := unreleasedRegex.FindStringSubmatch(changelog)
+
+	if len(matches) < 2 {
+		t.Fatal("Could not extract Unreleased section content")
+	}
+
+	unreleasedContent := matches[1]
+
+	if !strings.Contains(unreleasedContent, "### Fixed") {
+		t.Error("Unreleased section missing '### Fixed' subsection")
+	}
+}

--- a/tests/integration/loop_dynamic_test.go
+++ b/tests/integration/loop_dynamic_test.go
@@ -1594,3 +1594,326 @@ states:
 	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
 	assert.Len(t, lines, 2, "should process exactly 2 items with batch_count=2")
 }
+
+// =============================================================================
+// F047: Loop JSON Serialization - Integration Tests
+// =============================================================================
+
+// TestForEachLoop_WithObjectItems_Integration tests US3: for_each loop with JSON objects
+// AC1: {{.loop.Item}} passed to call_workflow produces valid JSON
+// AC2: Nested objects and arrays properly serialized
+func TestForEachLoop_WithObjectItems_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: A parent workflow that iterates over JSON objects and passes them to a child workflow
+	fixturesDir := "../fixtures/workflows"
+
+	repo := repository.NewYAMLRepository(fixturesDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := newSimpleExpressionEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil, evaluator,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// When: The workflow executes with default JSON objects containing nested arrays
+	// Default items: [{"name":"S1","type":"fix","files":["a.go","b.go"]},{"name":"S2","type":"feat","files":["c.go"]}]
+	execCtx, err := execSvc.Run(ctx, "loop-json-serialization", nil)
+
+	// Then: Workflow should complete successfully
+	require.NoError(t, err, "workflow execution should not error")
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status, "workflow should complete successfully")
+	assert.Equal(t, "done", execCtx.CurrentStep, "workflow should end at done state")
+
+	// Then: Validation step should exist and pass (no Go map format)
+	validateState, ok := execCtx.GetStepState("validate_item")
+	require.True(t, ok, "validate_item state should exist")
+	assert.Equal(t, 0, validateState.ExitCode, "validate_item should succeed")
+
+	// Verify validation output confirms JSON format
+	validationOutput := validateState.Output
+	assert.Contains(t, validationOutput, "VALIDATION_SUCCESS", "validation should confirm JSON format")
+	assert.NotContains(t, validationOutput, "map[", "output should not contain Go map format")
+	assert.NotContains(t, validationOutput, "VALIDATION_FAILED", "validation should not fail")
+}
+
+// TestForEachLoop_WithNestedStructures tests AC2: nested objects and arrays properly serialized
+func TestForEachLoop_WithNestedStructures(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: A workflow with deeply nested JSON structures
+	fixturesDir := "../fixtures/workflows"
+
+	repo := repository.NewYAMLRepository(fixturesDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := newSimpleExpressionEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil, evaluator,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// When: Items contain nested objects and arrays
+	nestedJSON := `[{"name":"Task1","metadata":{"priority":"high","tags":["urgent","bug"]},"assignees":[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}]}]`
+	inputs := map[string]any{"items_json": nestedJSON}
+
+	execCtx, err := execSvc.Run(ctx, "loop-json-serialization", inputs)
+
+	// Then: Workflow should complete and child validates nested JSON
+	require.NoError(t, err, "workflow with nested structures should not error")
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status, "workflow should complete")
+
+	// Verify nested structures are valid JSON
+	validateState, ok := execCtx.GetStepState("validate_item")
+	require.True(t, ok, "validate_item state should exist")
+	assert.Equal(t, 0, validateState.ExitCode, "should validate nested JSON")
+	assert.Contains(t, validateState.Output, "VALIDATION_SUCCESS", "nested JSON should validate")
+}
+
+// TestForEachLoop_MixedPrimitiveAndComplex tests mixed primitive and complex types in loop
+func TestForEachLoop_MixedPrimitiveAndComplex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: A workflow that can handle both primitive and complex types
+	tmpDir := t.TempDir()
+	outputFile := filepath.Join(tmpDir, "results.txt")
+
+	// Create a simple workflow that echoes loop items to a file
+	wfYAML := `name: mixed-types
+version: "1.0.0"
+inputs:
+  - name: items_json
+    type: string
+    required: true
+states:
+  initial: loop_items
+  loop_items:
+    type: for_each
+    items: "{{.inputs.items_json}}"
+    body:
+      - echo_item
+    on_complete: done
+  echo_item:
+    type: step
+    command: |
+      item='{{.loop.Item}}'
+      printf '%s\n' "$item" >> ` + outputFile + `
+    on_success: loop_items
+  done:
+    type: terminal
+    status: success
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "mixed-types.yaml"), []byte(wfYAML), 0644)
+	require.NoError(t, err)
+
+	repo := repository.NewYAMLRepository(tmpDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := newSimpleExpressionEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil, evaluator,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// When: Mix of primitives and objects in the array
+	mixedJSON := `["string",42,{"key":"value"},[1,2,3],true,null]`
+	inputs := map[string]any{"items_json": mixedJSON}
+
+	execCtx, err := execSvc.Run(ctx, "mixed-types", inputs)
+
+	// Then: All items should be serialized appropriately
+	require.NoError(t, err, "workflow with mixed types should not error")
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status, "workflow should complete")
+
+	// Verify output file contains properly serialized items
+	data, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+	output := string(data)
+
+	// Primitives should pass through unchanged
+	assert.Contains(t, output, "string", "string primitive should be preserved")
+	assert.Contains(t, output, "42", "number primitive should be preserved")
+	assert.Contains(t, output, "true", "boolean primitive should be preserved")
+
+	// Complex types should be JSON
+	assert.Contains(t, output, `{"key":"value"}`, "object should be JSON")
+	assert.Contains(t, output, "[1,2,3]", "array should be JSON")
+
+	// Should NOT contain Go map format
+	assert.NotContains(t, output, "map[", "should not have Go map format")
+}
+
+// TestForEachLoop_EmptyObjectsAndArrays tests edge case: empty objects and arrays
+func TestForEachLoop_EmptyObjectsAndArrays(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Workflow with empty objects and arrays
+	fixturesDir := "../fixtures/workflows"
+
+	repo := repository.NewYAMLRepository(fixturesDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := newSimpleExpressionEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil, evaluator,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// When: Items include empty objects and arrays
+	emptyJSON := `[{},{"name":"test","data":[]},{"items":[]}]`
+	inputs := map[string]any{"items_json": emptyJSON}
+
+	execCtx, err := execSvc.Run(ctx, "loop-json-serialization", inputs)
+
+	// Then: Empty structures should serialize as valid JSON
+	require.NoError(t, err, "workflow with empty structures should not error")
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status, "workflow should complete")
+
+	validateState, ok := execCtx.GetStepState("validate_item")
+	require.True(t, ok, "validate_item state should exist")
+	assert.Equal(t, 0, validateState.ExitCode, "empty structures should validate as JSON")
+}
+
+// TestForEachLoop_UnicodeAndSpecialChars tests edge case: unicode and special characters
+func TestForEachLoop_UnicodeAndSpecialChars(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Workflow with unicode and special characters
+	fixturesDir := "../fixtures/workflows"
+
+	repo := repository.NewYAMLRepository(fixturesDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := newSimpleExpressionEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil, evaluator,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// When: Items contain unicode, emojis, and special characters
+	unicodeJSON := `[{"name":"测试","emoji":"🚀","special":"quote:\"value\""}]`
+	inputs := map[string]any{"items_json": unicodeJSON}
+
+	execCtx, err := execSvc.Run(ctx, "loop-json-serialization", inputs)
+
+	// Then: Unicode and special chars should be properly escaped in JSON
+	require.NoError(t, err, "workflow with unicode should not error")
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status, "workflow should complete")
+
+	validateState, ok := execCtx.GetStepState("validate_item")
+	require.True(t, ok, "validate_item state should exist")
+	assert.Equal(t, 0, validateState.ExitCode, "unicode JSON should validate")
+}
+
+// TestForEachLoop_BackwardCompatibility_StringItems tests AC4: existing workflows work unchanged
+func TestForEachLoop_BackwardCompatibility_StringItems(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: A workflow with simple string items (existing behavior)
+	tmpDir := t.TempDir()
+	outputFile := filepath.Join(tmpDir, "output.txt")
+
+	wfYAML := `name: string-items
+version: "1.0.0"
+states:
+  initial: loop
+  loop:
+    type: for_each
+    items: '["item1", "item2", "item3"]'
+    body:
+      - echo_item
+    on_complete: done
+  echo_item:
+    type: step
+    command: 'echo "{{.loop.Item}}" >> ` + outputFile + `'
+    on_success: loop
+  done:
+    type: terminal
+    status: success
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "string-items.yaml"), []byte(wfYAML), 0644)
+	require.NoError(t, err)
+
+	repo := repository.NewYAMLRepository(tmpDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := newSimpleExpressionEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil, evaluator,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// When: Running workflow with string items (pre-F047 behavior)
+	execCtx, err := execSvc.Run(ctx, "string-items", nil)
+
+	// Then: String items should pass through unchanged (backward compatibility)
+	require.NoError(t, err, "string items workflow should work")
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status, "workflow should complete")
+
+	data, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+
+	assert.Len(t, lines, 3, "should have 3 items")
+	assert.Equal(t, "item1", lines[0], "string should not be quoted")
+	assert.Equal(t, "item2", lines[1], "string should not be quoted")
+	assert.Equal(t, "item3", lines[2], "string should not be quoted")
+
+	// Strings should NOT be JSON-quoted (backward compatibility)
+	assert.NotContains(t, string(data), `"item1"`, "strings should not be JSON-encoded")
+}

--- a/tests/integration/loop_json_child_test.go
+++ b/tests/integration/loop_json_child_test.go
@@ -1,0 +1,542 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vanoix/awf/internal/application"
+	"github.com/vanoix/awf/internal/domain/workflow"
+	"github.com/vanoix/awf/internal/infrastructure/executor"
+	"github.com/vanoix/awf/internal/infrastructure/repository"
+	"github.com/vanoix/awf/pkg/interpolation"
+)
+
+// =============================================================================
+// F047 - Component T010: loop_json_child.yaml Fixture Tests
+// =============================================================================
+// US3: Integration validation for loop item JSON serialization
+// Tests that the child workflow correctly validates JSON vs Go map format
+
+// TestLoopJSONChild_HappyPath_ValidJSONInput tests the child workflow receives
+// and validates a properly formatted JSON object.
+// Item: T010
+// Feature: F047
+func TestLoopJSONChild_HappyPath_ValidJSONInput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Child workflow fixture exists
+	fixturesDir := "../fixtures/workflows"
+	repo := repository.NewYAMLRepository(fixturesDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionService(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// When: Child workflow receives valid JSON object
+	validJSON := `{"name":"S1","type":"fix","files":["a.go","b.go"]}`
+	inputs := map[string]any{
+		"item":  validJSON,
+		"index": 0,
+	}
+
+	execCtx, err := execSvc.Run(ctx, "loop-json-child", inputs)
+
+	// Then: Validation succeeds
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+	assert.Equal(t, "done", execCtx.CurrentStep)
+
+	// Verify output contains validation success
+	validateState, exists := execCtx.States["validate"]
+	require.True(t, exists, "validate state should exist")
+	assert.Contains(t, validateState.Output, "VALIDATION_SUCCESS")
+	assert.Contains(t, validateState.Output, "name=S1")
+	assert.Contains(t, validateState.Output, "type=fix")
+}
+
+// TestLoopJSONChild_HappyPath_NestedJSON tests validation with nested objects.
+// Item: T010
+// Feature: F047
+func TestLoopJSONChild_HappyPath_NestedJSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Child workflow fixture
+	fixturesDir := "../fixtures/workflows"
+	repo := repository.NewYAMLRepository(fixturesDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionService(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// When: Child receives nested JSON structure
+	nestedJSON := `{"name":"S2","type":"feat","metadata":{"priority":"high","tags":["urgent","api"]},"files":["c.go"]}`
+	inputs := map[string]any{
+		"item":  nestedJSON,
+		"index": 1,
+	}
+
+	execCtx, err := execSvc.Run(ctx, "loop-json-child", inputs)
+
+	// Then: Validation succeeds with nested data
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+
+	validateState, exists := execCtx.States["validate"]
+	require.True(t, exists)
+	assert.Contains(t, validateState.Output, "VALIDATION_SUCCESS")
+	assert.Contains(t, validateState.Output, "name=S2")
+	assert.Contains(t, validateState.Output, "type=feat")
+}
+
+// TestLoopJSONChild_HappyPath_JSONArray tests validation with array values.
+// Item: T010
+// Feature: F047
+func TestLoopJSONChild_HappyPath_JSONArray(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Child workflow fixture
+	fixturesDir := "../fixtures/workflows"
+	repo := repository.NewYAMLRepository(fixturesDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionService(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// When: JSON object has array with multiple files
+	arrayJSON := `{"name":"S3","type":"refactor","files":["a.go","b.go","c.go","d.go"]}`
+	inputs := map[string]any{
+		"item":  arrayJSON,
+		"index": 2,
+	}
+
+	execCtx, err := execSvc.Run(ctx, "loop-json-child", inputs)
+
+	// Then: Array is properly parsed
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+
+	validateState, exists := execCtx.States["validate"]
+	require.True(t, exists)
+	assert.Contains(t, validateState.Output, "VALIDATION_SUCCESS")
+	assert.Contains(t, validateState.Output, "files_count=4")
+}
+
+// TestLoopJSONChild_EdgeCase_EmptyFields tests JSON with empty field values.
+// Item: T010
+// Feature: F047
+func TestLoopJSONChild_EdgeCase_EmptyFields(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Child workflow fixture
+	fixturesDir := "../fixtures/workflows"
+	repo := repository.NewYAMLRepository(fixturesDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionService(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// When: JSON has empty arrays or missing fields
+	emptyJSON := `{"name":"S4","type":"","files":[]}`
+	inputs := map[string]any{
+		"item":  emptyJSON,
+		"index": 3,
+	}
+
+	execCtx, err := execSvc.Run(ctx, "loop-json-child", inputs)
+
+	// Then: Still valid JSON, validation succeeds
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+
+	validateState, exists := execCtx.States["validate"]
+	require.True(t, exists)
+	assert.Contains(t, validateState.Output, "VALIDATION_SUCCESS")
+	assert.Contains(t, validateState.Output, "files_count=0")
+}
+
+// TestLoopJSONChild_EdgeCase_UnicodeCharacters tests JSON with unicode/special chars.
+// Item: T010
+// Feature: F047
+func TestLoopJSONChild_EdgeCase_UnicodeCharacters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Child workflow fixture
+	fixturesDir := "../fixtures/workflows"
+	repo := repository.NewYAMLRepository(fixturesDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionService(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// When: JSON contains unicode characters
+	unicodeJSON := `{"name":"S5-✨","type":"feat","files":["café.go","日本語.go"]}`
+	inputs := map[string]any{
+		"item":  unicodeJSON,
+		"index": 4,
+	}
+
+	execCtx, err := execSvc.Run(ctx, "loop-json-child", inputs)
+
+	// Then: Unicode is properly handled
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+
+	validateState, exists := execCtx.States["validate"]
+	require.True(t, exists)
+	assert.Contains(t, validateState.Output, "VALIDATION_SUCCESS")
+}
+
+// TestLoopJSONChild_EdgeCase_MinimalJSON tests minimal valid JSON object.
+// Item: T010
+// Feature: F047
+func TestLoopJSONChild_EdgeCase_MinimalJSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Child workflow fixture
+	fixturesDir := "../fixtures/workflows"
+	repo := repository.NewYAMLRepository(fixturesDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionService(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// When: Minimal JSON object with only required field
+	minimalJSON := `{}`
+	inputs := map[string]any{
+		"item":  minimalJSON,
+		"index": 5,
+	}
+
+	execCtx, err := execSvc.Run(ctx, "loop-json-child", inputs)
+
+	// Then: Empty object is still valid JSON
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+
+	validateState, exists := execCtx.States["validate"]
+	require.True(t, exists)
+	assert.Contains(t, validateState.Output, "VALIDATION_SUCCESS")
+}
+
+// TestLoopJSONChild_ErrorHandling_GoMapFormat tests detection of Go map format.
+// This is the CRITICAL test - ensures the bug is detected.
+// Item: T010
+// Feature: F047
+func TestLoopJSONChild_ErrorHandling_GoMapFormat(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Child workflow fixture
+	fixturesDir := "../fixtures/workflows"
+	repo := repository.NewYAMLRepository(fixturesDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionService(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// When: Item is in Go map format (the bug we're testing for)
+	goMapFormat := `map[name:S1 type:fix files:[a.go b.go]]`
+	inputs := map[string]any{
+		"item":  goMapFormat,
+		"index": 0,
+	}
+
+	execCtx, err := execSvc.Run(ctx, "loop-json-child", inputs)
+
+	// Then: Workflow should FAIL with validation error
+	// This test MUST FAIL until F047 is implemented
+	require.Error(t, err, "Go map format should be rejected")
+	assert.Equal(t, workflow.StatusFailed, execCtx.Status)
+	assert.Equal(t, "error", execCtx.CurrentStep)
+
+	// Verify error message indicates Go map format
+	validateState, exists := execCtx.States["validate"]
+	require.True(t, exists)
+	assert.Contains(t, validateState.Output, "VALIDATION_FAILED")
+	assert.Contains(t, validateState.Output, "Go map format")
+}
+
+// TestLoopJSONChild_ErrorHandling_InvalidJSON tests malformed JSON detection.
+// Item: T010
+// Feature: F047
+func TestLoopJSONChild_ErrorHandling_InvalidJSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Child workflow fixture
+	fixturesDir := "../fixtures/workflows"
+	repo := repository.NewYAMLRepository(fixturesDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionService(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tests := []struct {
+		name        string
+		invalidJSON string
+	}{
+		{"missing_brace", `{"name":"S1","type":"fix"`},
+		{"trailing_comma", `{"name":"S1","type":"fix",}`},
+		{"single_quotes", `{'name':'S1','type':'fix'}`},
+		{"unquoted_keys", `{name:"S1",type:"fix"}`},
+		{"plain_text", `just some text`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// When: Invalid JSON is provided
+			inputs := map[string]any{
+				"item":  tt.invalidJSON,
+				"index": 99,
+			}
+
+			execCtx, err := execSvc.Run(ctx, "loop-json-child", inputs)
+
+			// Then: Validation fails
+			require.Error(t, err, "invalid JSON should be rejected")
+			assert.Equal(t, workflow.StatusFailed, execCtx.Status)
+
+			validateState, exists := execCtx.States["validate"]
+			require.True(t, exists)
+			assert.Contains(t, validateState.Output, "VALIDATION_FAILED")
+			assert.Contains(t, validateState.Output, "not valid JSON")
+		})
+	}
+}
+
+// TestLoopJSONChild_ErrorHandling_MissingRequiredInput tests behavior with missing item.
+// Item: T010
+// Feature: F047
+func TestLoopJSONChild_ErrorHandling_MissingRequiredInput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Child workflow fixture
+	fixturesDir := "../fixtures/workflows"
+	repo := repository.NewYAMLRepository(fixturesDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionService(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// When: Required 'item' input is missing
+	inputs := map[string]any{
+		"index": 0,
+		// "item" is missing
+	}
+
+	_, err := execSvc.Run(ctx, "loop_json_child", inputs)
+
+	// Then: Should fail with input validation error
+	require.Error(t, err, "missing required input should fail")
+	assert.True(t,
+		strings.Contains(err.Error(), "item") ||
+			strings.Contains(err.Error(), "required") ||
+			strings.Contains(err.Error(), "input"),
+		"error should mention missing required input")
+}
+
+// TestLoopJSONChild_EdgeCase_IndexParameter tests optional index parameter.
+// Item: T010
+// Feature: F047
+func TestLoopJSONChild_EdgeCase_IndexParameter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Child workflow fixture
+	fixturesDir := "../fixtures/workflows"
+	repo := repository.NewYAMLRepository(fixturesDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionService(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tests := []struct {
+		name  string
+		index any
+	}{
+		{"explicit_index_0", 0},
+		{"explicit_index_5", 5},
+		{"omitted_index_defaults", nil}, // Should use default value 0
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// When: Index is provided or omitted
+			inputs := map[string]any{
+				"item": `{"name":"test","type":"test","files":[]}`,
+			}
+			if tt.index != nil {
+				inputs["index"] = tt.index
+			}
+
+			execCtx, err := execSvc.Run(ctx, "loop-json-child", inputs)
+
+			// Then: Workflow succeeds regardless of index value
+			require.NoError(t, err)
+			assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+
+			validateState, exists := execCtx.States["validate"]
+			require.True(t, exists)
+			assert.Contains(t, validateState.Output, "VALIDATION_SUCCESS")
+		})
+	}
+}
+
+// TestLoopJSONChild_Integration_LoadsAndValidates verifies fixture can be loaded.
+// Item: T010
+// Feature: F047
+func TestLoopJSONChild_Integration_LoadsAndValidates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Fixtures directory
+	fixturesDir := "../fixtures/workflows"
+	repo := repository.NewYAMLRepository(fixturesDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// When: Loading loop-json-child workflow
+	wf, err := wfSvc.GetWorkflow(ctx, "loop-json-child")
+
+	// Then: Workflow loads successfully
+	require.NoError(t, err, "loop-json-child.yaml should load without errors")
+	require.NotNil(t, wf, "workflow should not be nil")
+	assert.Equal(t, "loop-json-child", wf.Name)
+	assert.Equal(t, "1.0.0", wf.Version)
+
+	// Verify inputs are defined correctly
+	require.Len(t, wf.Inputs, 2, "should have 2 inputs: item and index")
+	assert.Equal(t, "item", wf.Inputs[0].Name)
+	assert.True(t, wf.Inputs[0].Required)
+	assert.Equal(t, "index", wf.Inputs[1].Name)
+	assert.False(t, wf.Inputs[1].Required)
+
+	// Verify steps structure (Steps, not States)
+	require.Contains(t, wf.Steps, "validate", "should have validate step")
+	require.Contains(t, wf.Steps, "done", "should have done step")
+	require.Contains(t, wf.Steps, "error", "should have error step")
+
+	// Validate the workflow structure
+	err = wfSvc.ValidateWorkflow(ctx, "loop-json-child")
+	assert.NoError(t, err, "workflow should pass validation")
+}

--- a/tests/integration/loop_json_serialization_test.go
+++ b/tests/integration/loop_json_serialization_test.go
@@ -1,0 +1,667 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vanoix/awf/internal/application"
+	"github.com/vanoix/awf/internal/domain/workflow"
+	"github.com/vanoix/awf/internal/infrastructure/executor"
+	"github.com/vanoix/awf/internal/infrastructure/repository"
+	"github.com/vanoix/awf/pkg/interpolation"
+)
+
+// =============================================================================
+// Feature: F047 - Loop Item JSON Serialization
+// Functional Tests - End-to-End Scenarios
+// =============================================================================
+//
+// These tests validate the complete feature implementation across real-world
+// usage patterns, ensuring all acceptance criteria are met:
+//
+// AC1: {{.loop.Item}} passed to call_workflow produces valid JSON
+// AC2: Nested objects and arrays properly serialized
+// AC3: Unit tests cover serialization scenarios (see pkg/interpolation tests)
+// AC4: Existing workflows work without workarounds
+
+// TestF047_HappyPath_CallWorkflowWithJSONObjects tests AC1:
+// for_each loop passing JSON objects to call_workflow via {{.loop.Item}}
+// Feature: F047
+func TestF047_HappyPath_CallWorkflowWithJSONObjects(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Parent workflow iterates over JSON objects and calls child workflow
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "output")
+	err := os.MkdirAll(outputDir, 0755)
+	require.NoError(t, err)
+
+	// Create child workflow that validates and processes JSON item
+	childYAML := `name: process-item
+version: "1.0.0"
+inputs:
+  - name: item
+    type: string
+    required: true
+outputs:
+  - name: result
+    from: states.process.output
+states:
+  initial: process
+  process:
+    type: step
+    command: |
+      item='{{.inputs.item}}'
+      # Validate it's JSON, not Go map format
+      if echo "$item" | grep -q '^map\['; then
+        echo "ERROR: Received Go map format" >&2
+        exit 1
+      fi
+      # Parse with jq to ensure valid JSON
+      name=$(echo "$item" | jq -r '.name')
+      type=$(echo "$item" | jq -r '.type')
+      echo "Processed: $name ($type)"
+    on_success: done
+  done:
+    type: terminal
+    status: success
+`
+	err = os.WriteFile(filepath.Join(tmpDir, "process-item.yaml"), []byte(childYAML), 0644)
+	require.NoError(t, err)
+
+	// Create parent workflow with for_each calling child
+	parentYAML := `name: parent
+version: "1.0.0"
+states:
+  initial: extract_items
+  extract_items:
+    type: step
+    command: echo '[{"name":"S1","type":"fix","files":["a.go"]},{"name":"S2","type":"feat","files":["b.go","c.go"]}]'
+    on_success: loop_items
+  loop_items:
+    type: for_each
+    items: "{{.states.extract_items.Output}}"
+    body:
+      - call_child
+    on_complete: done
+  call_child:
+    type: call_workflow
+    workflow: process-item
+    inputs:
+      item: "{{.loop.Item}}"
+    on_success: loop_items
+  done:
+    type: terminal
+    status: success
+`
+	err = os.WriteFile(filepath.Join(tmpDir, "parent.yaml"), []byte(parentYAML), 0644)
+	require.NoError(t, err)
+
+	repo := repository.NewYAMLRepository(tmpDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := newSimpleExpressionEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil, evaluator,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// When: Parent workflow executes
+	execCtx, err := execSvc.Run(ctx, "parent", nil)
+
+	// Then: Workflow completes successfully
+	require.NoError(t, err, "call_workflow with JSON items should succeed")
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+
+	// Verify child received valid JSON (no errors about Go map format)
+	callChildState, exists := execCtx.GetStepState("call_child")
+	require.True(t, exists, "call_child state should exist")
+	assert.NotContains(t, callChildState.Output, "Go map format", "child should not receive Go map format")
+}
+
+// TestF047_HappyPath_NestedObjectsAndArrays tests AC2:
+// Complex nested structures serialize correctly
+// Feature: F047
+func TestF047_HappyPath_NestedObjectsAndArrays(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Workflow with deeply nested JSON structures
+	tmpDir := t.TempDir()
+
+	wfYAML := `name: nested-json
+version: "1.0.0"
+states:
+  initial: create_nested
+  create_nested:
+    type: step
+    command: echo '[{"task":"Feature1","metadata":{"priority":"high","tags":["urgent","bug"],"assignees":[{"id":1,"name":"Alice","roles":["dev","reviewer"]},{"id":2,"name":"Bob","roles":["qa"]}]},"files":["a.go","b.go"]}]'
+    on_success: loop_items
+  loop_items:
+    type: for_each
+    items: "{{.states.create_nested.Output}}"
+    body:
+      - validate_nested
+    on_complete: done
+  validate_nested:
+    type: step
+    command: |
+      item='{{.loop.Item}}'
+      # Verify it's valid JSON
+      if ! echo "$item" | jq empty 2>/dev/null; then
+        echo "Invalid JSON" >&2
+        exit 1
+      fi
+      # Verify nested structures are preserved
+      task=$(echo "$item" | jq -r '.task')
+      priority=$(echo "$item" | jq -r '.metadata.priority')
+      tag_count=$(echo "$item" | jq -r '.metadata.tags | length')
+      assignee_count=$(echo "$item" | jq -r '.metadata.assignees | length')
+      first_assignee_role_count=$(echo "$item" | jq -r '.metadata.assignees[0].roles | length')
+
+      echo "Valid: task=$task, priority=$priority, tags=$tag_count, assignees=$assignee_count, first_roles=$first_assignee_role_count"
+
+      # Assertions
+      [ "$task" = "Feature1" ] || exit 1
+      [ "$priority" = "high" ] || exit 1
+      [ "$tag_count" = "2" ] || exit 1
+      [ "$assignee_count" = "2" ] || exit 1
+      [ "$first_assignee_role_count" = "2" ] || exit 1
+    on_success: loop_items
+  done:
+    type: terminal
+    status: success
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "nested-json.yaml"), []byte(wfYAML), 0644)
+	require.NoError(t, err)
+
+	repo := repository.NewYAMLRepository(tmpDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := newSimpleExpressionEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil, evaluator,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// When: Workflow with nested structures executes
+	execCtx, err := execSvc.Run(ctx, "nested-json", nil)
+
+	// Then: Nested structures are properly serialized and parsed
+	require.NoError(t, err, "nested structures should serialize correctly")
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+
+	validateState, exists := execCtx.GetStepState("validate_nested")
+	require.True(t, exists)
+	assert.Contains(t, validateState.Output, "Valid:", "nested JSON should validate")
+}
+
+// TestF047_EdgeCase_EmptyObjectsAndArrays tests edge cases with empty structures
+// Feature: F047
+func TestF047_EdgeCase_EmptyObjectsAndArrays(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Items with empty objects and arrays
+	tmpDir := t.TempDir()
+
+	wfYAML := `name: empty-structures
+version: "1.0.0"
+states:
+  initial: loop_items
+  loop_items:
+    type: for_each
+    items: '[{}, {"data":[]}, {"nested":{"values":[]}}]'
+    body:
+      - validate_empty
+    on_complete: done
+  validate_empty:
+    type: step
+    command: |
+      item='{{.loop.Item}}'
+      # Must be valid JSON
+      if ! echo "$item" | jq empty 2>/dev/null; then
+        echo "Not valid JSON" >&2
+        exit 1
+      fi
+      echo "Valid empty structure: $item"
+    on_success: loop_items
+  done:
+    type: terminal
+    status: success
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "empty-structures.yaml"), []byte(wfYAML), 0644)
+	require.NoError(t, err)
+
+	repo := repository.NewYAMLRepository(tmpDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := newSimpleExpressionEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil, evaluator,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// When: Processing empty structures
+	execCtx, err := execSvc.Run(ctx, "empty-structures", nil)
+
+	// Then: Empty structures serialize as valid JSON
+	require.NoError(t, err, "empty structures should be valid JSON")
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+}
+
+// TestF047_EdgeCase_PrimitiveTypes tests AC4: primitives pass through unchanged
+// Feature: F047
+func TestF047_EdgeCase_PrimitiveTypes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Loop items are primitive types (not objects)
+	tmpDir := t.TempDir()
+	outputFile := filepath.Join(tmpDir, "output.txt")
+
+	tests := []struct {
+		name     string
+		items    string
+		expected []string
+	}{
+		{
+			name:     "strings",
+			items:    `["string1", "string2", "string3"]`,
+			expected: []string{"string1", "string2", "string3"},
+		},
+		{
+			name:     "numbers",
+			items:    `[1, 2, 3]`,
+			expected: []string{"1", "2", "3"},
+		},
+		{
+			name:     "booleans",
+			items:    `[true, false, true]`,
+			expected: []string{"true", "false", "true"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clean output file
+			_ = os.Remove(outputFile)
+
+			wfYAML := `name: primitive-items
+version: "1.0.0"
+states:
+  initial: loop
+  loop:
+    type: for_each
+    items: '` + tt.items + `'
+    body:
+      - echo_item
+    on_complete: done
+  echo_item:
+    type: step
+    command: 'echo "{{.loop.Item}}" >> ` + outputFile + `'
+    on_success: loop
+  done:
+    type: terminal
+    status: success
+`
+			err := os.WriteFile(filepath.Join(tmpDir, "primitive-items.yaml"), []byte(wfYAML), 0644)
+			require.NoError(t, err)
+
+			repo := repository.NewYAMLRepository(tmpDir)
+			store := newMockStateStore()
+			exec := executor.NewShellExecutor()
+			logger := &mockLogger{}
+			resolver := interpolation.NewTemplateResolver()
+			evaluator := newSimpleExpressionEvaluator()
+
+			wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+			parallelExec := application.NewParallelExecutor(logger)
+			execSvc := application.NewExecutionServiceWithEvaluator(
+				wfSvc, exec, parallelExec, store, logger, resolver, nil, evaluator,
+			)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+
+			// When: Processing primitive items
+			execCtx, err := execSvc.Run(ctx, "primitive-items", nil)
+
+			// Then: Primitives pass through unchanged (not JSON-encoded)
+			require.NoError(t, err, "primitive items should work")
+			assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+
+			data, err := os.ReadFile(outputFile)
+			require.NoError(t, err)
+			lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+
+			require.Len(t, lines, len(tt.expected))
+			for i, expected := range tt.expected {
+				assert.Equal(t, expected, lines[i], "primitive should not be JSON-encoded")
+			}
+		})
+	}
+}
+
+// TestF047_EdgeCase_UnicodeAndSpecialCharacters tests unicode handling
+// Feature: F047
+func TestF047_EdgeCase_UnicodeAndSpecialCharacters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Items with unicode characters
+	tmpDir := t.TempDir()
+
+	wfYAML := `name: unicode-test
+version: "1.0.0"
+states:
+  initial: loop
+  loop:
+    type: for_each
+    items: '[{"name":"测试","emoji":"🚀🎉","desc":"Café \"special\" quotes"}]'
+    body:
+      - validate_unicode
+    on_complete: done
+  validate_unicode:
+    type: step
+    command: |
+      item='{{.loop.Item}}'
+      # Validate JSON
+      if ! echo "$item" | jq empty 2>/dev/null; then
+        echo "Invalid JSON with unicode" >&2
+        exit 1
+      fi
+      # Extract fields to verify unicode preservation
+      name=$(echo "$item" | jq -r '.name')
+      emoji=$(echo "$item" | jq -r '.emoji')
+      echo "Unicode preserved: name=$name, emoji=$emoji"
+    on_success: loop
+  done:
+    type: terminal
+    status: success
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "unicode-test.yaml"), []byte(wfYAML), 0644)
+	require.NoError(t, err)
+
+	repo := repository.NewYAMLRepository(tmpDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := newSimpleExpressionEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil, evaluator,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// When: Processing unicode characters
+	execCtx, err := execSvc.Run(ctx, "unicode-test", nil)
+
+	// Then: Unicode is properly handled in JSON
+	require.NoError(t, err, "unicode should be handled correctly")
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+
+	validateState, exists := execCtx.GetStepState("validate_unicode")
+	require.True(t, exists)
+	assert.Contains(t, validateState.Output, "Unicode preserved")
+}
+
+// TestF047_Integration_RealWorldWorkflowPattern tests a realistic scenario
+// Feature: F047
+func TestF047_Integration_RealWorldWorkflowPattern(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: A realistic PR review workflow pattern
+	tmpDir := t.TempDir()
+	outputFile := filepath.Join(tmpDir, "review-results.txt")
+
+	// Child workflow: review a single file
+	reviewFileYAML := `name: review-file
+version: "1.0.0"
+inputs:
+  - name: file_info
+    type: string
+    required: true
+outputs:
+  - name: review_result
+    from: states.review.output
+states:
+  initial: review
+  review:
+    type: step
+    command: |
+      file_info='{{.inputs.file_info}}'
+      # Parse JSON
+      path=$(echo "$file_info" | jq -r '.path')
+      type=$(echo "$file_info" | jq -r '.type')
+      lines=$(echo "$file_info" | jq -r '.lines')
+      echo "Reviewed: $path ($type, $lines lines)" >> ` + outputFile + `
+    on_success: done
+  done:
+    type: terminal
+    status: success
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "review-file.yaml"), []byte(reviewFileYAML), 0644)
+	require.NoError(t, err)
+
+	// Parent workflow: PR review orchestrator
+	prReviewYAML := `name: pr-review
+version: "1.0.0"
+states:
+  initial: get_changed_files
+  get_changed_files:
+    type: step
+    command: echo '[{"path":"src/main.go","type":"modified","lines":42},{"path":"pkg/util.go","type":"added","lines":15},{"path":"README.md","type":"modified","lines":3}]'
+    on_success: review_loop
+  review_loop:
+    type: for_each
+    items: "{{.states.get_changed_files.Output}}"
+    body:
+      - review_file
+    on_complete: done
+  review_file:
+    type: call_workflow
+    workflow: review-file
+    inputs:
+      file_info: "{{.loop.Item}}"
+    on_success: review_loop
+  done:
+    type: terminal
+    status: success
+`
+	err = os.WriteFile(filepath.Join(tmpDir, "pr-review.yaml"), []byte(prReviewYAML), 0644)
+	require.NoError(t, err)
+
+	repo := repository.NewYAMLRepository(tmpDir)
+	store := newMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &mockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := newSimpleExpressionEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc, exec, parallelExec, store, logger, resolver, nil, evaluator,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// When: PR review workflow executes
+	execCtx, err := execSvc.Run(ctx, "pr-review", nil)
+
+	// Then: All files are reviewed successfully
+	require.NoError(t, err, "PR review workflow should complete")
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+
+	// Verify all files were processed
+	data, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+	output := string(data)
+
+	assert.Contains(t, output, "src/main.go (modified, 42 lines)")
+	assert.Contains(t, output, "pkg/util.go (added, 15 lines)")
+	assert.Contains(t, output, "README.md (modified, 3 lines)")
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	assert.Len(t, lines, 3, "should have reviewed 3 files")
+}
+
+// TestF047_BackwardCompatibility_ExistingWorkflows tests AC4:
+// Workflows created before F047 continue to work unchanged
+// Feature: F047
+func TestF047_BackwardCompatibility_ExistingWorkflows(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Given: Pre-F047 workflows with simple string/number items
+	tmpDir := t.TempDir()
+	outputFile := filepath.Join(tmpDir, "output.txt")
+
+	tests := []struct {
+		name     string
+		workflow string
+		expected []string
+	}{
+		{
+			name: "simple_strings",
+			workflow: `name: simple-strings
+version: "1.0.0"
+states:
+  initial: loop
+  loop:
+    type: for_each
+    items: '["file1.go", "file2.go", "file3.go"]'
+    body:
+      - process
+    on_complete: done
+  process:
+    type: step
+    command: 'echo "Processing {{.loop.Item}}" >> ` + outputFile + `'
+    on_success: loop
+  done:
+    type: terminal
+    status: success
+`,
+			expected: []string{
+				"Processing file1.go",
+				"Processing file2.go",
+				"Processing file3.go",
+			},
+		},
+		{
+			name: "numeric_iterations",
+			workflow: `name: numeric-iterations
+version: "1.0.0"
+states:
+  initial: loop
+  loop:
+    type: for_each
+    items: '[1, 2, 3, 4, 5]'
+    body:
+      - process
+    on_complete: done
+  process:
+    type: step
+    command: 'echo "Iteration {{.loop.Item}}" >> ` + outputFile + `'
+    on_success: loop
+  done:
+    type: terminal
+    status: success
+`,
+			expected: []string{
+				"Iteration 1",
+				"Iteration 2",
+				"Iteration 3",
+				"Iteration 4",
+				"Iteration 5",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clean output file
+			_ = os.Remove(outputFile)
+
+			err := os.WriteFile(filepath.Join(tmpDir, tt.name+".yaml"), []byte(tt.workflow), 0644)
+			require.NoError(t, err)
+
+			repo := repository.NewYAMLRepository(tmpDir)
+			store := newMockStateStore()
+			exec := executor.NewShellExecutor()
+			logger := &mockLogger{}
+			resolver := interpolation.NewTemplateResolver()
+			evaluator := newSimpleExpressionEvaluator()
+
+			wfSvc := application.NewWorkflowService(repo, store, exec, logger)
+			parallelExec := application.NewParallelExecutor(logger)
+			execSvc := application.NewExecutionServiceWithEvaluator(
+				wfSvc, exec, parallelExec, store, logger, resolver, nil, evaluator,
+			)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+
+			// When: Running pre-F047 workflow
+			execCtx, err := execSvc.Run(ctx, tt.name, nil)
+
+			// Then: Workflow works exactly as before
+			require.NoError(t, err, "pre-F047 workflow should still work")
+			assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+
+			data, err := os.ReadFile(outputFile)
+			require.NoError(t, err)
+			lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+
+			require.Len(t, lines, len(tt.expected))
+			for i, expected := range tt.expected {
+				assert.Equal(t, expected, lines[i], "output should match pre-F047 behavior")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fix loop items serializing as Go map literals (`map[key:value]`) instead of JSON when passed to `call_workflow` steps
- Add `SerializeValue` with type-aware JSON serialization for complex loop items (maps, slices)
- Add `toJson` template function for explicit serialization control in templates

## Changes

### Modified
- `pkg/interpolation/template_resolver.go`: Integrate serializer at template resolution boundary
- `CHANGELOG.md`: Document F047 bug fix in Unreleased section

### Added
- `pkg/interpolation/serializer.go`: Type-aware serialization with graceful error handling
- `pkg/interpolation/serializer_test.go`: 797 lines covering edge cases
- `pkg/interpolation/resolver_test.go`: 1666 lines for loop serialization scenarios
- `tests/integration/loop_json_serialization_test.go`: Functional tests for JSON serialization
- `tests/integration/loop_json_child_test.go`: Child workflow integration tests
- `tests/integration/loop_dynamic_test.go`: Dynamic loop variable tests
- `tests/integration/changelog_test.go`: Changelog format validation
- `tests/fixtures/workflows/loop-json-serialization.yaml`: Test fixtures
- `tests/fixtures/workflows/loop-json-child.yaml`: Test fixtures
- `tests/fixtures/workflows/test-loop-simple.yaml`: Test fixtures
- `docs/reference/interpolation.md`: Document `toJson` template function
- `docs/user-guide/workflow-syntax.md`: Add loop serialization examples

## Testing

- [x] Unit: 413 passed (pkg/interpolation)
- [x] Integration: 48 passed
- [x] Lint: blocked (requires approval)

> **Note**: Pre-existing timeout in `TestWorkflowExecution` unrelated to this change

## Links

Closes #64

---
Generated with awf commit workflow
