### PR TITLE
feat(plugin): implement Manifest.Validate() with comprehensive test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **C031** Implemented plugin manifest validation to replace ErrNotImplemented stub
+  - Replaced `Manifest.Validate()` stub with comprehensive field validation logic
+  - Name validation: enforces `^[a-z][a-z0-9-]*$` pattern (lowercase, starts with letter, alphanumeric + hyphens)
+  - Version validation: ensures non-empty version string
+  - AWFVersion validation: requires non-empty AWF version constraint
+  - Capabilities validation: verifies all capabilities against whitelist (operations, commands, validators)
+  - Config field validation: validates field types (string, integer, boolean), enum constraints (string only), default type matching
+  - Added 15 table-driven unit test functions with 130+ test cases covering valid/invalid names, versions, capabilities, and config fields
+  - Added 18 integration tests verifying parser-to-validation workflow with realistic YAML fixtures
+  - Achieved 99% test coverage for manifest.go validation logic (exceeds 80% requirement)
+  - Breaking change: `Manifest.Validate()` now returns `nil` for valid manifests instead of `ErrNotImplemented`
+  - All validation errors provide descriptive messages indicating which field failed and why
+
 - **C030** Reduced test skip count by 84% (823 → 128 skipped tests)
   - Converted 400+ integration test runtime skips to `//go:build integration` tags
   - Removed 250+ obsolete conditional skip guards from plugin infrastructure tests (state store, loader, registry, version)

--- a/internal/domain/plugin/manifest.go
+++ b/internal/domain/plugin/manifest.go
@@ -1,10 +1,19 @@
 // Package plugin provides domain entities for the plugin system.
 package plugin
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+)
 
 // ErrNotImplemented indicates a stub method that needs implementation.
 var ErrNotImplemented = errors.New("not implemented")
+
+// namePattern enforces manifest name validation rules.
+// Names must start with a lowercase letter followed by lowercase letters, digits, or hyphens.
+var namePattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
 
 // Valid capability names that plugins can declare.
 const (
@@ -57,9 +66,92 @@ type ConfigField struct {
 }
 
 // Validate checks if the manifest is valid.
-// Stub: returns ErrNotImplemented.
+// It validates name format, version, AWFVersion, capabilities, and config fields.
 func (m *Manifest) Validate() error {
-	return ErrNotImplemented
+	// 1. Name validation
+	if m.Name == "" {
+		return errors.New("name cannot be empty")
+	}
+	if !namePattern.MatchString(m.Name) {
+		return fmt.Errorf("invalid name %q: must match pattern ^[a-z][a-z0-9-]*$", m.Name)
+	}
+
+	// 2. Version validation
+	if m.Version == "" {
+		return errors.New("version cannot be empty")
+	}
+
+	// 3. AWFVersion validation
+	if m.AWFVersion == "" {
+		return errors.New("awf_version cannot be empty")
+	}
+
+	// 4. Capabilities validation
+	for _, cap := range m.Capabilities {
+		if !slices.Contains(ValidCapabilities, cap) {
+			return fmt.Errorf("invalid capability %q: must be one of %v", cap, ValidCapabilities)
+		}
+	}
+
+	// 5. Config validation - validate each config field
+	for name, cf := range m.Config {
+		if err := validateConfigField(name, &cf); err != nil {
+			return fmt.Errorf("config field %q: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+// validateConfigField validates a single configuration field.
+// It checks that the type is valid, enum constraints are only on strings,
+// and default values match the declared type.
+func validateConfigField(name string, cf *ConfigField) error {
+	// 1. Type validation: must be non-empty and in ValidConfigTypes
+	if cf.Type == "" {
+		return fmt.Errorf("type cannot be empty")
+	}
+	if !slices.Contains(ValidConfigTypes, cf.Type) {
+		return fmt.Errorf("invalid type %q: must be one of %v", cf.Type, ValidConfigTypes)
+	}
+
+	// 2. Enum validation: only allowed on string types
+	if len(cf.Enum) > 0 && cf.Type != ConfigTypeString {
+		return fmt.Errorf("enum is only allowed on string type, got %q", cf.Type)
+	}
+
+	// 3. Default value type validation: must match declared Type (if not nil)
+	if cf.Default != nil {
+		if err := validateDefaultType(cf.Type, cf.Default); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateDefaultType checks if the default value type matches the declared config field type.
+// Supports JSON unmarshaling behavior where numbers become float64.
+func validateDefaultType(configType string, defaultValue any) error {
+	switch configType {
+	case ConfigTypeString:
+		if _, ok := defaultValue.(string); !ok {
+			return fmt.Errorf("default value type mismatch: expected string, got %T", defaultValue)
+		}
+	case ConfigTypeInteger:
+		// JSON decoding may produce float64 for integer types, so accept both int and float64
+		switch defaultValue.(type) {
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float64:
+			// Valid integer types
+		default:
+			return fmt.Errorf("default value type mismatch: expected integer or float64, got %T", defaultValue)
+		}
+	case ConfigTypeBoolean:
+		if _, ok := defaultValue.(bool); !ok {
+			return fmt.Errorf("default value type mismatch: expected bool, got %T", defaultValue)
+		}
+	}
+	return nil
 }
 
 // HasCapability checks if the plugin declares a specific capability.

--- a/internal/domain/plugin/manifest_test.go
+++ b/internal/domain/plugin/manifest_test.go
@@ -39,240 +39,218 @@ func TestConfigTypeConstants_Values(t *testing.T) {
 }
 
 // =============================================================================
-// Manifest Creation Tests
+// NamePattern Regex Tests (Component T001)
+// Feature: C031
 // =============================================================================
 
-func TestManifest_Creation(t *testing.T) {
-	m := plugin.Manifest{
-		Name:         "slack-notifier",
-		Version:      "1.0.0",
-		Description:  "Send notifications to Slack",
-		AWFVersion:   ">=0.4.0",
-		Capabilities: []string{"operations"},
-		Config: map[string]plugin.ConfigField{
-			"webhook_url": {
-				Type:        "string",
-				Required:    true,
-				Description: "Slack webhook URL",
-			},
-		},
-	}
-
-	assert.Equal(t, "slack-notifier", m.Name)
-	assert.Equal(t, "1.0.0", m.Version)
-	assert.Equal(t, "Send notifications to Slack", m.Description)
-	assert.Equal(t, ">=0.4.0", m.AWFVersion)
-	assert.Contains(t, m.Capabilities, "operations")
-	require.Contains(t, m.Config, "webhook_url")
-	assert.Equal(t, "string", m.Config["webhook_url"].Type)
-	assert.True(t, m.Config["webhook_url"].Required)
-}
-
-func TestManifest_FullManifest(t *testing.T) {
-	m := plugin.Manifest{
-		Name:         "awf-plugin-slack",
-		Version:      "1.0.0",
-		Description:  "Slack notifications for AWF workflows",
-		AWFVersion:   ">=0.4.0",
-		Author:       "Jane Developer <jane@example.com>",
-		License:      "MIT",
-		Homepage:     "https://github.com/example/awf-plugin-slack",
-		Capabilities: []string{plugin.CapabilityOperations, plugin.CapabilityCommands},
-		Config: map[string]plugin.ConfigField{
-			"webhook_url": {
-				Type:        plugin.ConfigTypeString,
-				Required:    true,
-				Description: "Slack webhook URL",
-			},
-			"channel": {
-				Type:        plugin.ConfigTypeString,
-				Required:    false,
-				Default:     "#general",
-				Description: "Target Slack channel",
-			},
-		},
-	}
-
-	assert.Equal(t, "awf-plugin-slack", m.Name)
-	assert.Equal(t, "1.0.0", m.Version)
-	assert.Equal(t, "Slack notifications for AWF workflows", m.Description)
-	assert.Equal(t, ">=0.4.0", m.AWFVersion)
-	assert.Equal(t, "Jane Developer <jane@example.com>", m.Author)
-	assert.Equal(t, "MIT", m.License)
-	assert.Equal(t, "https://github.com/example/awf-plugin-slack", m.Homepage)
-	assert.Len(t, m.Capabilities, 2)
-	assert.Len(t, m.Config, 2)
-}
-
-func TestManifest_EmptyConfig(t *testing.T) {
-	m := plugin.Manifest{
-		Name:         "simple-plugin",
-		Version:      "0.1.0",
-		Capabilities: []string{"operations"},
-	}
-
-	assert.Empty(t, m.Config)
-	assert.Empty(t, m.Description)
-	assert.Empty(t, m.AWFVersion)
-	assert.Empty(t, m.Author)
-	assert.Empty(t, m.License)
-	assert.Empty(t, m.Homepage)
-}
-
-func TestManifest_MultipleCapabilities(t *testing.T) {
-	m := plugin.Manifest{
-		Name:         "full-plugin",
-		Version:      "2.0.0",
-		Capabilities: []string{"operations", "commands", "validators"},
-	}
-
-	assert.Len(t, m.Capabilities, 3)
-	assert.Contains(t, m.Capabilities, "operations")
-	assert.Contains(t, m.Capabilities, "commands")
-	assert.Contains(t, m.Capabilities, "validators")
-}
-
-func TestManifest_OptionalMetadata(t *testing.T) {
+func TestNamePattern_ValidNames(t *testing.T) {
+	// Component: T001
+	// Feature: C031
 	tests := []struct {
-		name     string
-		manifest plugin.Manifest
+		name  string
+		input string
 	}{
-		{
-			name: "with author only",
-			manifest: plugin.Manifest{
-				Name:    "test-plugin",
-				Version: "1.0.0",
-				Author:  "Test Author",
-			},
-		},
-		{
-			name: "with license only",
-			manifest: plugin.Manifest{
-				Name:    "test-plugin",
-				Version: "1.0.0",
-				License: "Apache-2.0",
-			},
-		},
-		{
-			name: "with homepage only",
-			manifest: plugin.Manifest{
-				Name:     "test-plugin",
-				Version:  "1.0.0",
-				Homepage: "https://example.com",
-			},
-		},
-		{
-			name: "with all optional metadata",
-			manifest: plugin.Manifest{
-				Name:        "test-plugin",
-				Version:     "1.0.0",
-				Description: "A test plugin",
-				Author:      "Test Author <test@example.com>",
-				License:     "MIT",
-				Homepage:    "https://github.com/example/test-plugin",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.NotEmpty(t, tt.manifest.Name)
-			assert.NotEmpty(t, tt.manifest.Version)
-		})
-	}
-}
-
-// =============================================================================
-// HasCapability Tests
-// =============================================================================
-
-func TestManifest_HasCapability(t *testing.T) {
-	tests := []struct {
-		name         string
-		capabilities []string
-		check        string
-		want         bool
-	}{
-		{
-			name:         "has operations capability",
-			capabilities: []string{plugin.CapabilityOperations},
-			check:        plugin.CapabilityOperations,
-			want:         true,
-		},
-		{
-			name:         "has commands capability",
-			capabilities: []string{plugin.CapabilityCommands},
-			check:        plugin.CapabilityCommands,
-			want:         true,
-		},
-		{
-			name:         "has validators capability",
-			capabilities: []string{plugin.CapabilityValidators},
-			check:        plugin.CapabilityValidators,
-			want:         true,
-		},
-		{
-			name:         "multiple capabilities - check first",
-			capabilities: []string{plugin.CapabilityOperations, plugin.CapabilityCommands},
-			check:        plugin.CapabilityOperations,
-			want:         true,
-		},
-		{
-			name:         "multiple capabilities - check second",
-			capabilities: []string{plugin.CapabilityOperations, plugin.CapabilityCommands},
-			check:        plugin.CapabilityCommands,
-			want:         true,
-		},
-		{
-			name:         "all capabilities - check validators",
-			capabilities: []string{plugin.CapabilityOperations, plugin.CapabilityCommands, plugin.CapabilityValidators},
-			check:        plugin.CapabilityValidators,
-			want:         true,
-		},
-		{
-			name:         "does not have capability",
-			capabilities: []string{plugin.CapabilityOperations},
-			check:        plugin.CapabilityCommands,
-			want:         false,
-		},
-		{
-			name:         "empty capabilities",
-			capabilities: []string{},
-			check:        plugin.CapabilityOperations,
-			want:         false,
-		},
-		{
-			name:         "nil capabilities",
-			capabilities: nil,
-			check:        plugin.CapabilityOperations,
-			want:         false,
-		},
-		{
-			name:         "unknown capability check",
-			capabilities: []string{plugin.CapabilityOperations},
-			check:        "unknown",
-			want:         false,
-		},
-		{
-			name:         "empty string capability check",
-			capabilities: []string{plugin.CapabilityOperations},
-			check:        "",
-			want:         false,
-		},
+		{name: "lowercase single letter", input: "a"},
+		{name: "lowercase word", input: "plugin"},
+		{name: "lowercase with hyphen", input: "my-plugin"},
+		{name: "multiple hyphens", input: "my-awesome-plugin"},
+		{name: "numbers after letter", input: "plugin123"},
+		{name: "mixed alphanumeric with hyphens", input: "my-plugin-v2"},
+		{name: "trailing numbers", input: "test1"},
+		{name: "complex pattern", input: "awf-marketplace-v2-beta"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := plugin.Manifest{
-				Name:         "test-plugin",
-				Version:      "1.0.0",
-				Capabilities: tt.capabilities,
+				Name:       tt.input,
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
 			}
-
-			got := m.HasCapability(tt.check)
-			assert.Equal(t, tt.want, got)
+			err := m.Validate()
+			assert.NoError(t, err, "expected %q to be valid", tt.input)
 		})
 	}
+}
+
+func TestNamePattern_InvalidNames(t *testing.T) {
+	// Component: T001
+	// Feature: C031
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "starts with digit", input: "1plugin"},
+		{name: "contains uppercase", input: "MyPlugin"},
+		{name: "contains underscore", input: "my_plugin"},
+		{name: "contains space", input: "my plugin"},
+		{name: "starts with hyphen", input: "-plugin"},
+		{name: "contains special chars", input: "my@plugin"},
+		{name: "contains dot", input: "my.plugin"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := plugin.Manifest{
+				Name:       tt.input,
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			}
+			err := m.Validate()
+			assert.Error(t, err, "expected %q to be invalid", tt.input)
+			assert.Contains(t, err.Error(), "name")
+		})
+	}
+}
+
+func TestNamePattern_EdgeCases(t *testing.T) {
+	// Component: T001
+	// Feature: C031
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "empty string", input: "", wantErr: true},
+		{name: "whitespace only", input: "   ", wantErr: true},
+		{name: "hyphen only", input: "-", wantErr: true},
+		{name: "number only", input: "123", wantErr: true},
+		{name: "valid single char", input: "a", wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := plugin.Manifest{
+				Name:       tt.input,
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			}
+			err := m.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "name")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNamePattern_RegexCompilation(t *testing.T) {
+	// Component: T001
+	// Feature: C031
+	// Test that the regex pattern compiles successfully
+	// This is implicitly tested by other tests, but explicit verification is good practice
+	m := plugin.Manifest{
+		Name:       "valid-plugin",
+		Version:    "1.0.0",
+		AWFVersion: ">=0.4.0",
+	}
+	err := m.Validate()
+	assert.NoError(t, err)
+}
+
+// =============================================================================
+// Manifest Creation Tests
+// =============================================================================
+
+func TestManifest_Creation(t *testing.T) {
+	m := plugin.Manifest{
+		Name:       "test-plugin",
+		Version:    "1.0.0",
+		AWFVersion: ">=0.4.0",
+	}
+	assert.Equal(t, "test-plugin", m.Name)
+	assert.Equal(t, "1.0.0", m.Version)
+	assert.Equal(t, ">=0.4.0", m.AWFVersion)
+}
+
+func TestManifest_FullManifest(t *testing.T) {
+	m := plugin.Manifest{
+		Name:        "marketplace-plugin",
+		Version:     "1.2.3",
+		AWFVersion:  ">=0.4.0",
+		Description: "A marketplace plugin",
+		Author:      "AWF Team",
+		License:     "MIT",
+		Homepage:    "https://github.com/vanoix/awf",
+		Capabilities: []string{
+			plugin.CapabilityOperations,
+			plugin.CapabilityCommands,
+		},
+		Config: map[string]plugin.ConfigField{
+			"api_key": {
+				Type:        plugin.ConfigTypeString,
+				Required:    true,
+				Description: "API key for authentication",
+			},
+		},
+	}
+
+	assert.Equal(t, "marketplace-plugin", m.Name)
+	assert.Equal(t, "1.2.3", m.Version)
+	assert.Equal(t, ">=0.4.0", m.AWFVersion)
+	assert.Len(t, m.Capabilities, 2)
+	assert.Len(t, m.Config, 1)
+}
+
+func TestManifest_EmptyConfig(t *testing.T) {
+	m := plugin.Manifest{
+		Name:       "test-plugin",
+		Version:    "1.0.0",
+		AWFVersion: ">=0.4.0",
+		Config:     map[string]plugin.ConfigField{},
+	}
+	assert.NotNil(t, m.Config)
+	assert.Len(t, m.Config, 0)
+}
+
+func TestManifest_MultipleCapabilities(t *testing.T) {
+	m := plugin.Manifest{
+		Name:       "test-plugin",
+		Version:    "1.0.0",
+		AWFVersion: ">=0.4.0",
+		Capabilities: []string{
+			plugin.CapabilityOperations,
+			plugin.CapabilityCommands,
+			plugin.CapabilityValidators,
+		},
+	}
+	assert.Len(t, m.Capabilities, 3)
+	assert.Contains(t, m.Capabilities, plugin.CapabilityOperations)
+	assert.Contains(t, m.Capabilities, plugin.CapabilityCommands)
+	assert.Contains(t, m.Capabilities, plugin.CapabilityValidators)
+}
+
+func TestManifest_OptionalMetadata(t *testing.T) {
+	m := plugin.Manifest{
+		Name:        "test-plugin",
+		Version:     "1.0.0",
+		AWFVersion:  ">=0.4.0",
+		Description: "Test plugin description",
+		Author:      "Test Author",
+		License:     "MIT",
+		Homepage:    "https://example.com",
+	}
+	assert.Equal(t, "Test plugin description", m.Description)
+	assert.Equal(t, "Test Author", m.Author)
+	assert.Equal(t, "MIT", m.License)
+	assert.Equal(t, "https://example.com", m.Homepage)
+}
+
+func TestManifest_HasCapability(t *testing.T) {
+	m := plugin.Manifest{
+		Name:       "test-plugin",
+		Version:    "1.0.0",
+		AWFVersion: ">=0.4.0",
+		Capabilities: []string{
+			plugin.CapabilityOperations,
+		},
+	}
+
+	assert.True(t, m.HasCapability(plugin.CapabilityOperations))
+	assert.False(t, m.HasCapability(plugin.CapabilityCommands))
+	assert.False(t, m.HasCapability(plugin.CapabilityValidators))
 }
 
 // =============================================================================
@@ -280,204 +258,73 @@ func TestManifest_HasCapability(t *testing.T) {
 // =============================================================================
 
 func TestConfigField_Creation(t *testing.T) {
-	tests := []struct {
-		name     string
-		field    plugin.ConfigField
-		wantType string
-		wantReq  bool
-	}{
-		{
-			name: "required string field",
-			field: plugin.ConfigField{
-				Type:        "string",
-				Required:    true,
-				Description: "A required string",
-			},
-			wantType: "string",
-			wantReq:  true,
-		},
-		{
-			name: "optional integer with default",
-			field: plugin.ConfigField{
-				Type:        "integer",
-				Required:    false,
-				Default:     42,
-				Description: "Port number",
-			},
-			wantType: "integer",
-			wantReq:  false,
-		},
-		{
-			name: "boolean field",
-			field: plugin.ConfigField{
-				Type:     "boolean",
-				Required: false,
-				Default:  true,
-			},
-			wantType: "boolean",
-			wantReq:  false,
-		},
+	cf := plugin.ConfigField{
+		Type:        plugin.ConfigTypeString,
+		Required:    true,
+		Description: "API key",
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.wantType, tt.field.Type)
-			assert.Equal(t, tt.wantReq, tt.field.Required)
-		})
-	}
+	assert.Equal(t, plugin.ConfigTypeString, cf.Type)
+	assert.True(t, cf.Required)
+	assert.Equal(t, "API key", cf.Description)
 }
 
 func TestConfigField_DefaultValues(t *testing.T) {
-	tests := []struct {
-		name        string
-		field       plugin.ConfigField
-		wantDefault any
-	}{
-		{
-			name: "string default",
-			field: plugin.ConfigField{
-				Type:    "string",
-				Default: "default-value",
-			},
-			wantDefault: "default-value",
-		},
-		{
-			name: "integer default",
-			field: plugin.ConfigField{
-				Type:    "integer",
-				Default: 8080,
-			},
-			wantDefault: 8080,
-		},
-		{
-			name: "boolean default true",
-			field: plugin.ConfigField{
-				Type:    "boolean",
-				Default: true,
-			},
-			wantDefault: true,
-		},
-		{
-			name: "boolean default false",
-			field: plugin.ConfigField{
-				Type:    "boolean",
-				Default: false,
-			},
-			wantDefault: false,
-		},
-		{
-			name: "nil default",
-			field: plugin.ConfigField{
-				Type: "string",
-			},
-			wantDefault: nil,
-		},
+	cf := plugin.ConfigField{
+		Type:    plugin.ConfigTypeString,
+		Default: "default-value",
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.wantDefault, tt.field.Default)
-		})
-	}
+	assert.Equal(t, "default-value", cf.Default)
 }
 
 func TestConfigField_WithEnum(t *testing.T) {
-	tests := []struct {
-		name     string
-		field    plugin.ConfigField
-		wantEnum []string
-	}{
-		{
-			name: "string field with enum",
-			field: plugin.ConfigField{
-				Type:        plugin.ConfigTypeString,
-				Required:    true,
-				Description: "Environment",
-				Enum:        []string{"development", "staging", "production"},
-			},
-			wantEnum: []string{"development", "staging", "production"},
-		},
-		{
-			name: "single value enum",
-			field: plugin.ConfigField{
-				Type: plugin.ConfigTypeString,
-				Enum: []string{"only-option"},
-			},
-			wantEnum: []string{"only-option"},
-		},
-		{
-			name: "empty enum",
-			field: plugin.ConfigField{
-				Type: plugin.ConfigTypeString,
-				Enum: []string{},
-			},
-			wantEnum: []string{},
-		},
-		{
-			name: "nil enum",
-			field: plugin.ConfigField{
-				Type: plugin.ConfigTypeString,
-			},
-			wantEnum: nil,
-		},
+	cf := plugin.ConfigField{
+		Type: plugin.ConfigTypeString,
+		Enum: []string{"option1", "option2", "option3"},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.wantEnum == nil {
-				assert.Nil(t, tt.field.Enum)
-			} else {
-				assert.Equal(t, tt.wantEnum, tt.field.Enum)
-			}
-		})
-	}
+	assert.Len(t, cf.Enum, 3)
+	assert.Contains(t, cf.Enum, "option1")
+	assert.Contains(t, cf.Enum, "option2")
+	assert.Contains(t, cf.Enum, "option3")
 }
 
 func TestConfigField_FullField(t *testing.T) {
-	field := plugin.ConfigField{
+	cf := plugin.ConfigField{
 		Type:        plugin.ConfigTypeString,
 		Required:    true,
-		Default:     "info",
-		Description: "Log level for the plugin",
-		Enum:        []string{"debug", "info", "warn", "error"},
+		Default:     "default",
+		Description: "Configuration field",
+		Enum:        []string{"option1", "option2"},
 	}
-
-	assert.Equal(t, plugin.ConfigTypeString, field.Type)
-	assert.True(t, field.Required)
-	assert.Equal(t, "info", field.Default)
-	assert.Equal(t, "Log level for the plugin", field.Description)
-	assert.Len(t, field.Enum, 4)
-	assert.Contains(t, field.Enum, "debug")
-	assert.Contains(t, field.Enum, "info")
-	assert.Contains(t, field.Enum, "warn")
-	assert.Contains(t, field.Enum, "error")
+	assert.Equal(t, plugin.ConfigTypeString, cf.Type)
+	assert.True(t, cf.Required)
+	assert.Equal(t, "default", cf.Default)
+	assert.Equal(t, "Configuration field", cf.Description)
+	assert.Len(t, cf.Enum, 2)
 }
 
 // =============================================================================
-// Edge Cases and Boundary Tests
+// Manifest Field Format Tests
 // =============================================================================
 
 func TestManifest_NameFormats(t *testing.T) {
 	tests := []struct {
-		name       string
-		pluginName string
+		name   string
+		format string
 	}{
-		{name: "simple name", pluginName: "myplugin"},
-		{name: "with hyphen", pluginName: "my-plugin"},
-		{name: "with multiple hyphens", pluginName: "my-awesome-plugin"},
-		{name: "with numbers", pluginName: "plugin123"},
-		{name: "with prefix", pluginName: "awf-plugin-slack"},
-		{name: "single char", pluginName: "a"},
-		{name: "numeric start", pluginName: "123plugin"},
+		{name: "simple lowercase", format: "plugin"},
+		{name: "hyphenated", format: "my-plugin"},
+		{name: "with numbers", format: "plugin123"},
+		{name: "complex", format: "awf-marketplace-v2"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := plugin.Manifest{
-				Name:    tt.pluginName,
-				Version: "1.0.0",
+				Name:       tt.format,
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
 			}
-			assert.Equal(t, tt.pluginName, m.Name)
+			assert.Equal(t, tt.format, m.Name)
 		})
 	}
 }
@@ -487,21 +334,20 @@ func TestManifest_VersionFormats(t *testing.T) {
 		name    string
 		version string
 	}{
-		{name: "standard semver", version: "1.0.0"},
-		{name: "with v prefix", version: "v1.0.0"},
-		{name: "prerelease", version: "1.0.0-alpha"},
-		{name: "prerelease with number", version: "1.0.0-beta.1"},
-		{name: "build metadata", version: "1.0.0+build.123"},
-		{name: "full semver", version: "1.0.0-rc.1+build.456"},
-		{name: "zero version", version: "0.0.0"},
-		{name: "high version", version: "99.99.99"},
+		{name: "semantic version", version: "1.0.0"},
+		{name: "with prerelease", version: "1.0.0-alpha.1"},
+		{name: "with build metadata", version: "1.0.0+20230101"},
+		{name: "full semver", version: "1.0.0-beta.2+build.123"},
+		{name: "major only", version: "1"},
+		{name: "major.minor", version: "1.0"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := plugin.Manifest{
-				Name:    "test-plugin",
-				Version: tt.version,
+				Name:       "test-plugin",
+				Version:    tt.version,
+				AWFVersion: ">=0.4.0",
 			}
 			assert.Equal(t, tt.version, m.Version)
 		})
@@ -538,54 +384,32 @@ func TestManifest_AWFVersionConstraints(t *testing.T) {
 
 func TestManifest_ConfigWithMultipleFields(t *testing.T) {
 	m := plugin.Manifest{
-		Name:         "complex-plugin",
-		Version:      "1.0.0",
-		Capabilities: []string{plugin.CapabilityOperations},
+		Name:       "test-plugin",
+		Version:    "1.0.0",
+		AWFVersion: ">=0.4.0",
 		Config: map[string]plugin.ConfigField{
-			"api_url": {
+			"api_key": {
 				Type:        plugin.ConfigTypeString,
 				Required:    true,
-				Description: "API endpoint URL",
+				Description: "API key",
 			},
 			"timeout": {
 				Type:        plugin.ConfigTypeInteger,
-				Required:    false,
 				Default:     30,
-				Description: "Request timeout in seconds",
+				Description: "Timeout in seconds",
 			},
-			"verify_ssl": {
+			"enabled": {
 				Type:        plugin.ConfigTypeBoolean,
-				Required:    false,
 				Default:     true,
-				Description: "Whether to verify SSL certificates",
-			},
-			"log_level": {
-				Type:        plugin.ConfigTypeString,
-				Required:    false,
-				Default:     "info",
-				Description: "Logging level",
-				Enum:        []string{"debug", "info", "warn", "error"},
+				Description: "Enable feature",
 			},
 		},
 	}
 
-	assert.Len(t, m.Config, 4)
-
-	apiURL := m.Config["api_url"]
-	assert.Equal(t, plugin.ConfigTypeString, apiURL.Type)
-	assert.True(t, apiURL.Required)
-
-	timeout := m.Config["timeout"]
-	assert.Equal(t, plugin.ConfigTypeInteger, timeout.Type)
-	assert.False(t, timeout.Required)
-	assert.Equal(t, 30, timeout.Default)
-
-	verifySSL := m.Config["verify_ssl"]
-	assert.Equal(t, plugin.ConfigTypeBoolean, verifySSL.Type)
-	assert.Equal(t, true, verifySSL.Default)
-
-	logLevel := m.Config["log_level"]
-	assert.Len(t, logLevel.Enum, 4)
+	assert.Len(t, m.Config, 3)
+	assert.Equal(t, plugin.ConfigTypeString, m.Config["api_key"].Type)
+	assert.Equal(t, plugin.ConfigTypeInteger, m.Config["timeout"].Type)
+	assert.Equal(t, plugin.ConfigTypeBoolean, m.Config["enabled"].Type)
 }
 
 func TestManifest_LicenseFormats(t *testing.T) {
@@ -597,17 +421,16 @@ func TestManifest_LicenseFormats(t *testing.T) {
 		{name: "Apache 2.0", license: "Apache-2.0"},
 		{name: "GPL v3", license: "GPL-3.0"},
 		{name: "BSD 3-Clause", license: "BSD-3-Clause"},
-		{name: "LGPL", license: "LGPL-2.1"},
 		{name: "Proprietary", license: "Proprietary"},
-		{name: "Unlicense", license: "Unlicense"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := plugin.Manifest{
-				Name:    "test-plugin",
-				Version: "1.0.0",
-				License: tt.license,
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				License:    tt.license,
 			}
 			assert.Equal(t, tt.license, m.License)
 		})
@@ -619,19 +442,19 @@ func TestManifest_HomepageFormats(t *testing.T) {
 		name     string
 		homepage string
 	}{
-		{name: "GitHub", homepage: "https://github.com/user/repo"},
-		{name: "GitLab", homepage: "https://gitlab.com/user/repo"},
-		{name: "Custom domain", homepage: "https://myplugin.example.com"},
-		{name: "With path", homepage: "https://example.com/plugins/my-plugin"},
-		{name: "HTTP", homepage: "http://insecure.example.com"},
+		{name: "GitHub URL", homepage: "https://github.com/vanoix/awf"},
+		{name: "GitLab URL", homepage: "https://gitlab.com/project/repo"},
+		{name: "Custom domain", homepage: "https://awf-plugin.example.com"},
+		{name: "HTTP URL", homepage: "http://example.com"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := plugin.Manifest{
-				Name:     "test-plugin",
-				Version:  "1.0.0",
-				Homepage: tt.homepage,
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Homepage:   tt.homepage,
 			}
 			assert.Equal(t, tt.homepage, m.Homepage)
 		})
@@ -643,11 +466,10 @@ func TestManifest_AuthorFormats(t *testing.T) {
 		name   string
 		author string
 	}{
-		{name: "name only", author: "John Doe"},
-		{name: "with email", author: "John Doe <john@example.com>"},
-		{name: "email only", author: "<john@example.com>"},
-		{name: "organization", author: "ACME Inc."},
-		{name: "multiple authors", author: "John Doe, Jane Smith"},
+		{name: "Simple name", author: "John Doe"},
+		{name: "Organization", author: "AWF Team"},
+		{name: "With email", author: "John Doe <john@example.com>"},
+		{name: "With URL", author: "AWF Team (https://github.com/vanoix)"},
 	}
 
 	for _, tt := range tests {
@@ -658,6 +480,2152 @@ func TestManifest_AuthorFormats(t *testing.T) {
 				Author:  tt.author,
 			}
 			assert.Equal(t, tt.author, m.Author)
+		})
+	}
+}
+
+// =============================================================================
+// validateConfigField() Tests (Component T002)
+// Feature: C031
+// =============================================================================
+
+// TestValidateConfigField_HappyPath tests valid ConfigField configurations
+func TestValidateConfigField_HappyPath(t *testing.T) {
+	// Component: T002, T008
+	// Feature: C031
+	tests := []struct {
+		name   string
+		field  plugin.ConfigField
+		config map[string]plugin.ConfigField
+	}{
+		{
+			name: "valid string field",
+			config: map[string]plugin.ConfigField{
+				"api_key": {
+					Type:        plugin.ConfigTypeString,
+					Required:    true,
+					Description: "API key for authentication",
+				},
+			},
+		},
+		{
+			name: "valid integer field",
+			config: map[string]plugin.ConfigField{
+				"timeout": {
+					Type:        plugin.ConfigTypeInteger,
+					Required:    false,
+					Default:     30,
+					Description: "Timeout in seconds",
+				},
+			},
+		},
+		{
+			name: "valid boolean field",
+			config: map[string]plugin.ConfigField{
+				"enabled": {
+					Type:        plugin.ConfigTypeBoolean,
+					Required:    false,
+					Default:     true,
+					Description: "Enable feature",
+				},
+			},
+		},
+		{
+			name: "string field with enum",
+			config: map[string]plugin.ConfigField{
+				"log_level": {
+					Type:        plugin.ConfigTypeString,
+					Required:    false,
+					Default:     "info",
+					Enum:        []string{"debug", "info", "warn", "error"},
+					Description: "Logging level",
+				},
+			},
+		},
+		{
+			name: "string field with default matching enum",
+			config: map[string]plugin.ConfigField{
+				"environment": {
+					Type:     plugin.ConfigTypeString,
+					Default:  "development",
+					Enum:     []string{"development", "staging", "production"},
+					Required: false,
+				},
+			},
+		},
+		{
+			name: "field without default value",
+			config: map[string]plugin.ConfigField{
+				"optional_field": {
+					Type:        plugin.ConfigTypeString,
+					Required:    false,
+					Description: "Optional field",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config:     tt.config,
+			}
+			err := m.Validate()
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestValidateConfigField_TypeValidation tests config field type validation
+func TestValidateConfigField_TypeValidation(t *testing.T) {
+	// Component: T002, T008
+	// Feature: C031
+	tests := []struct {
+		name    string
+		field   plugin.ConfigField
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "empty type",
+			field: plugin.ConfigField{
+				Type:        "",
+				Description: "Field with empty type",
+			},
+			wantErr: true,
+			errMsg:  "type",
+		},
+		{
+			name: "invalid type",
+			field: plugin.ConfigField{
+				Type:        "array",
+				Description: "Unsupported array type",
+			},
+			wantErr: true,
+			errMsg:  "type",
+		},
+		{
+			name: "unknown type",
+			field: plugin.ConfigField{
+				Type:        "object",
+				Description: "Unsupported object type",
+			},
+			wantErr: true,
+			errMsg:  "type",
+		},
+		{
+			name: "valid string type",
+			field: plugin.ConfigField{
+				Type:        plugin.ConfigTypeString,
+				Description: "Valid string field",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid integer type",
+			field: plugin.ConfigField{
+				Type:        plugin.ConfigTypeInteger,
+				Description: "Valid integer field",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid boolean type",
+			field: plugin.ConfigField{
+				Type:        plugin.ConfigTypeBoolean,
+				Description: "Valid boolean field",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"test_field": tt.field,
+				},
+			}
+			err := m.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateConfigField_EnumValidation tests enum constraint validation
+func TestValidateConfigField_EnumValidation(t *testing.T) {
+	// Component: T002, T008
+	// Feature: C031
+	tests := []struct {
+		name    string
+		field   plugin.ConfigField
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "enum on string type - valid",
+			field: plugin.ConfigField{
+				Type: plugin.ConfigTypeString,
+				Enum: []string{"option1", "option2", "option3"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "enum on integer type - invalid",
+			field: plugin.ConfigField{
+				Type: plugin.ConfigTypeInteger,
+				Enum: []string{"1", "2", "3"},
+			},
+			wantErr: true,
+			errMsg:  "enum",
+		},
+		{
+			name: "enum on boolean type - invalid",
+			field: plugin.ConfigField{
+				Type: plugin.ConfigTypeBoolean,
+				Enum: []string{"true", "false"},
+			},
+			wantErr: true,
+			errMsg:  "enum",
+		},
+		{
+			name: "empty enum on string type",
+			field: plugin.ConfigField{
+				Type: plugin.ConfigTypeString,
+				Enum: []string{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "nil enum on string type",
+			field: plugin.ConfigField{
+				Type: plugin.ConfigTypeString,
+				Enum: nil,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"test_field": tt.field,
+				},
+			}
+			err := m.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateConfigField_DefaultTypeValidation tests default value type matching
+func TestValidateConfigField_DefaultTypeValidation(t *testing.T) {
+	// Component: T002, T008
+	// Feature: C031
+	tests := []struct {
+		name    string
+		field   plugin.ConfigField
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "string default matches string type",
+			field: plugin.ConfigField{
+				Type:    plugin.ConfigTypeString,
+				Default: "default-value",
+			},
+			wantErr: false,
+		},
+		{
+			name: "integer default matches integer type - int",
+			field: plugin.ConfigField{
+				Type:    plugin.ConfigTypeInteger,
+				Default: 42,
+			},
+			wantErr: false,
+		},
+		{
+			name: "integer default matches integer type - float64 (JSON)",
+			field: plugin.ConfigField{
+				Type:    plugin.ConfigTypeInteger,
+				Default: float64(42),
+			},
+			wantErr: false,
+		},
+		{
+			name: "boolean default matches boolean type",
+			field: plugin.ConfigField{
+				Type:    plugin.ConfigTypeBoolean,
+				Default: true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "string default mismatch with integer type",
+			field: plugin.ConfigField{
+				Type:    plugin.ConfigTypeInteger,
+				Default: "not-a-number",
+			},
+			wantErr: true,
+			errMsg:  "type mismatch",
+		},
+		{
+			name: "integer default mismatch with string type",
+			field: plugin.ConfigField{
+				Type:    plugin.ConfigTypeString,
+				Default: 123,
+			},
+			wantErr: true,
+			errMsg:  "type mismatch",
+		},
+		{
+			name: "boolean default mismatch with string type",
+			field: plugin.ConfigField{
+				Type:    plugin.ConfigTypeString,
+				Default: true,
+			},
+			wantErr: true,
+			errMsg:  "type mismatch",
+		},
+		{
+			name: "string default mismatch with boolean type",
+			field: plugin.ConfigField{
+				Type:    plugin.ConfigTypeBoolean,
+				Default: "true",
+			},
+			wantErr: true,
+			errMsg:  "type mismatch",
+		},
+		{
+			name: "nil default value - valid",
+			field: plugin.ConfigField{
+				Type:    plugin.ConfigTypeString,
+				Default: nil,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"test_field": tt.field,
+				},
+			}
+			err := m.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateConfigField_EdgeCases tests edge cases in config field validation
+func TestValidateConfigField_EdgeCases(t *testing.T) {
+	// Component: T002, T008
+	// Feature: C031
+	tests := []struct {
+		name    string
+		config  map[string]plugin.ConfigField
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil config map",
+			config:  nil,
+			wantErr: false,
+		},
+		{
+			name:    "empty config map",
+			config:  map[string]plugin.ConfigField{},
+			wantErr: false,
+		},
+		{
+			name: "multiple valid fields",
+			config: map[string]plugin.ConfigField{
+				"field1": {Type: plugin.ConfigTypeString, Default: "value1"},
+				"field2": {Type: plugin.ConfigTypeInteger, Default: 42},
+				"field3": {Type: plugin.ConfigTypeBoolean, Default: true},
+			},
+			wantErr: false,
+		},
+		{
+			name: "first field valid, second field invalid",
+			config: map[string]plugin.ConfigField{
+				"valid_field":   {Type: plugin.ConfigTypeString, Default: "value"},
+				"invalid_field": {Type: "invalid_type", Default: "value"},
+			},
+			wantErr: true,
+			errMsg:  "type",
+		},
+		{
+			name: "field with all attributes",
+			config: map[string]plugin.ConfigField{
+				"comprehensive": {
+					Type:        plugin.ConfigTypeString,
+					Required:    true,
+					Default:     "default",
+					Description: "Comprehensive field test",
+					Enum:        []string{"option1", "option2"},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config:     tt.config,
+			}
+			err := m.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateConfigField_ErrorMessages tests error message clarity
+func TestValidateConfigField_ErrorMessages(t *testing.T) {
+	// Component: T002, T008
+	// Feature: C031
+	tests := []struct {
+		name        string
+		config      map[string]plugin.ConfigField
+		expectedErr []string // multiple strings that should appear in error
+	}{
+		{
+			name: "invalid type error includes field name",
+			config: map[string]plugin.ConfigField{
+				"bad_field": {Type: "invalid"},
+			},
+			expectedErr: []string{"bad_field"},
+		},
+		{
+			name: "enum on non-string includes field name and constraint",
+			config: map[string]plugin.ConfigField{
+				"numeric_enum": {
+					Type: plugin.ConfigTypeInteger,
+					Enum: []string{"1", "2", "3"},
+				},
+			},
+			expectedErr: []string{"numeric_enum", "enum"},
+		},
+		{
+			name: "type mismatch includes expected and actual types",
+			config: map[string]plugin.ConfigField{
+				"wrong_default": {
+					Type:    plugin.ConfigTypeInteger,
+					Default: "not-a-number",
+				},
+			},
+			expectedErr: []string{"wrong_default", "type mismatch"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config:     tt.config,
+			}
+			err := m.Validate()
+			require.Error(t, err)
+			for _, expected := range tt.expectedErr {
+				assert.Contains(t, err.Error(), expected,
+					"error message should contain %q", expected)
+			}
+		})
+	}
+}
+
+// TestValidateConfigField_ComplexScenarios tests realistic complex configurations
+func TestValidateConfigField_ComplexScenarios(t *testing.T) {
+	// Component: T002, T008
+	// Feature: C031
+	tests := []struct {
+		name    string
+		config  map[string]plugin.ConfigField
+		wantErr bool
+	}{
+		{
+			name: "realistic marketplace plugin config",
+			config: map[string]plugin.ConfigField{
+				"api_key": {
+					Type:        plugin.ConfigTypeString,
+					Required:    true,
+					Description: "Marketplace API key",
+				},
+				"timeout": {
+					Type:        plugin.ConfigTypeInteger,
+					Default:     30,
+					Description: "Request timeout in seconds",
+				},
+				"environment": {
+					Type:        plugin.ConfigTypeString,
+					Default:     "production",
+					Enum:        []string{"development", "staging", "production"},
+					Description: "Deployment environment",
+				},
+				"cache_enabled": {
+					Type:        plugin.ConfigTypeBoolean,
+					Default:     true,
+					Description: "Enable response caching",
+				},
+				"log_level": {
+					Type:        plugin.ConfigTypeString,
+					Default:     "info",
+					Enum:        []string{"debug", "info", "warn", "error"},
+					Description: "Logging verbosity level",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "config with one invalid field among many valid",
+			config: map[string]plugin.ConfigField{
+				"valid1":  {Type: plugin.ConfigTypeString, Default: "value"},
+				"valid2":  {Type: plugin.ConfigTypeInteger, Default: 42},
+				"invalid": {Type: "bad_type", Default: "value"},
+				"valid3":  {Type: plugin.ConfigTypeBoolean, Default: true},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config:     tt.config,
+			}
+			err := m.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// validateDefaultType() Helper Tests (Component T003)
+// =============================================================================
+
+// TestValidateDefaultType_StringType tests string type validation via validateDefaultType
+func TestValidateDefaultType_StringType(t *testing.T) {
+	// Component: T003, T008
+	// Feature: C031
+	tests := []struct {
+		name         string
+		defaultValue any
+		wantErr      bool
+		errMsg       string
+	}{
+		{
+			name:         "valid string default",
+			defaultValue: "hello",
+			wantErr:      false,
+		},
+		{
+			name:         "empty string is valid",
+			defaultValue: "",
+			wantErr:      false,
+		},
+		{
+			name:         "multiline string is valid",
+			defaultValue: "line1\nline2\nline3",
+			wantErr:      false,
+		},
+		{
+			name:         "string with special characters",
+			defaultValue: "test@#$%^&*()_+-={}[]|\\:;\"'<>,.?/",
+			wantErr:      false,
+		},
+		{
+			name:         "unicode string is valid",
+			defaultValue: "こんにちは世界",
+			wantErr:      false,
+		},
+		{
+			name:         "integer instead of string",
+			defaultValue: 42,
+			wantErr:      true,
+			errMsg:       "type mismatch",
+		},
+		{
+			name:         "float instead of string",
+			defaultValue: 3.14,
+			wantErr:      true,
+			errMsg:       "type mismatch",
+		},
+		{
+			name:         "boolean instead of string",
+			defaultValue: true,
+			wantErr:      true,
+			errMsg:       "type mismatch",
+		},
+		{
+			name:         "slice instead of string",
+			defaultValue: []string{"a", "b"},
+			wantErr:      true,
+			errMsg:       "type mismatch",
+		},
+		{
+			name:         "map instead of string",
+			defaultValue: map[string]string{"key": "value"},
+			wantErr:      true,
+			errMsg:       "type mismatch",
+		},
+		{
+			name:         "nil value is valid (no default)",
+			defaultValue: nil,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"test_field": {
+						Type:    plugin.ConfigTypeString,
+						Default: tt.defaultValue,
+					},
+				},
+			}
+			err := m.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateDefaultType_IntegerType tests integer type validation via validateDefaultType
+func TestValidateDefaultType_IntegerType(t *testing.T) {
+	// Component: T003, T008
+	// Feature: C031
+	tests := []struct {
+		name         string
+		defaultValue any
+		wantErr      bool
+		errMsg       string
+	}{
+		{
+			name:         "valid int",
+			defaultValue: 42,
+			wantErr:      false,
+		},
+		{
+			name:         "valid int8",
+			defaultValue: int8(127),
+			wantErr:      false,
+		},
+		{
+			name:         "valid int16",
+			defaultValue: int16(32767),
+			wantErr:      false,
+		},
+		{
+			name:         "valid int32",
+			defaultValue: int32(2147483647),
+			wantErr:      false,
+		},
+		{
+			name:         "valid int64",
+			defaultValue: int64(9223372036854775807),
+			wantErr:      false,
+		},
+		{
+			name:         "valid uint",
+			defaultValue: uint(42),
+			wantErr:      false,
+		},
+		{
+			name:         "valid uint8",
+			defaultValue: uint8(255),
+			wantErr:      false,
+		},
+		{
+			name:         "valid uint16",
+			defaultValue: uint16(65535),
+			wantErr:      false,
+		},
+		{
+			name:         "valid uint32",
+			defaultValue: uint32(4294967295),
+			wantErr:      false,
+		},
+		{
+			name:         "valid uint64",
+			defaultValue: uint64(18446744073709551615),
+			wantErr:      false,
+		},
+		{
+			name:         "valid float64 from JSON (42.0)",
+			defaultValue: float64(42),
+			wantErr:      false,
+		},
+		{
+			name:         "valid float64 from JSON (negative)",
+			defaultValue: float64(-100),
+			wantErr:      false,
+		},
+		{
+			name:         "valid zero",
+			defaultValue: 0,
+			wantErr:      false,
+		},
+		{
+			name:         "valid negative integer",
+			defaultValue: -42,
+			wantErr:      false,
+		},
+		{
+			name:         "string instead of integer",
+			defaultValue: "42",
+			wantErr:      true,
+			errMsg:       "type mismatch",
+		},
+		{
+			name:         "boolean instead of integer",
+			defaultValue: true,
+			wantErr:      true,
+			errMsg:       "type mismatch",
+		},
+		{
+			name:         "slice instead of integer",
+			defaultValue: []int{1, 2, 3},
+			wantErr:      true,
+			errMsg:       "type mismatch",
+		},
+		{
+			name:         "nil value is valid (no default)",
+			defaultValue: nil,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"test_field": {
+						Type:    plugin.ConfigTypeInteger,
+						Default: tt.defaultValue,
+					},
+				},
+			}
+			err := m.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateDefaultType_BooleanType tests boolean type validation via validateDefaultType
+func TestValidateDefaultType_BooleanType(t *testing.T) {
+	// Component: T003, T008
+	// Feature: C031
+	tests := []struct {
+		name         string
+		defaultValue any
+		wantErr      bool
+		errMsg       string
+	}{
+		{
+			name:         "valid true",
+			defaultValue: true,
+			wantErr:      false,
+		},
+		{
+			name:         "valid false",
+			defaultValue: false,
+			wantErr:      false,
+		},
+		{
+			name:         "string 'true' instead of boolean",
+			defaultValue: "true",
+			wantErr:      true,
+			errMsg:       "type mismatch",
+		},
+		{
+			name:         "string 'false' instead of boolean",
+			defaultValue: "false",
+			wantErr:      true,
+			errMsg:       "type mismatch",
+		},
+		{
+			name:         "integer 1 instead of boolean",
+			defaultValue: 1,
+			wantErr:      true,
+			errMsg:       "type mismatch",
+		},
+		{
+			name:         "integer 0 instead of boolean",
+			defaultValue: 0,
+			wantErr:      true,
+			errMsg:       "type mismatch",
+		},
+		{
+			name:         "slice instead of boolean",
+			defaultValue: []bool{true, false},
+			wantErr:      true,
+			errMsg:       "type mismatch",
+		},
+		{
+			name:         "nil value is valid (no default)",
+			defaultValue: nil,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"test_field": {
+						Type:    plugin.ConfigTypeBoolean,
+						Default: tt.defaultValue,
+					},
+				},
+			}
+			err := m.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateDefaultType_TypeMismatchMessages tests error message clarity
+func TestValidateDefaultType_TypeMismatchMessages(t *testing.T) {
+	// Component: T003, T008
+	// Feature: C031
+	tests := []struct {
+		name          string
+		configType    string
+		defaultValue  any
+		wantErrSubstr []string
+	}{
+		{
+			name:          "string type expects string",
+			configType:    plugin.ConfigTypeString,
+			defaultValue:  123,
+			wantErrSubstr: []string{"type mismatch", "expected string", "got int"},
+		},
+		{
+			name:          "integer type expects integer",
+			configType:    plugin.ConfigTypeInteger,
+			defaultValue:  "not-a-number",
+			wantErrSubstr: []string{"type mismatch", "expected integer", "got string"},
+		},
+		{
+			name:          "boolean type expects bool",
+			configType:    plugin.ConfigTypeBoolean,
+			defaultValue:  "true",
+			wantErrSubstr: []string{"type mismatch", "expected bool", "got string"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"test_field": {
+						Type:    tt.configType,
+						Default: tt.defaultValue,
+					},
+				},
+			}
+			err := m.Validate()
+			require.Error(t, err)
+			for _, substr := range tt.wantErrSubstr {
+				assert.Contains(t, err.Error(), substr, "error message should contain %q", substr)
+			}
+		})
+	}
+}
+
+// TestValidateDefaultType_EdgeCases tests edge cases in type validation
+func TestValidateDefaultType_EdgeCases(t *testing.T) {
+	// Component: T003, T008
+	// Feature: C031
+	tests := []struct {
+		name       string
+		field      plugin.ConfigField
+		wantErr    bool
+		errMsg     string
+		skipReason string
+	}{
+		{
+			name: "nil default with string type (optional field)",
+			field: plugin.ConfigField{
+				Type:    plugin.ConfigTypeString,
+				Default: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "nil default with integer type (optional field)",
+			field: plugin.ConfigField{
+				Type:    plugin.ConfigTypeInteger,
+				Default: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "nil default with boolean type (optional field)",
+			field: plugin.ConfigField{
+				Type:    plugin.ConfigTypeBoolean,
+				Default: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "struct instead of primitive type",
+			field: plugin.ConfigField{
+				Type:    plugin.ConfigTypeString,
+				Default: struct{ Value string }{Value: "test"},
+			},
+			wantErr: true,
+			errMsg:  "type mismatch",
+		},
+		{
+			name: "pointer to string instead of string",
+			field: plugin.ConfigField{
+				Type:    plugin.ConfigTypeString,
+				Default: func() *string { s := "test"; return &s }(),
+			},
+			wantErr: true,
+			errMsg:  "type mismatch",
+		},
+		{
+			name: "pointer to int instead of int",
+			field: plugin.ConfigField{
+				Type:    plugin.ConfigTypeInteger,
+				Default: func() *int { i := 42; return &i }(),
+			},
+			wantErr: true,
+			errMsg:  "type mismatch",
+		},
+		{
+			name: "pointer to bool instead of bool",
+			field: plugin.ConfigField{
+				Type:    plugin.ConfigTypeBoolean,
+				Default: func() *bool { b := true; return &b }(),
+			},
+			wantErr: true,
+			errMsg:  "type mismatch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.skipReason != "" {
+				t.Skip(tt.skipReason)
+			}
+			m := plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"test_field": tt.field,
+				},
+			}
+			err := m.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateDefaultType_JSONUnmarshalBehavior tests JSON float64 handling for integers
+func TestValidateDefaultType_JSONUnmarshalBehavior(t *testing.T) {
+	// Component: T003, T008
+	// Feature: C031
+	//
+	// This test verifies that validateDefaultType correctly handles the JSON
+	// unmarshaling behavior where all numbers are decoded as float64.
+	// This is critical for YAML/JSON config parsing.
+	tests := []struct {
+		name         string
+		defaultValue any
+		wantErr      bool
+	}{
+		{
+			name:         "float64(42) from JSON should be valid for integer type",
+			defaultValue: float64(42),
+			wantErr:      false,
+		},
+		{
+			name:         "float64(0) should be valid for integer type",
+			defaultValue: float64(0),
+			wantErr:      false,
+		},
+		{
+			name:         "float64(-100) should be valid for integer type",
+			defaultValue: float64(-100),
+			wantErr:      false,
+		},
+		{
+			name:         "float64(3.14) should be valid (no fractional check)",
+			defaultValue: float64(3.14),
+			wantErr:      false,
+		},
+		{
+			name:         "native int should still work",
+			defaultValue: 42,
+			wantErr:      false,
+		},
+		{
+			name:         "float32 is NOT accepted (not from JSON)",
+			defaultValue: float32(42),
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"test_field": {
+						Type:    plugin.ConfigTypeInteger,
+						Default: tt.defaultValue,
+					},
+				},
+			}
+			err := m.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateDefaultType_MultipleFields tests type validation across multiple config fields
+func TestValidateDefaultType_MultipleFields(t *testing.T) {
+	// Component: T003, T008
+	// Feature: C031
+	tests := []struct {
+		name    string
+		config  map[string]plugin.ConfigField
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "all fields valid with correct types",
+			config: map[string]plugin.ConfigField{
+				"api_key":     {Type: plugin.ConfigTypeString, Default: "secret-key"},
+				"port":        {Type: plugin.ConfigTypeInteger, Default: 8080},
+				"enabled":     {Type: plugin.ConfigTypeBoolean, Default: true},
+				"timeout":     {Type: plugin.ConfigTypeInteger, Default: float64(30)},
+				"description": {Type: plugin.ConfigTypeString, Default: ""},
+			},
+			wantErr: false,
+		},
+		{
+			name: "first field invalid type",
+			config: map[string]plugin.ConfigField{
+				"api_key": {Type: plugin.ConfigTypeString, Default: 12345},
+				"port":    {Type: plugin.ConfigTypeInteger, Default: 8080},
+			},
+			wantErr: true,
+			errMsg:  "type mismatch",
+		},
+		{
+			name: "middle field invalid type",
+			config: map[string]plugin.ConfigField{
+				"api_key": {Type: plugin.ConfigTypeString, Default: "secret"},
+				"port":    {Type: plugin.ConfigTypeInteger, Default: "8080"},
+				"enabled": {Type: plugin.ConfigTypeBoolean, Default: true},
+			},
+			wantErr: true,
+			errMsg:  "type mismatch",
+		},
+		{
+			name: "last field invalid type",
+			config: map[string]plugin.ConfigField{
+				"api_key": {Type: plugin.ConfigTypeString, Default: "secret"},
+				"port":    {Type: plugin.ConfigTypeInteger, Default: 8080},
+				"enabled": {Type: plugin.ConfigTypeBoolean, Default: "true"},
+			},
+			wantErr: true,
+			errMsg:  "type mismatch",
+		},
+		{
+			name: "all fields with nil defaults",
+			config: map[string]plugin.ConfigField{
+				"api_key": {Type: plugin.ConfigTypeString, Default: nil},
+				"port":    {Type: plugin.ConfigTypeInteger, Default: nil},
+				"enabled": {Type: plugin.ConfigTypeBoolean, Default: nil},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config:     tt.config,
+			}
+			err := m.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Manifest.Validate() Integration Tests (Component T004)
+// Feature: C031
+// =============================================================================
+
+// TestManifestValidate_HappyPath tests valid manifests that should pass all validation
+func TestManifestValidate_HappyPath(t *testing.T) {
+	// Component: T004
+	// Feature: C031
+	tests := []struct {
+		name     string
+		manifest plugin.Manifest
+	}{
+		{
+			name: "minimal valid manifest",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+		},
+		{
+			name: "complete valid manifest with all fields",
+			manifest: plugin.Manifest{
+				Name:        "marketplace-plugin",
+				Version:     "1.2.3",
+				AWFVersion:  ">=0.4.0",
+				Description: "A marketplace integration plugin",
+				Author:      "AWF Team <team@awf.dev>",
+				License:     "MIT",
+				Homepage:    "https://github.com/vanoix/awf",
+				Capabilities: []string{
+					plugin.CapabilityOperations,
+					plugin.CapabilityCommands,
+					plugin.CapabilityValidators,
+				},
+				Config: map[string]plugin.ConfigField{
+					"api_key": {
+						Type:        plugin.ConfigTypeString,
+						Required:    true,
+						Description: "API key for authentication",
+					},
+					"timeout": {
+						Type:        plugin.ConfigTypeInteger,
+						Default:     30,
+						Description: "Request timeout in seconds",
+					},
+					"enabled": {
+						Type:        plugin.ConfigTypeBoolean,
+						Default:     true,
+						Description: "Enable plugin",
+					},
+					"environment": {
+						Type:        plugin.ConfigTypeString,
+						Default:     "production",
+						Enum:        []string{"development", "staging", "production"},
+						Description: "Deployment environment",
+					},
+				},
+			},
+		},
+		{
+			name: "manifest with single capability",
+			manifest: plugin.Manifest{
+				Name:         "simple-plugin",
+				Version:      "0.1.0",
+				AWFVersion:   ">=0.4.0",
+				Capabilities: []string{plugin.CapabilityOperations},
+			},
+		},
+		{
+			name: "manifest with empty capabilities list",
+			manifest: plugin.Manifest{
+				Name:         "basic-plugin",
+				Version:      "2.0.0",
+				AWFVersion:   "^0.4.0",
+				Capabilities: []string{},
+			},
+		},
+		{
+			name: "manifest with nil config",
+			manifest: plugin.Manifest{
+				Name:       "no-config-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config:     nil,
+			},
+		},
+		{
+			name: "manifest with version prerelease",
+			manifest: plugin.Manifest{
+				Name:       "beta-plugin",
+				Version:    "1.0.0-beta.1",
+				AWFVersion: ">=0.4.0",
+			},
+		},
+		{
+			name: "manifest with version build metadata",
+			manifest: plugin.Manifest{
+				Name:       "build-plugin",
+				Version:    "1.0.0+build.123",
+				AWFVersion: ">=0.4.0",
+			},
+		},
+		{
+			name: "manifest with complex name pattern",
+			manifest: plugin.Manifest{
+				Name:       "awf-marketplace-v2-beta",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.manifest.Validate()
+			assert.NoError(t, err, "expected valid manifest to pass validation")
+			assert.NotErrorIs(t, err, plugin.ErrNotImplemented, "should not return ErrNotImplemented")
+		})
+	}
+}
+
+// TestManifestValidate_NameValidation tests name field validation
+func TestManifestValidate_NameValidation(t *testing.T) {
+	// Component: T004, T005
+	// Feature: C031
+	tests := []struct {
+		name      string
+		manifest  plugin.Manifest
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "empty name",
+			manifest: plugin.Manifest{
+				Name:       "",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr:   true,
+			errSubstr: "name cannot be empty",
+		},
+		{
+			name: "whitespace only name",
+			manifest: plugin.Manifest{
+				Name:       "   ",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr:   true,
+			errSubstr: "invalid name",
+		},
+		{
+			name: "name starts with digit",
+			manifest: plugin.Manifest{
+				Name:       "1plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr:   true,
+			errSubstr: "invalid name",
+		},
+		{
+			name: "name contains uppercase",
+			manifest: plugin.Manifest{
+				Name:       "MyPlugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr:   true,
+			errSubstr: "invalid name",
+		},
+		{
+			name: "name contains underscore",
+			manifest: plugin.Manifest{
+				Name:       "my_plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr:   true,
+			errSubstr: "invalid name",
+		},
+		{
+			name: "name contains space",
+			manifest: plugin.Manifest{
+				Name:       "my plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr:   true,
+			errSubstr: "invalid name",
+		},
+		{
+			name: "name contains special characters",
+			manifest: plugin.Manifest{
+				Name:       "my@plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr:   true,
+			errSubstr: "invalid name",
+		},
+		{
+			name: "name starts with hyphen",
+			manifest: plugin.Manifest{
+				Name:       "-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr:   true,
+			errSubstr: "invalid name",
+		},
+		{
+			name: "valid lowercase name",
+			manifest: plugin.Manifest{
+				Name:       "plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid name with hyphens and numbers",
+			manifest: plugin.Manifest{
+				Name:       "my-plugin-v2",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.manifest.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				assert.NotErrorIs(t, err, plugin.ErrNotImplemented)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestManifestValidate_VersionValidation tests version field validation
+func TestManifestValidate_VersionValidation(t *testing.T) {
+	// Component: T004, T006
+	// Feature: C031
+	tests := []struct {
+		name      string
+		manifest  plugin.Manifest
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "empty version",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr:   true,
+			errSubstr: "version cannot be empty",
+		},
+		{
+			name: "valid semantic version",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid version with prerelease",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0-alpha.1",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid version with build metadata",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0+20230101",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid version major.minor",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid version major only",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "arbitrary version string (ADR-003 minimal validation)",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "v2024.01.01",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.manifest.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				assert.NotErrorIs(t, err, plugin.ErrNotImplemented)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestManifestValidate_AWFVersionValidation tests AWFVersion field validation
+func TestManifestValidate_AWFVersionValidation(t *testing.T) {
+	// Component: T004, T006
+	// Feature: C031
+	tests := []struct {
+		name      string
+		manifest  plugin.Manifest
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "empty AWFVersion",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: "",
+			},
+			wantErr:   true,
+			errSubstr: "awf_version cannot be empty",
+		},
+		{
+			name: "valid constraint >=",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid constraint ^",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: "^0.4.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid constraint ~",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: "~0.4.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid range constraint",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0 <1.0.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid exact version",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: "0.4.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "arbitrary constraint string (ADR-003 minimal validation)",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: "latest",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.manifest.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				assert.NotErrorIs(t, err, plugin.ErrNotImplemented)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestManifestValidate_CapabilitiesValidation tests capabilities list validation
+func TestManifestValidate_CapabilitiesValidation(t *testing.T) {
+	// Component: T004, T007
+	// Feature: C031
+	tests := []struct {
+		name      string
+		manifest  plugin.Manifest
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "nil capabilities list",
+			manifest: plugin.Manifest{
+				Name:         "test-plugin",
+				Version:      "1.0.0",
+				AWFVersion:   ">=0.4.0",
+				Capabilities: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty capabilities list",
+			manifest: plugin.Manifest{
+				Name:         "test-plugin",
+				Version:      "1.0.0",
+				AWFVersion:   ">=0.4.0",
+				Capabilities: []string{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "single valid capability - operations",
+			manifest: plugin.Manifest{
+				Name:         "test-plugin",
+				Version:      "1.0.0",
+				AWFVersion:   ">=0.4.0",
+				Capabilities: []string{plugin.CapabilityOperations},
+			},
+			wantErr: false,
+		},
+		{
+			name: "single valid capability - commands",
+			manifest: plugin.Manifest{
+				Name:         "test-plugin",
+				Version:      "1.0.0",
+				AWFVersion:   ">=0.4.0",
+				Capabilities: []string{plugin.CapabilityCommands},
+			},
+			wantErr: false,
+		},
+		{
+			name: "single valid capability - validators",
+			manifest: plugin.Manifest{
+				Name:         "test-plugin",
+				Version:      "1.0.0",
+				AWFVersion:   ">=0.4.0",
+				Capabilities: []string{plugin.CapabilityValidators},
+			},
+			wantErr: false,
+		},
+		{
+			name: "all valid capabilities",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Capabilities: []string{
+					plugin.CapabilityOperations,
+					plugin.CapabilityCommands,
+					plugin.CapabilityValidators,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid capability",
+			manifest: plugin.Manifest{
+				Name:         "test-plugin",
+				Version:      "1.0.0",
+				AWFVersion:   ">=0.4.0",
+				Capabilities: []string{"unknown"},
+			},
+			wantErr:   true,
+			errSubstr: "invalid capability",
+		},
+		{
+			name: "mixed valid and invalid capabilities",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Capabilities: []string{
+					plugin.CapabilityOperations,
+					"invalid-capability",
+				},
+			},
+			wantErr:   true,
+			errSubstr: "invalid capability",
+		},
+		{
+			name: "duplicate valid capabilities",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Capabilities: []string{
+					plugin.CapabilityOperations,
+					plugin.CapabilityOperations,
+				},
+			},
+			wantErr: false, // duplicates are allowed per spec
+		},
+		{
+			name: "capability with typo",
+			manifest: plugin.Manifest{
+				Name:         "test-plugin",
+				Version:      "1.0.0",
+				AWFVersion:   ">=0.4.0",
+				Capabilities: []string{"operation"}, // missing 's'
+			},
+			wantErr:   true,
+			errSubstr: "invalid capability",
+		},
+		{
+			name: "capability with wrong case",
+			manifest: plugin.Manifest{
+				Name:         "test-plugin",
+				Version:      "1.0.0",
+				AWFVersion:   ">=0.4.0",
+				Capabilities: []string{"Operations"}, // capitalized
+			},
+			wantErr:   true,
+			errSubstr: "invalid capability",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.manifest.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				assert.NotErrorIs(t, err, plugin.ErrNotImplemented)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestManifestValidate_ConfigValidation tests config field validation integration
+func TestManifestValidate_ConfigValidation(t *testing.T) {
+	// Component: T004, T008
+	// Feature: C031
+	tests := []struct {
+		name      string
+		manifest  plugin.Manifest
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "nil config map",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config:     nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty config map",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config:     map[string]plugin.ConfigField{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid single config field",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"api_key": {
+						Type:        plugin.ConfigTypeString,
+						Required:    true,
+						Description: "API key",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid config field type",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"bad_field": {
+						Type: "invalid_type",
+					},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "config field \"bad_field\"",
+		},
+		{
+			name: "config field with enum on non-string type",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"port": {
+						Type: plugin.ConfigTypeInteger,
+						Enum: []string{"8080", "8081"},
+					},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "enum",
+		},
+		{
+			name: "config field with type mismatch default",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"timeout": {
+						Type:    plugin.ConfigTypeInteger,
+						Default: "not-a-number",
+					},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "type mismatch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.manifest.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				assert.NotErrorIs(t, err, plugin.ErrNotImplemented)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestManifestValidate_FailFastBehavior tests that validation returns first error
+func TestManifestValidate_FailFastBehavior(t *testing.T) {
+	// Component: T004
+	// Feature: C031
+	//
+	// Per ADR-001, validation should fail fast and return the first error encountered.
+	// This test verifies that multiple errors don't result in aggregated errors.
+	tests := []struct {
+		name        string
+		manifest    plugin.Manifest
+		firstErrMsg string // The first validation error expected
+		notErrMsg   string // A later error that should NOT appear
+	}{
+		{
+			name: "empty name fails before version check",
+			manifest: plugin.Manifest{
+				Name:       "",
+				Version:    "", // also invalid
+				AWFVersion: ">=0.4.0",
+			},
+			firstErrMsg: "name",
+			notErrMsg:   "version",
+		},
+		{
+			name: "invalid name fails before version check",
+			manifest: plugin.Manifest{
+				Name:       "Invalid-Name",
+				Version:    "", // also invalid
+				AWFVersion: ">=0.4.0",
+			},
+			firstErrMsg: "name",
+			notErrMsg:   "version",
+		},
+		{
+			name: "empty version fails before AWFVersion check",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "",
+				AWFVersion: "", // also invalid
+			},
+			firstErrMsg: "version",
+			notErrMsg:   "awf_version",
+		},
+		{
+			name: "empty AWFVersion fails before capabilities check",
+			manifest: plugin.Manifest{
+				Name:         "test-plugin",
+				Version:      "1.0.0",
+				AWFVersion:   "",
+				Capabilities: []string{"invalid"}, // also invalid
+			},
+			firstErrMsg: "awf_version",
+			notErrMsg:   "capability",
+		},
+		{
+			name: "invalid capability fails before config check",
+			manifest: plugin.Manifest{
+				Name:         "test-plugin",
+				Version:      "1.0.0",
+				AWFVersion:   ">=0.4.0",
+				Capabilities: []string{"bad-capability"},
+				Config: map[string]plugin.ConfigField{
+					"bad": {Type: "invalid"}, // also invalid
+				},
+			},
+			firstErrMsg: "capability",
+			notErrMsg:   "config",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.manifest.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.firstErrMsg,
+				"should contain first error: %s", tt.firstErrMsg)
+			assert.NotContains(t, err.Error(), tt.notErrMsg,
+				"should NOT contain later error: %s (fail-fast behavior)", tt.notErrMsg)
+			assert.NotErrorIs(t, err, plugin.ErrNotImplemented)
+		})
+	}
+}
+
+// TestManifestValidate_EdgeCases tests edge cases and boundary conditions
+func TestManifestValidate_EdgeCases(t *testing.T) {
+	// Component: T004
+	// Feature: C031
+	tests := []struct {
+		name      string
+		manifest  plugin.Manifest
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "all fields empty",
+			manifest: plugin.Manifest{
+				Name:       "",
+				Version:    "",
+				AWFVersion: "",
+			},
+			wantErr:   true,
+			errSubstr: "name",
+		},
+		{
+			name: "whitespace in name",
+			manifest: plugin.Manifest{
+				Name:       "  ",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr:   true,
+			errSubstr: "name",
+		},
+		{
+			name: "single character name",
+			manifest: plugin.Manifest{
+				Name:       "a",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "very long valid name",
+			manifest: plugin.Manifest{
+				Name:       "very-long-plugin-name-with-many-hyphens-and-numbers-12345",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "manifest with all optional fields filled",
+			manifest: plugin.Manifest{
+				Name:        "complete-plugin",
+				Version:     "1.0.0",
+				AWFVersion:  ">=0.4.0",
+				Description: "Complete plugin with all fields",
+				Author:      "Author Name",
+				License:     "MIT",
+				Homepage:    "https://example.com",
+				Capabilities: []string{
+					plugin.CapabilityOperations,
+					plugin.CapabilityCommands,
+				},
+				Config: map[string]plugin.ConfigField{
+					"key": {
+						Type:        plugin.ConfigTypeString,
+						Required:    true,
+						Default:     "value",
+						Description: "A key",
+						Enum:        []string{"value", "other"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "zero-length capabilities slice (not nil)",
+			manifest: plugin.Manifest{
+				Name:         "test-plugin",
+				Version:      "1.0.0",
+				AWFVersion:   ">=0.4.0",
+				Capabilities: []string{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "config with empty field name key",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"": {Type: plugin.ConfigTypeString},
+				},
+			},
+			wantErr: false, // empty keys are allowed in Go maps
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.manifest.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errSubstr != "" {
+					assert.Contains(t, err.Error(), tt.errSubstr)
+				}
+				assert.NotErrorIs(t, err, plugin.ErrNotImplemented)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestManifestValidate_ErrorMessages tests error message clarity and helpfulness
+func TestManifestValidate_ErrorMessages(t *testing.T) {
+	// Component: T004
+	// Feature: C031
+	tests := []struct {
+		name           string
+		manifest       plugin.Manifest
+		expectedSubstr []string // All substrings that should appear in error
+	}{
+		{
+			name: "invalid name error shows pattern",
+			manifest: plugin.Manifest{
+				Name:       "Invalid_Name",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+			expectedSubstr: []string{"invalid name", "Invalid_Name", "pattern"},
+		},
+		{
+			name: "invalid capability error shows valid options",
+			manifest: plugin.Manifest{
+				Name:         "test-plugin",
+				Version:      "1.0.0",
+				AWFVersion:   ">=0.4.0",
+				Capabilities: []string{"bad-capability"},
+			},
+			expectedSubstr: []string{"invalid capability", "bad-capability", "operations", "commands", "validators"},
+		},
+		{
+			name: "config field error includes field name",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"problematic_field": {Type: "invalid"},
+				},
+			},
+			expectedSubstr: []string{"config field", "problematic_field"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.manifest.Validate()
+			require.Error(t, err)
+			for _, substr := range tt.expectedSubstr {
+				assert.Contains(t, err.Error(), substr,
+					"error message should contain %q", substr)
+			}
+		})
+	}
+}
+
+// TestManifestValidate_NoLongerReturnsErrNotImplemented verifies stub is replaced
+func TestManifestValidate_NoLongerReturnsErrNotImplemented(t *testing.T) {
+	// Component: T004
+	// Feature: C031
+	//
+	// This test explicitly verifies that Manifest.Validate() no longer returns
+	// ErrNotImplemented, confirming that the stub has been fully replaced with
+	// actual validation logic.
+	tests := []struct {
+		name     string
+		manifest plugin.Manifest
+	}{
+		{
+			name: "valid manifest should not return ErrNotImplemented",
+			manifest: plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+		},
+		{
+			name: "invalid manifest should not return ErrNotImplemented",
+			manifest: plugin.Manifest{
+				Name:       "", // invalid
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.manifest.Validate()
+			assert.NotErrorIs(t, err, plugin.ErrNotImplemented,
+				"Validate() should never return ErrNotImplemented after C031 implementation")
 		})
 	}
 }

--- a/tests/integration/casing_standalone_test.go
+++ b/tests/integration/casing_standalone_test.go
@@ -22,7 +22,6 @@ const awfBinary = "../../bin/awf"
 // TestCLI_SingleLowercaseError validates that awf validate detects a single
 // lowercase property and provides a helpful error message with a suggestion.
 func TestCLI_SingleLowercaseError(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "lowercase-single")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -44,7 +43,6 @@ func TestCLI_SingleLowercaseError(t *testing.T) {
 // TestCLI_MultipleLowercaseErrors validates that all lowercase properties
 // are reported, not just the first one (non-fail-fast behavior).
 func TestCLI_MultipleLowercaseErrors(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "lowercase-multiple")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -75,7 +73,6 @@ func TestCLI_MultipleLowercaseErrors(t *testing.T) {
 // TestCLI_UppercasePropertiesPass validates that workflows using correct
 // uppercase property syntax pass validation without errors.
 func TestCLI_UppercasePropertiesPass(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "uppercase-valid")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -92,7 +89,6 @@ func TestCLI_UppercasePropertiesPass(t *testing.T) {
 // TestCLI_MixedCasing validates that workflows with both correct and
 // incorrect casing report only the incorrect references.
 func TestCLI_MixedCasing(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "mixed-casing")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -114,7 +110,6 @@ func TestCLI_MixedCasing(t *testing.T) {
 // Note: Loop conditions may not be validated in current implementation.
 // This test is kept for future enhancement verification.
 func TestCLI_LoopConditionLowercase(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "loop-lowercase")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -137,7 +132,6 @@ func TestCLI_LoopConditionLowercase(t *testing.T) {
 // TestCLI_HookValidation validates that workflows with hooks can be validated.
 // Note: Hook content validation may not be implemented yet.
 func TestCLI_HookValidation(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "hook-lowercase")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -156,7 +150,6 @@ func TestCLI_HookValidation(t *testing.T) {
 // TestCLI_ErrorMessageQuality validates that error messages meet quality
 // standards: clear property identification, actionable suggestions, context.
 func TestCLI_ErrorMessageQuality(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "lowercase-single")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 

--- a/tests/integration/casing_validation_test.go
+++ b/tests/integration/casing_validation_test.go
@@ -30,7 +30,6 @@ import (
 //
 // Acceptance: US2 - Validation Errors on Incorrect Casing
 func TestValidate_SingleLowercaseError(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -59,7 +58,6 @@ func TestValidate_SingleLowercaseError(t *testing.T) {
 //
 // Acceptance: US2 - Mixed casing scenario
 func TestValidate_MultipleLowercaseErrors(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -92,7 +90,6 @@ func TestValidate_MultipleLowercaseErrors(t *testing.T) {
 //
 // Acceptance: US1 - Correct Template Field Casing
 func TestValidate_UppercasePropertiesPass(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -117,7 +114,6 @@ func TestValidate_UppercasePropertiesPass(t *testing.T) {
 //
 // Edge Case: Partial correctness
 func TestValidate_MixedCasing(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -155,7 +151,6 @@ func TestValidate_MixedCasing(t *testing.T) {
 //
 // Edge Case: Properties in control flow structures
 func TestValidate_LoopConditionLowercase(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -182,7 +177,6 @@ func TestValidate_LoopConditionLowercase(t *testing.T) {
 //
 // Edge Case: Properties in hooks (on_error, on_success)
 func TestValidate_HookLowercase(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -209,7 +203,6 @@ func TestValidate_HookLowercase(t *testing.T) {
 //
 // Integration: Error message formatting
 func TestValidate_ErrorMessageQuality(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -249,7 +242,6 @@ func TestValidate_ErrorMessageQuality(t *testing.T) {
 //
 // Edge Case: All-caps and mixed case variants
 func TestValidate_CaseSensitivity(t *testing.T) {
-
 	// Create a temporary workflow with all-caps property
 	tmpDir := t.TempDir()
 	workflowPath := tmpDir + "/test-allcaps.yaml"
@@ -295,7 +287,6 @@ steps:
 //
 // Integration: Complex valid workflows
 func TestValidate_NoFalsePositives(t *testing.T) {
-
 	// Test with existing valid workflows that use correct casing
 	validWorkflows := []string{
 		"valid-simple",
@@ -336,7 +327,6 @@ func TestValidate_NoFalsePositives(t *testing.T) {
 //
 // Edge Case: No state references at all
 func TestValidate_EmptyWorkflow(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	workflowPath := tmpDir + "/test-empty.yaml"
 
@@ -379,7 +369,6 @@ steps:
 //
 // Non-Functional: NFR-001 - Performance
 func TestValidate_PerformanceUnder100ms(t *testing.T) {
-
 	// Create a workflow with many steps (up to 50)
 	tmpDir := t.TempDir()
 	workflowPath := tmpDir + "/test-large.yaml"

--- a/tests/integration/cli_exitcodes_test.go
+++ b/tests/integration/cli_exitcodes_test.go
@@ -53,7 +53,6 @@ func getBinaryPath(t *testing.T) string {
 // Feature: C011 - Task T011
 // Strategy: Run valid workflow via subprocess, verify exit code 0
 func TestCLI_ExitCode0_Success_Integration(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowFile string
@@ -103,7 +102,6 @@ func TestCLI_ExitCode0_Success_Integration(t *testing.T) {
 // Feature: C011 - Task T011
 // Strategy: Trigger user errors (missing input, validation failure), verify exit code 1
 func TestCLI_ExitCode1_UserError_Integration(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowFile string
@@ -155,7 +153,6 @@ func TestCLI_ExitCode1_UserError_Integration(t *testing.T) {
 // Feature: C011 - Task T011
 // Strategy: Provide invalid input value (violates validation rule), verify exit code 1
 func TestCLI_ExitCode1_InvalidInputValue_Integration(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowFile string
@@ -207,7 +204,6 @@ func TestCLI_ExitCode1_InvalidInputValue_Integration(t *testing.T) {
 // Feature: C011 - Task T011
 // Strategy: Use workflow with invalid state reference, verify exit code 2
 func TestCLI_ExitCode2_InvalidStateReference_Integration(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowFile string
@@ -259,7 +255,6 @@ func TestCLI_ExitCode2_InvalidStateReference_Integration(t *testing.T) {
 // Feature: C011 - Task T011
 // Strategy: Use workflow with cycle, verify exit code 2
 func TestCLI_ExitCode2_CyclicStateMachine_Integration(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowFile string
@@ -311,7 +306,6 @@ func TestCLI_ExitCode2_CyclicStateMachine_Integration(t *testing.T) {
 // Feature: C011 - Task T011
 // Strategy: Run workflow with failing command, verify exit code 3
 func TestCLI_ExitCode3_CommandFailure_Integration(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowFile string
@@ -363,7 +357,6 @@ func TestCLI_ExitCode3_CommandFailure_Integration(t *testing.T) {
 // Feature: C011 - Task T011
 // Strategy: Run workflow that times out, verify exit code 3
 func TestCLI_ExitCode3_Timeout_Integration(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowFile string
@@ -415,7 +408,6 @@ func TestCLI_ExitCode3_Timeout_Integration(t *testing.T) {
 // Feature: C011 - Task T011
 // Strategy: Try to run non-existent workflow file, verify exit code 4
 func TestCLI_ExitCode4_FileNotFound_Integration(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowFile string
@@ -467,7 +459,6 @@ func TestCLI_ExitCode4_FileNotFound_Integration(t *testing.T) {
 // Feature: C011 - Task T011
 // Strategy: Create unreadable workflow file, verify exit code 4
 func TestCLI_ExitCode4_PermissionDenied_Integration(t *testing.T) {
-
 	// Skip on systems where we can't test permissions reliably
 	if os.Getuid() == 0 {
 		t.Skip("skipping permission test when running as root")
@@ -533,7 +524,6 @@ states:
 // Feature: C011 - Task T011 (Comprehensive edge cases)
 // Strategy: Table-driven test covering all exit codes with various scenarios
 func TestCLI_ExitCodeMapping_ComprehensiveScenarios_Integration(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowFile string

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestCLI_List_Integration(t *testing.T) {
-
 	// Use fixtures directory
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
@@ -34,7 +33,6 @@ func TestCLI_List_Integration(t *testing.T) {
 }
 
 func TestCLI_Validate_Valid_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -51,7 +49,6 @@ func TestCLI_Validate_Valid_Integration(t *testing.T) {
 }
 
 func TestCLI_Validate_Invalid_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -65,7 +62,6 @@ func TestCLI_Validate_Invalid_Integration(t *testing.T) {
 }
 
 func TestCLI_Run_Integration(t *testing.T) {
-
 	// Create temp directory for state storage
 	tmpDir := t.TempDir()
 	statesDir := filepath.Join(tmpDir, "states")
@@ -91,7 +87,6 @@ func TestCLI_Run_Integration(t *testing.T) {
 }
 
 func TestCLI_Status_NotFound_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	cmd := cli.NewRootCommand()
@@ -159,7 +154,6 @@ func TestCLI_GlobalFlags_Integration(t *testing.T) {
 }
 
 func TestCLI_Run_WithInputs_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create a workflow that uses inputs
@@ -250,7 +244,6 @@ func TestCLI_ExitCodes_Integration(t *testing.T) {
 
 // TestCLI_Run_FailingCommand_Integration tests workflow with a failing command
 func TestCLI_Run_FailingCommand_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create a workflow with a failing command
@@ -290,7 +283,6 @@ states:
 
 // TestCLI_Validate_InvalidStrategy_Integration tests validation of invalid parallel strategy
 func TestCLI_Validate_InvalidStrategy_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create a workflow with invalid parallel strategy
@@ -336,7 +328,6 @@ states:
 
 // TestCLI_Run_OutputModes_Integration tests different output modes
 func TestCLI_Run_OutputModes_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create a simple workflow
@@ -417,7 +408,6 @@ states:
 
 // TestCLI_Run_MultiStep_Integration tests a workflow with multiple steps
 func TestCLI_Run_MultiStep_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create a multi-step workflow
@@ -467,7 +457,6 @@ states:
 
 // TestCLI_Run_StepSuccessFeedback_Integration tests F037 success feedback for silent steps
 func TestCLI_Run_StepSuccessFeedback_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create a workflow with a step that produces no output

--- a/tests/integration/cognitive_complexity_refactoring_test.go
+++ b/tests/integration/cognitive_complexity_refactoring_test.go
@@ -54,7 +54,6 @@ func (m *mockC005Logger) WithContext(ctx map[string]any) ports.Logger {
 // =============================================================================
 
 func TestC005_TemplateService_ExpandWorkflow_WithNestedTemplates_Integration(t *testing.T) {
-
 	// Feature: C005 - Component T001 (expandStep helpers)
 	// Given: A workflow with nested template references
 	// When: The workflow is expanded
@@ -139,7 +138,6 @@ states:
 }
 
 func TestC005_TemplateService_ExpandWorkflow_WithParameterSubstitution_Integration(t *testing.T) {
-
 	// Feature: C005 - Component T001 (applyTemplateFields with parameter substitution)
 	// Given: A template with parameter substitution
 	// When: The workflow is expanded with parameters
@@ -206,7 +204,6 @@ states:
 // =============================================================================
 
 func TestC005_TemplateService_ExpandWorkflow_CircularReference_DetectsError_Integration(t *testing.T) {
-
 	// Feature: C005 - Component T001 (validateAndLoadTemplate circular detection)
 	// Given: Templates with circular references
 	// When: Expansion is attempted
@@ -279,7 +276,6 @@ states:
 // =============================================================================
 
 func TestC005_TemplateService_ExpandWorkflow_MissingTemplate_ReturnsError_Integration(t *testing.T) {
-
 	// Feature: C005 - Component T001 (validateAndLoadTemplate error path)
 	// Given: A workflow referencing a non-existent template
 	// When: Expansion is attempted
@@ -316,7 +312,6 @@ func TestC005_TemplateService_ExpandWorkflow_MissingTemplate_ReturnsError_Integr
 }
 
 func TestC005_TemplateService_SelectPrimaryStep_MultipleSteps_SelectsCorrectly_Integration(t *testing.T) {
-
 	// Feature: C005 - Component T001 (selectPrimaryStep helper)
 	// Given: A template with multiple steps
 	// When: SelectPrimaryStep is called
@@ -365,7 +360,6 @@ states:
 // =============================================================================
 
 func TestC005_TemplateService_FullExpansion_DeepNesting_ThreeLevels_Integration(t *testing.T) {
-
 	// Feature: C005 - All T001 components working together
 	// Given: Three levels of nested templates
 	// When: The workflow is expanded
@@ -472,7 +466,6 @@ states:
 // =============================================================================
 
 func TestC005_ExecutorIntegration_HandleSuccess_WorkflowCompletion(t *testing.T) {
-
 	// Feature: C005 - Component T002 (HandleSuccess result handler behavioral validation)
 	// Given: A simple workflow with sequential successful steps
 	// When: The workflow is executed via AWF CLI
@@ -530,7 +523,6 @@ states:
 }
 
 func TestC005_ExecutorIntegration_ErrorHandling_WorkflowStructure(t *testing.T) {
-
 	// Feature: C005 - Component T002 (HandleNonZeroExit & HandleExecutionError validation)
 	// Given: A workflow with error handling paths
 	// When: The workflow structure is validated
@@ -583,7 +575,6 @@ states:
 }
 
 func TestC005_ParallelExecutorIntegration_StrategyValidation(t *testing.T) {
-
 	// Feature: C005 - Component T003 (RunBranchWithSemaphore & CheckBranchSuccess validation)
 	// Given: Workflows with different parallel strategies
 	// When: The workflows are validated
@@ -695,7 +686,6 @@ states:
 // =============================================================================
 
 func TestC005_FullIntegration_TemplateExpansion_ParallelExecution(t *testing.T) {
-
 	// Feature: C005 - All components (T001 + T002 + T003) working together
 	// Given: A complex workflow with templates and parallel execution
 	// When: The workflow is loaded and templates expanded

--- a/tests/integration/concurrent_workflow_test.go
+++ b/tests/integration/concurrent_workflow_test.go
@@ -87,7 +87,6 @@ func (m *concurrentMockLogger) WithContext(ctx map[string]any) ports.Logger {
 // This is the core test for bug-48: BadgerDB used exclusive locks preventing
 // concurrent workflow execution.
 func TestConcurrentWorkflowExecution_SharedHistoryStore(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	workflowDir := filepath.Join(tmpDir, "workflows")
 	historyPath := filepath.Join(tmpDir, "history.db")
@@ -182,7 +181,6 @@ states:
 // TestConcurrentWorkflowExecution_HistoryIntegrity verifies that all workflow
 // executions are correctly recorded in history even under concurrent load.
 func TestConcurrentWorkflowExecution_HistoryIntegrity(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	workflowDir := filepath.Join(tmpDir, "workflows")
 	historyPath := filepath.Join(tmpDir, "history.db")
@@ -282,7 +280,6 @@ states:
 // TestConcurrentHistoryStoreAccess validates that multiple goroutines can
 // read and write to the SQLite history store without data corruption.
 func TestConcurrentHistoryStoreAccess(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	historyPath := filepath.Join(tmpDir, "history.db")
 
@@ -401,7 +398,6 @@ func TestConcurrentHistoryStoreAccess(t *testing.T) {
 // TestConcurrentWorkflowExecution_NoLockContention ensures that concurrent
 // workflow executions don't block each other due to database locking.
 func TestConcurrentWorkflowExecution_NoLockContention(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	workflowDir := filepath.Join(tmpDir, "workflows")
 	historyPath := filepath.Join(tmpDir, "history.db")
@@ -510,7 +506,6 @@ states:
 // concurrently without conflicts. This simulates multiple awf processes accessing
 // the same history database.
 func TestConcurrentHistoryStoreAccess_MultipleStoreInstances(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	historyPath := filepath.Join(tmpDir, "history.db")
 	ctx := context.Background()
@@ -603,7 +598,6 @@ func TestConcurrentHistoryStoreAccess_MultipleStoreInstances(t *testing.T) {
 // TestConcurrentWorkflowExecution_RapidSuccession tests that workflows can be
 // started in rapid succession without database errors.
 func TestConcurrentWorkflowExecution_RapidSuccession(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	workflowDir := filepath.Join(tmpDir, "workflows")
 	historyPath := filepath.Join(tmpDir, "history.db")
@@ -681,7 +675,6 @@ states:
 // TestConcurrentHistoryStoreAccess_MixedOperations tests concurrent
 // Record, List, GetStats, and Cleanup operations on the history store.
 func TestConcurrentHistoryStoreAccess_MixedOperations(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	historyPath := filepath.Join(tmpDir, "history.db")
 

--- a/tests/integration/config_test.go
+++ b/tests/integration/config_test.go
@@ -25,7 +25,6 @@ import (
 
 // TestConfigShow_Integration tests the 'awf config show' command behavior.
 func TestConfigShow_Integration(t *testing.T) {
-
 	t.Run("displays config values when config exists", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		awfDir := filepath.Join(tmpDir, ".awf")
@@ -192,7 +191,6 @@ func TestConfigShow_Integration(t *testing.T) {
 
 // TestConfigInputsInWorkflow_Integration tests that config inputs are used in workflows.
 func TestConfigInputsInWorkflow_Integration(t *testing.T) {
-
 	t.Run("workflow uses input from config file", func(t *testing.T) {
 		tmpDir := t.TempDir()
 
@@ -380,7 +378,6 @@ states:
 
 // TestConfigValidation_Integration tests config validation during workflow run.
 func TestConfigValidation_Integration(t *testing.T) {
-
 	t.Run("invalid YAML produces error on workflow run", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		awfDir := filepath.Join(tmpDir, ".awf")
@@ -504,7 +501,6 @@ states:
 
 // TestConfigInit_Integration tests that 'awf init' creates config file.
 func TestConfigInit_Integration(t *testing.T) {
-
 	t.Run("init creates config.yaml with template", func(t *testing.T) {
 		tmpDir := t.TempDir()
 
@@ -572,7 +568,6 @@ inputs:
 
 // TestConfigMultipleInputTypes_Integration tests various input types in config.
 func TestConfigMultipleInputTypes_Integration(t *testing.T) {
-
 	t.Run("supports string, number, and boolean inputs", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		awfDir := filepath.Join(tmpDir, ".awf")
@@ -621,7 +616,6 @@ func TestConfigMultipleInputTypes_Integration(t *testing.T) {
 
 // TestConfigEdgeCases_Integration tests edge cases for config handling.
 func TestConfigEdgeCases_Integration(t *testing.T) {
-
 	t.Run("empty config file is valid", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		awfDir := filepath.Join(tmpDir, ".awf")
@@ -782,7 +776,6 @@ states:
 
 // TestConfigShowFormats_Integration tests different output formats for config show.
 func TestConfigShowFormats_Integration(t *testing.T) {
-
 	t.Run("json format with no config shows empty state", func(t *testing.T) {
 		tmpDir := t.TempDir()
 
@@ -827,7 +820,6 @@ func TestConfigShowFormats_Integration(t *testing.T) {
 
 // TestConfigMultipleOverrides_Integration tests multiple CLI overrides.
 func TestConfigMultipleOverrides_Integration(t *testing.T) {
-
 	t.Run("multiple CLI inputs override multiple config values", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		awfDir := filepath.Join(tmpDir, ".awf")
@@ -968,7 +960,6 @@ states:
 
 // TestConfigResume_Integration tests config integration with resume command.
 func TestConfigResume_Integration(t *testing.T) {
-
 	t.Run("resume uses config inputs for new inputs", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		awfDir := filepath.Join(tmpDir, ".awf")
@@ -1035,7 +1026,6 @@ states:
 
 // TestConfigPermissions_Integration tests config file permission errors.
 func TestConfigPermissions_Integration(t *testing.T) {
-
 	// Skip on Windows where permission model is different
 	if os.Getenv("OS") == "Windows_NT" {
 		t.Skip("skipping permission test on Windows")
@@ -1071,7 +1061,6 @@ func TestConfigPermissions_Integration(t *testing.T) {
 
 // TestConfigWithSpecialCharacters_Integration tests config with special characters in values.
 func TestConfigWithSpecialCharacters_Integration(t *testing.T) {
-
 	t.Run("config values with special characters are preserved", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		awfDir := filepath.Join(tmpDir, ".awf")

--- a/tests/integration/diagram_test.go
+++ b/tests/integration/diagram_test.go
@@ -31,7 +31,6 @@ import (
 // TestDiagram_Simple_OutputsValidDOT tests US1: basic DOT output to stdout
 // for a linear workflow.
 func TestDiagram_Simple_OutputsValidDOT(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -63,7 +62,6 @@ func TestDiagram_Simple_OutputsValidDOT(t *testing.T) {
 // TestDiagram_Parallel_ShowsSubgraphCluster tests FR-004: parallel branches
 // are grouped in subgraph clusters.
 func TestDiagram_Parallel_ShowsSubgraphCluster(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -87,7 +85,6 @@ func TestDiagram_Parallel_ShowsSubgraphCluster(t *testing.T) {
 // TestDiagram_AllTypes_MapsCorrectShapes tests FR-002: each step type maps
 // to its correct DOT shape.
 func TestDiagram_AllTypes_MapsCorrectShapes(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -127,7 +124,6 @@ func TestDiagram_AllTypes_MapsCorrectShapes(t *testing.T) {
 // TestDiagram_InitialStep_HasIndicator tests FR-005: initial step marked with
 // special indicator.
 func TestDiagram_InitialStep_HasIndicator(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -153,7 +149,6 @@ func TestDiagram_InitialStep_HasIndicator(t *testing.T) {
 // TestDiagram_EdgeStyles_SuccessAndFailure tests FR-003: edge styling for
 // success and failure transitions.
 func TestDiagram_EdgeStyles_SuccessAndFailure(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -188,7 +183,6 @@ func TestDiagram_EdgeStyles_SuccessAndFailure(t *testing.T) {
 // TestDiagram_Direction_AllValues tests FR-007: --direction flag controls
 // graph layout direction.
 func TestDiagram_Direction_AllValues(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tests := []struct {
@@ -221,7 +215,6 @@ func TestDiagram_Direction_AllValues(t *testing.T) {
 
 // TestDiagram_Direction_Default tests that default direction is TB.
 func TestDiagram_Direction_Default(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -247,7 +240,6 @@ func TestDiagram_Direction_Default(t *testing.T) {
 // TestDiagram_Highlight_EmphasizesStep tests US3: --highlight step_name
 // visually emphasizes the specified step.
 func TestDiagram_Highlight_EmphasizesStep(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -275,7 +267,6 @@ func TestDiagram_Highlight_EmphasizesStep(t *testing.T) {
 
 // TestDiagram_Highlight_NonexistentStep tests highlight of non-existent step.
 func TestDiagram_Highlight_NonexistentStep(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -299,7 +290,6 @@ func TestDiagram_Highlight_NonexistentStep(t *testing.T) {
 
 // TestDiagram_Output_DotFile tests FR-006: --output exports to .dot file.
 func TestDiagram_Output_DotFile(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -327,7 +317,6 @@ func TestDiagram_Output_DotFile(t *testing.T) {
 // TestDiagram_Output_ImageExport_RequiresGraphviz tests US2: image export
 // requires graphviz and produces clear error if missing.
 func TestDiagram_Output_ImageExport_RequiresGraphviz(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	// Check if graphviz is installed
@@ -373,7 +362,6 @@ func TestDiagram_Output_ImageExport_RequiresGraphviz(t *testing.T) {
 
 // TestDiagram_Output_SVGExport tests SVG export format detection.
 func TestDiagram_Output_SVGExport(t *testing.T) {
-
 	// Skip if graphviz not available
 	if _, err := exec.LookPath("dot"); err != nil {
 		t.Skip("graphviz not installed, skipping image export test")
@@ -400,7 +388,6 @@ func TestDiagram_Output_SVGExport(t *testing.T) {
 
 // TestDiagram_Output_PDFExport tests PDF export format detection.
 func TestDiagram_Output_PDFExport(t *testing.T) {
-
 	// Skip if graphviz not available
 	if _, err := exec.LookPath("dot"); err != nil {
 		t.Skip("graphviz not installed, skipping image export test")
@@ -433,7 +420,6 @@ func TestDiagram_Output_PDFExport(t *testing.T) {
 
 // TestDiagram_CombinedFlags_DirectionAndHighlight tests multiple flags together.
 func TestDiagram_CombinedFlags_DirectionAndHighlight(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -462,7 +448,6 @@ func TestDiagram_CombinedFlags_DirectionAndHighlight(t *testing.T) {
 
 // TestDiagram_CombinedFlags_AllFlags tests all flags combined.
 func TestDiagram_CombinedFlags_AllFlags(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -497,7 +482,6 @@ func TestDiagram_CombinedFlags_AllFlags(t *testing.T) {
 
 // TestDiagram_InvalidWorkflow_NotFound tests FR-008: non-existent workflow.
 func TestDiagram_InvalidWorkflow_NotFound(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -520,7 +504,6 @@ func TestDiagram_InvalidWorkflow_NotFound(t *testing.T) {
 
 // TestDiagram_InvalidWorkflow_MalformedYAML tests FR-008: malformed YAML.
 func TestDiagram_InvalidWorkflow_MalformedYAML(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create a malformed YAML workflow
@@ -551,7 +534,6 @@ states:
 
 // TestDiagram_InvalidDirection tests error for invalid direction value.
 func TestDiagram_InvalidDirection(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -585,7 +567,6 @@ func TestDiagram_MissingArgument(t *testing.T) {
 
 // TestDiagram_OutputDirectory_NotExists tests error when output directory doesn't exist.
 func TestDiagram_OutputDirectory_NotExists(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -604,7 +585,6 @@ func TestDiagram_OutputDirectory_NotExists(t *testing.T) {
 
 // TestDiagram_WorkflowWithSpecialCharacters tests DOT escaping for special characters.
 func TestDiagram_WorkflowWithSpecialCharacters(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create a workflow with special characters in descriptions
@@ -648,7 +628,6 @@ states:
 
 // TestDiagram_SingleStepWorkflow tests minimal workflow with single step.
 func TestDiagram_SingleStepWorkflow(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create minimal single-step workflow
@@ -682,7 +661,6 @@ states:
 
 // TestDiagram_NestedParallel tests workflow with nested parallel branches.
 func TestDiagram_NestedParallel(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create workflow with nested parallel
@@ -745,7 +723,6 @@ states:
 
 // TestDiagram_LongStepNames tests workflow with long step names.
 func TestDiagram_LongStepNames(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	longName := "this_is_a_very_long_step_name_that_might_cause_issues_with_rendering"
@@ -786,7 +763,6 @@ states:
 // TestDiagram_DOTSyntax_ValidWithGraphviz validates DOT output with graphviz
 // if available. This is the ultimate integration test per US1 acceptance.
 func TestDiagram_DOTSyntax_ValidWithGraphviz(t *testing.T) {
-
 	// Skip if graphviz not available
 	dotPath, err := exec.LookPath("dot")
 	if err != nil {
@@ -818,7 +794,6 @@ func TestDiagram_DOTSyntax_ValidWithGraphviz(t *testing.T) {
 
 // TestDiagram_DOTSyntax_AllFixtures validates all diagram fixtures produce valid DOT.
 func TestDiagram_DOTSyntax_AllFixtures(t *testing.T) {
-
 	// Skip if graphviz not available
 	dotPath, err := exec.LookPath("dot")
 	if err != nil {

--- a/tests/integration/dry_run_test.go
+++ b/tests/integration/dry_run_test.go
@@ -36,7 +36,6 @@ import (
 // -----------------------------------------------------------------------------
 
 func TestDryRun_SimpleWorkflow_ShowsExecutionPlan_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -61,7 +60,6 @@ func TestDryRun_SimpleWorkflow_ShowsExecutionPlan_Integration(t *testing.T) {
 }
 
 func TestDryRun_WithInputs_ResolvesInterpolation_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -89,7 +87,6 @@ func TestDryRun_WithInputs_ResolvesInterpolation_Integration(t *testing.T) {
 }
 
 func TestDryRun_ShowsDefaultInputValues_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -116,7 +113,6 @@ func TestDryRun_ShowsDefaultInputValues_Integration(t *testing.T) {
 }
 
 func TestDryRun_ParallelWorkflow_ShowsBranchesAndStrategy_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -141,7 +137,6 @@ func TestDryRun_ParallelWorkflow_ShowsBranchesAndStrategy_Integration(t *testing
 }
 
 func TestDryRun_ForEachLoop_ShowsLoopConfiguration_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -165,7 +160,6 @@ func TestDryRun_ForEachLoop_ShowsLoopConfiguration_Integration(t *testing.T) {
 }
 
 func TestDryRun_WhileLoop_ShowsCondition_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -187,7 +181,6 @@ func TestDryRun_WhileLoop_ShowsCondition_Integration(t *testing.T) {
 }
 
 func TestDryRun_NestedLoops_ShowsBothLoops_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -209,7 +202,6 @@ func TestDryRun_NestedLoops_ShowsBothLoops_Integration(t *testing.T) {
 }
 
 func TestDryRun_WithHooks_ShowsPrePostHooks_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -231,7 +223,6 @@ func TestDryRun_WithHooks_ShowsPrePostHooks_Integration(t *testing.T) {
 }
 
 func TestDryRun_WithRetry_ShowsRetryConfiguration_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -259,7 +250,6 @@ func TestDryRun_WithRetry_ShowsRetryConfiguration_Integration(t *testing.T) {
 }
 
 func TestDryRun_WithCapture_ShowsCaptureConfiguration_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -287,7 +277,6 @@ func TestDryRun_WithCapture_ShowsCaptureConfiguration_Integration(t *testing.T) 
 }
 
 func TestDryRun_WithTimeout_ShowsTimeoutValue_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -313,7 +302,6 @@ func TestDryRun_WithTimeout_ShowsTimeoutValue_Integration(t *testing.T) {
 }
 
 func TestDryRun_ShowsTransitions_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -335,7 +323,6 @@ func TestDryRun_ShowsTransitions_Integration(t *testing.T) {
 }
 
 func TestDryRun_ConditionalTransitions_ShowsAllPaths_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -363,7 +350,6 @@ func TestDryRun_ConditionalTransitions_ShowsAllPaths_Integration(t *testing.T) {
 }
 
 func TestDryRun_WithWorkingDirectory_ShowsDir_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -385,7 +371,6 @@ func TestDryRun_WithWorkingDirectory_ShowsDir_Integration(t *testing.T) {
 }
 
 func TestDryRun_ContinueOnError_ShowsFlag_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -411,7 +396,6 @@ func TestDryRun_ContinueOnError_ShowsFlag_Integration(t *testing.T) {
 }
 
 func TestDryRun_TerminalSteps_ShowsStatus_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -441,7 +425,6 @@ func TestDryRun_TerminalSteps_ShowsStatus_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestDryRun_JSONOutput_ValidJSON_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -471,7 +454,6 @@ func TestDryRun_JSONOutput_ValidJSON_Integration(t *testing.T) {
 }
 
 func TestDryRun_JSONOutput_ContainsAllFields_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -510,7 +492,6 @@ func TestDryRun_JSONOutput_ContainsAllFields_Integration(t *testing.T) {
 }
 
 func TestDryRun_JSONOutput_StepsHaveCorrectTypes_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -552,7 +533,6 @@ func TestDryRun_JSONOutput_StepsHaveCorrectTypes_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestDryRun_QuietMode_OutputsWorkflowNameOnly_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -580,7 +560,6 @@ func TestDryRun_QuietMode_OutputsWorkflowNameOnly_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestDryRun_NoStateFiles_Created_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -604,7 +583,6 @@ func TestDryRun_NoStateFiles_Created_Integration(t *testing.T) {
 }
 
 func TestDryRun_NoHistoryRecorded_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -635,7 +613,6 @@ func TestDryRun_NoHistoryRecorded_Integration(t *testing.T) {
 }
 
 func TestDryRun_NoCommandExecution_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -664,7 +641,6 @@ func TestDryRun_NoCommandExecution_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestDryRun_WorkflowNotFound_ReturnsError_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -681,7 +657,6 @@ func TestDryRun_WorkflowNotFound_ReturnsError_Integration(t *testing.T) {
 }
 
 func TestDryRun_MissingRequiredInput_ReturnsError_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -703,7 +678,6 @@ func TestDryRun_MissingRequiredInput_ReturnsError_Integration(t *testing.T) {
 }
 
 func TestDryRun_InvalidInputFormat_ReturnsError_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -730,7 +704,6 @@ func TestDryRun_InvalidInputFormat_ReturnsError_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestDryRun_EmptyInputValue_Accepted_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -751,7 +724,6 @@ func TestDryRun_EmptyInputValue_Accepted_Integration(t *testing.T) {
 }
 
 func TestDryRun_MultipleInputs_AllResolved_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -781,7 +753,6 @@ func TestDryRun_MultipleInputs_AllResolved_Integration(t *testing.T) {
 }
 
 func TestDryRun_WorkflowWithDescription_ShowsDescription_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -807,7 +778,6 @@ func TestDryRun_WorkflowWithDescription_ShowsDescription_Integration(t *testing.
 }
 
 func TestDryRun_StepDescriptions_Shown_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -837,7 +807,6 @@ func TestDryRun_StepDescriptions_Shown_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestDryRun_VariousWorkflows_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tests := []struct {
@@ -947,7 +916,6 @@ func TestDryRun_VariousWorkflows_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestDryRun_DoesNotModifyWorkflowPath_Integration(t *testing.T) {
-
 	originalPath := os.Getenv("AWF_WORKFLOWS_PATH")
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
@@ -975,7 +943,6 @@ func TestDryRun_DoesNotModifyWorkflowPath_Integration(t *testing.T) {
 }
 
 func TestDryRun_CanRunMultipleTimes_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()

--- a/tests/integration/execution_test.go
+++ b/tests/integration/execution_test.go
@@ -54,7 +54,6 @@ func (m *mockStateStore) List(ctx context.Context) ([]string, error) {
 }
 
 func TestLinearExecution_Integration(t *testing.T) {
-
 	// setup temp directory with workflow file
 	tmpDir := t.TempDir()
 
@@ -111,7 +110,6 @@ states:
 }
 
 func TestLinearExecution_FailurePath_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	wfYAML := `name: failure-test
@@ -168,7 +166,6 @@ states:
 }
 
 func TestLinearExecution_Timeout_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	wfYAML := `name: timeout-test
@@ -221,7 +218,6 @@ states:
 }
 
 func TestLinearExecution_WithValidFixture_Integration(t *testing.T) {
-
 	// use existing fixtures
 	fixturesPath := "../fixtures/workflows"
 
@@ -245,7 +241,6 @@ func TestLinearExecution_WithValidFixture_Integration(t *testing.T) {
 }
 
 func TestHooks_WorkflowAndStepHooks_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// workflow with hooks that write to a log file for verification
@@ -303,7 +298,6 @@ states:
 }
 
 func TestHooks_WorkflowErrorHook_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "error_hooks.log")
 
@@ -358,7 +352,6 @@ states:
 }
 
 func TestHooks_MultipleSteps_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "multi_step_hooks.log")
 
@@ -424,7 +417,6 @@ states:
 }
 
 func TestHooks_LogAction_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// workflow using log hooks (not command hooks)
@@ -475,7 +467,6 @@ states:
 }
 
 func TestStreamingOutput_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	wfYAML := `name: streaming-test
@@ -524,7 +515,6 @@ states:
 }
 
 func TestValidFixtures_Integration(t *testing.T) {
-
 	// test that all valid fixtures can be loaded and validated
 	fixturesPath := "../fixtures/workflows"
 

--- a/tests/integration/expression_context_test.go
+++ b/tests/integration/expression_context_test.go
@@ -29,7 +29,6 @@ import (
 // TestExpressionContext_LowercaseStateFields tests that expressions using
 // lowercase state field keys fail validation with helpful suggestions.
 func TestExpressionContext_LowercaseStateFields(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "expr-lowercase-state")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -50,7 +49,6 @@ func TestExpressionContext_LowercaseStateFields(t *testing.T) {
 // TestExpressionContext_LowercaseErrorFields tests that expressions using
 // lowercase error namespace keys fail validation.
 func TestExpressionContext_LowercaseErrorFields(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "expr-lowercase-error")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -67,7 +65,6 @@ func TestExpressionContext_LowercaseErrorFields(t *testing.T) {
 // TestExpressionContext_LowercaseContextFields tests that expressions using
 // lowercase context namespace keys fail validation.
 func TestExpressionContext_LowercaseContextFields(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "expr-lowercase-context")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -84,7 +81,6 @@ func TestExpressionContext_LowercaseContextFields(t *testing.T) {
 // TestExpressionContext_PascalCaseStateFields tests that expressions using
 // correct PascalCase state field keys pass validation.
 func TestExpressionContext_PascalCaseStateFields(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "expr-pascalcase-state")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -102,7 +98,6 @@ func TestExpressionContext_PascalCaseStateFields(t *testing.T) {
 // TestExpressionContext_LoopNamespace tests that loop.* namespace fields
 // are accessible in break_when expressions with PascalCase keys.
 func TestExpressionContext_LoopNamespace(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "expr-loop-namespace")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -116,7 +111,6 @@ func TestExpressionContext_LoopNamespace(t *testing.T) {
 // TestExpressionContext_ErrorNamespace tests that error.* namespace fields
 // are accessible in error hook when: expressions.
 func TestExpressionContext_ErrorNamespace(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "expr-error-namespace")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -130,7 +124,6 @@ func TestExpressionContext_ErrorNamespace(t *testing.T) {
 // TestExpressionContext_SystemContextNamespace tests that context.* namespace
 // fields are accessible in expressions.
 func TestExpressionContext_SystemContextNamespace(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "expr-context-namespace")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -144,7 +137,6 @@ func TestExpressionContext_SystemContextNamespace(t *testing.T) {
 // TestExpressionContext_NewStateFields tests that new state fields
 // (Response, Tokens) from agent steps are accessible in expressions.
 func TestExpressionContext_NewStateFields(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "expr-agent-fields")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -158,7 +150,6 @@ func TestExpressionContext_NewStateFields(t *testing.T) {
 // TestExpressionContext_WorkflowFields tests that workflow.* fields
 // use PascalCase (ID, Name, CurrentState, Duration).
 func TestExpressionContext_WorkflowFields(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "expr-workflow-fields")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -172,7 +163,6 @@ func TestExpressionContext_WorkflowFields(t *testing.T) {
 // TestExpressionContext_MixedCasing tests that workflows with both correct
 // and incorrect casing report only the incorrect references.
 func TestExpressionContext_MixedCasing(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "expr-mixed-casing")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -194,7 +184,6 @@ func TestExpressionContext_MixedCasing(t *testing.T) {
 // all expression context features: state fields, loop namespace, error namespace,
 // context namespace, and workflow fields.
 func TestExpressionContext_CompleteWorkflow(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "expr-complete")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -208,7 +197,6 @@ func TestExpressionContext_CompleteWorkflow(t *testing.T) {
 // TestExpressionContext_NilSafety tests that expressions handle nil contexts
 // gracefully (e.g., error namespace when no error occurred).
 func TestExpressionContext_NilSafety(t *testing.T) {
-
 	// This workflow attempts to access error.Message in a success hook
 	// The expression evaluator should handle nil error context gracefully
 	cmd := exec.Command(awfBinary, "validate", "expr-nil-safety")
@@ -224,7 +212,6 @@ func TestExpressionContext_NilSafety(t *testing.T) {
 // TestExpressionContext_BreakWhenWithLoop tests that break_when expressions
 // can use loop namespace to control loop termination.
 func TestExpressionContext_BreakWhenWithLoop(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "expr-break-when")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -238,7 +225,6 @@ func TestExpressionContext_BreakWhenWithLoop(t *testing.T) {
 // TestExpressionContext_MultipleLowercaseErrors tests that workflows with
 // multiple lowercase expression keys report all errors (non-fail-fast).
 func TestExpressionContext_MultipleLowercaseErrors(t *testing.T) {
-
 	cmd := exec.Command(awfBinary, "validate", "expr-multiple-errors")
 	cmd.Env = append(os.Environ(), "AWF_WORKFLOWS_PATH=../fixtures/workflows")
 
@@ -255,7 +241,6 @@ func TestExpressionContext_MultipleLowercaseErrors(t *testing.T) {
 // TestExpressionContext_NoFalsePositives tests that valid workflows with
 // PascalCase expressions and complex conditions don't trigger false positive errors.
 func TestExpressionContext_NoFalsePositives(t *testing.T) {
-
 	// Test with existing valid workflows
 	validWorkflows := []string{
 		"valid-simple",

--- a/tests/integration/expression_validation_functional_test.go
+++ b/tests/integration/expression_validation_functional_test.go
@@ -43,7 +43,6 @@ import (
 // =============================================================================
 
 func TestExpressionValidation_HappyPath_ValidExpressions(t *testing.T) {
-
 	// Given: Real ExprValidator adapter (not mocked)
 	validator := expression.NewExprValidator()
 
@@ -109,7 +108,6 @@ func TestExpressionValidation_HappyPath_ValidExpressions(t *testing.T) {
 // =============================================================================
 
 func TestExpressionValidation_EdgeCases_BoundaryConditions(t *testing.T) {
-
 	validator := expression.NewExprValidator()
 
 	tests := []struct {
@@ -198,7 +196,6 @@ func TestExpressionValidation_EdgeCases_BoundaryConditions(t *testing.T) {
 // =============================================================================
 
 func TestExpressionValidation_ErrorHandling_InvalidSyntax(t *testing.T) {
-
 	validator := expression.NewExprValidator()
 
 	tests := []struct {
@@ -284,7 +281,6 @@ func TestExpressionValidation_ErrorHandling_InvalidSyntax(t *testing.T) {
 // =============================================================================
 
 func TestExpressionValidation_Integration_PortCompliance(t *testing.T) {
-
 	// Given: ExprValidator must implement ports.ExpressionValidator interface
 	var _ ports.ExpressionValidator = (*expression.ExprValidator)(nil)
 
@@ -302,7 +298,6 @@ func TestExpressionValidation_Integration_PortCompliance(t *testing.T) {
 // =============================================================================
 
 func TestExpressionValidation_Integration_ConversationStopConditions(t *testing.T) {
-
 	validator := expression.NewExprValidator()
 
 	// Test cases derived from conversation-stop-condition.yaml fixture
@@ -358,7 +353,6 @@ func TestExpressionValidation_Integration_ConversationStopConditions(t *testing.
 // =============================================================================
 
 func TestExpressionValidation_Integration_ValidatorFactory(t *testing.T) {
-
 	// When: Creating multiple validator instances
 	validator1 := expression.NewExprValidator()
 	validator2 := expression.NewExprValidator()
@@ -379,7 +373,6 @@ func TestExpressionValidation_Integration_ValidatorFactory(t *testing.T) {
 // =============================================================================
 
 func TestExpressionValidation_Integration_ErrorMessageClarity(t *testing.T) {
-
 	validator := expression.NewExprValidator()
 
 	tests := []struct {
@@ -431,7 +424,6 @@ func TestExpressionValidation_Integration_ErrorMessageClarity(t *testing.T) {
 // =============================================================================
 
 func TestExpressionValidation_Integration_ConcurrentValidation(t *testing.T) {
-
 	validator := expression.NewExprValidator()
 
 	// When: Multiple goroutines validate expressions concurrently

--- a/tests/integration/graph_algorithm_refactoring_test.go
+++ b/tests/integration/graph_algorithm_refactoring_test.go
@@ -38,7 +38,6 @@ import (
 // TestDetectCycles_Integration_LinearWorkflow validates that linear workflows
 // (no cycles) are correctly identified as cycle-free.
 func TestDetectCycles_Integration_LinearWorkflow(t *testing.T) {
-
 	steps := map[string]*workflow.Step{
 		"start": {
 			Type:      "command",
@@ -66,7 +65,6 @@ func TestDetectCycles_Integration_LinearWorkflow(t *testing.T) {
 // TestDetectCycles_Integration_ComplexParallelWorkflow validates cycle detection
 // in workflows with parallel branches and multiple paths.
 func TestDetectCycles_Integration_ComplexParallelWorkflow(t *testing.T) {
-
 	steps := map[string]*workflow.Step{
 		"start": {
 			Type:      "command",
@@ -119,7 +117,6 @@ func TestDetectCycles_Integration_ComplexParallelWorkflow(t *testing.T) {
 // TestComputeExecutionOrder_Integration_LinearWorkflow validates that execution
 // order is correctly computed for simple linear workflows.
 func TestComputeExecutionOrder_Integration_LinearWorkflow(t *testing.T) {
-
 	steps := map[string]*workflow.Step{
 		"start": {
 			Type:      "command",
@@ -157,7 +154,6 @@ func TestComputeExecutionOrder_Integration_LinearWorkflow(t *testing.T) {
 // TestComputeExecutionOrder_Integration_ParallelWorkflow validates execution
 // order computation for workflows with parallel branches.
 func TestComputeExecutionOrder_Integration_ParallelWorkflow(t *testing.T) {
-
 	steps := map[string]*workflow.Step{
 		"start": {
 			Type:      "command",
@@ -209,7 +205,6 @@ func TestComputeExecutionOrder_Integration_ParallelWorkflow(t *testing.T) {
 // TestDetectCycles_Integration_MultipleCyclesInGraph validates detection of
 // multiple distinct cycles in a single workflow graph.
 func TestDetectCycles_Integration_MultipleCyclesInGraph(t *testing.T) {
-
 	steps := map[string]*workflow.Step{
 		"start": {
 			Type:      "command",
@@ -254,7 +249,6 @@ func TestDetectCycles_Integration_MultipleCyclesInGraph(t *testing.T) {
 // TestDetectCycles_Integration_SelfLoopCycle validates detection of self-referencing
 // steps (a step that transitions to itself).
 func TestDetectCycles_Integration_SelfLoopCycle(t *testing.T) {
-
 	steps := map[string]*workflow.Step{
 		"start": {
 			Type:      "command",
@@ -279,7 +273,6 @@ func TestDetectCycles_Integration_SelfLoopCycle(t *testing.T) {
 // TestDetectCycles_Integration_DeepNestedCycle validates cycle detection in
 // deeply nested workflow structures (>10 levels).
 func TestDetectCycles_Integration_DeepNestedCycle(t *testing.T) {
-
 	steps := map[string]*workflow.Step{
 		"start":  {Type: "command", OnSuccess: "step1"},
 		"step1":  {Type: "command", OnSuccess: "step2"},
@@ -302,7 +295,6 @@ func TestDetectCycles_Integration_DeepNestedCycle(t *testing.T) {
 // TestComputeExecutionOrder_Integration_EmptyGraph validates handling of
 // empty workflow graphs.
 func TestComputeExecutionOrder_Integration_EmptyGraph(t *testing.T) {
-
 	tests := []struct {
 		name    string
 		steps   map[string]*workflow.Step
@@ -340,7 +332,6 @@ func TestComputeExecutionOrder_Integration_EmptyGraph(t *testing.T) {
 // TestComputeExecutionOrder_Integration_MaxBreadth validates handling of
 // workflows with many parallel branches (stress test for enqueueIfNotVisited).
 func TestComputeExecutionOrder_Integration_MaxBreadth(t *testing.T) {
-
 	// Create a workflow with 20 parallel branches
 	branches := make([]string, 20)
 	steps := make(map[string]*workflow.Step)
@@ -393,7 +384,6 @@ func TestComputeExecutionOrder_Integration_MaxBreadth(t *testing.T) {
 // TestDetectCycles_Integration_InvalidTransitions validates handling of
 // transitions to non-existent states.
 func TestDetectCycles_Integration_InvalidTransitions(t *testing.T) {
-
 	steps := map[string]*workflow.Step{
 		"start": {
 			Type:      "command",
@@ -415,7 +405,6 @@ func TestDetectCycles_Integration_InvalidTransitions(t *testing.T) {
 // TestComputeExecutionOrder_Integration_InvalidInitialState validates handling
 // of non-existent initial states.
 func TestComputeExecutionOrder_Integration_InvalidInitialState(t *testing.T) {
-
 	steps := map[string]*workflow.Step{
 		"start": {
 			Type:      "command",
@@ -435,7 +424,6 @@ func TestComputeExecutionOrder_Integration_InvalidInitialState(t *testing.T) {
 // TestComputeExecutionOrder_Integration_CircularDependencies validates handling
 // of workflows with cycles (which should be caught by DetectCycles first).
 func TestComputeExecutionOrder_Integration_CircularDependencies(t *testing.T) {
-
 	steps := map[string]*workflow.Step{
 		"start": {
 			Type:      "command",
@@ -468,7 +456,6 @@ func TestComputeExecutionOrder_Integration_CircularDependencies(t *testing.T) {
 // TestFullWorkflowValidation_Integration validates that DetectCycles and
 // ComputeExecutionOrder work correctly together for complete workflow validation.
 func TestFullWorkflowValidation_Integration(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		steps        map[string]*workflow.Step
@@ -584,7 +571,6 @@ func TestFullWorkflowValidation_Integration(t *testing.T) {
 // TestBackwardCompatibility_Integration validates that refactored algorithms
 // maintain exact same behavior as before C003 refactoring.
 func TestBackwardCompatibility_Integration(t *testing.T) {
-
 	// This test uses known workflow patterns that existed before C003
 	// to ensure backward compatibility
 	knownWorkflows := []struct {

--- a/tests/integration/history_test.go
+++ b/tests/integration/history_test.go
@@ -67,7 +67,6 @@ func (m *historyMockLogger) WithContext(ctx map[string]any) ports.Logger {
 }
 
 func TestHistoryStore_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	historyPath := filepath.Join(tmpDir, "history.db")
 
@@ -108,7 +107,6 @@ func TestHistoryStore_Integration(t *testing.T) {
 }
 
 func TestHistoryStore_FilterByWorkflowName_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	historyPath := filepath.Join(tmpDir, "history.db")
 
@@ -147,7 +145,6 @@ func TestHistoryStore_FilterByWorkflowName_Integration(t *testing.T) {
 }
 
 func TestHistoryStore_FilterByStatus_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	historyPath := filepath.Join(tmpDir, "history.db")
 
@@ -194,7 +191,6 @@ func TestHistoryStore_FilterByStatus_Integration(t *testing.T) {
 }
 
 func TestHistoryStore_FilterByDateRange_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	historyPath := filepath.Join(tmpDir, "history.db")
 
@@ -239,7 +235,6 @@ func TestHistoryStore_FilterByDateRange_Integration(t *testing.T) {
 }
 
 func TestHistoryStore_Cleanup_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	historyPath := filepath.Join(tmpDir, "history.db")
 
@@ -293,7 +288,6 @@ func TestHistoryStore_Cleanup_Integration(t *testing.T) {
 }
 
 func TestHistoryStore_Persistence_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	historyPath := filepath.Join(tmpDir, "history.db")
 	ctx := context.Background()
@@ -343,7 +337,6 @@ func TestHistoryStore_Persistence_Integration(t *testing.T) {
 }
 
 func TestHistoryService_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	historyPath := filepath.Join(tmpDir, "history.db")
 
@@ -384,7 +377,6 @@ func TestHistoryService_Integration(t *testing.T) {
 }
 
 func TestHistoryService_CleanupOnInit_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	historyPath := filepath.Join(tmpDir, "history.db")
 	ctx := context.Background()
@@ -443,7 +435,6 @@ func TestHistoryService_CleanupOnInit_Integration(t *testing.T) {
 }
 
 func TestWorkflowExecution_RecordsHistory_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	workflowDir := filepath.Join(tmpDir, "workflows")
 	historyPath := filepath.Join(tmpDir, "history.db")
@@ -499,7 +490,6 @@ states:
 }
 
 func TestHistoryStore_CombinedFilters_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	historyPath := filepath.Join(tmpDir, "history.db")
 
@@ -581,7 +571,6 @@ func TestHistoryStore_CombinedFilters_Integration(t *testing.T) {
 }
 
 func TestHistoryStore_StatsWithFilters_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	historyPath := filepath.Join(tmpDir, "history.db")
 

--- a/tests/integration/hooks_test.go
+++ b/tests/integration/hooks_test.go
@@ -36,7 +36,6 @@ import (
 // Feature: C011 - Task T004
 // Strategy: Run workflow with hooks writing to log file, verify order
 func TestHooks_WorkflowStartEnd_Integration(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowFile string
@@ -129,7 +128,6 @@ func TestHooks_WorkflowStartEnd_Integration(t *testing.T) {
 // Feature: C011 - Task T005
 // Strategy: Run workflow that fails, verify workflow_error hook receives error context
 func TestHooks_WorkflowError_Integration(t *testing.T) {
-
 	tests := []struct {
 		name            string
 		workflowYAML    string // Inline YAML for custom error scenarios
@@ -229,7 +227,6 @@ states:
 // Feature: C011 - Task T005
 // Strategy: Run workflow with step hooks, verify pre executes before command, post after
 func TestHooks_StepPrePost_Integration(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowFile string
@@ -317,7 +314,6 @@ func TestHooks_StepPrePost_Integration(t *testing.T) {
 // Feature: C011 - Task T006
 // Strategy: Run workflow with failing hook, verify workflow aborts and main command doesn't execute
 func TestHooks_FailurePropagation_Integration(t *testing.T) {
-
 	tests := []struct {
 		name               string
 		workflowFile       string
@@ -406,7 +402,6 @@ func TestHooks_FailurePropagation_Integration(t *testing.T) {
 // Feature: C011 - Task T006
 // Strategy: Run workflow with variables in hooks, verify {{workflow.id}}, {{inputs.x}}, {{states.y.output}} interpolated
 func TestHooks_VariableInterpolation_Integration(t *testing.T) {
-
 	tests := []struct {
 		name            string
 		workflowFile    string

--- a/tests/integration/input_collection_test.go
+++ b/tests/integration/input_collection_test.go
@@ -39,7 +39,6 @@ import (
 // When: The CLI detects missing required parameters
 // Then: It prompts me interactively for each missing required input
 func TestInputCollection_PromptForMissingRequired_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -75,7 +74,6 @@ func TestInputCollection_PromptForMissingRequired_Integration(t *testing.T) {
 // When: I am prompted
 // Then: I see the available enum options and can select one
 func TestInputCollection_DisplayEnumOptions_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -112,7 +110,6 @@ func TestInputCollection_DisplayEnumOptions_Integration(t *testing.T) {
 // When: I submit
 // Then: I see an error message and the prompt repeats
 func TestInputCollection_InvalidEnumRetry_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -146,7 +143,6 @@ func TestInputCollection_InvalidEnumRetry_Integration(t *testing.T) {
 // When: I complete all prompts
 // Then: The command executes with the collected values
 func TestInputCollection_ExecuteWithCollectedValues_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -183,7 +179,6 @@ func TestInputCollection_ExecuteWithCollectedValues_Integration(t *testing.T) {
 // When: I press Enter without providing a value
 // Then: The prompt accepts the empty input and moves to the next field
 func TestInputCollection_SkipOptionalInput_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -220,7 +215,6 @@ func TestInputCollection_SkipOptionalInput_Integration(t *testing.T) {
 // When: I skip it
 // Then: The default value is used
 func TestInputCollection_UseDefaultValue_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -261,7 +255,6 @@ func TestInputCollection_UseDefaultValue_Integration(t *testing.T) {
 // When: I submit
 // Then: I see a specific error message explaining the constraint
 func TestInputCollection_ValidationErrorMessage_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -295,7 +288,6 @@ func TestInputCollection_ValidationErrorMessage_Integration(t *testing.T) {
 // When: I provide a corrected value
 // Then: The prompt accepts it and continues
 func TestInputCollection_ErrorRecovery_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -332,7 +324,6 @@ func TestInputCollection_ErrorRecovery_Integration(t *testing.T) {
 // When: I press Ctrl+C
 // Then: The command exits gracefully
 func TestInputCollection_GracefulCancellation_Integration(t *testing.T) {
-
 	t.Skip("Ctrl+C simulation requires signal handling, testing via manual QA")
 
 	// Note: This test is difficult to automate because Ctrl+C sends SIGINT
@@ -349,7 +340,6 @@ func TestInputCollection_GracefulCancellation_Integration(t *testing.T) {
 
 // Test non-interactive stdin (no TTY) with missing inputs
 func TestInputCollection_NonInteractiveStdin_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -377,7 +367,6 @@ func TestInputCollection_NonInteractiveStdin_Integration(t *testing.T) {
 
 // Test all inputs provided via flags (no prompting needed)
 func TestInputCollection_AllInputsProvided_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -411,7 +400,6 @@ func TestInputCollection_AllInputsProvided_Integration(t *testing.T) {
 
 // Test partial inputs provided (some via flags, some prompts needed)
 func TestInputCollection_PartialInputsProvided_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()

--- a/tests/integration/input_validation_functional_test.go
+++ b/tests/integration/input_validation_functional_test.go
@@ -34,7 +34,6 @@ import (
 // (pattern, enum, numeric) work correctly through the full workflow
 // execution pipeline.
 func TestInputValidation_HappyPath(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowYAML string
@@ -285,7 +284,6 @@ states:
 
 // TestInputValidation_EdgeCases tests edge cases for input validation.
 func TestInputValidation_EdgeCases(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowYAML string

--- a/tests/integration/input_validation_test.go
+++ b/tests/integration/input_validation_test.go
@@ -35,7 +35,6 @@ import (
 // Feature: C011 - Component: input_validation_tests
 // Strategy: Test valid and invalid pattern matches
 func TestInputValidation_PatternMatch_Integration(t *testing.T) {
-
 	tests := []struct {
 		name      string
 		workflow  string
@@ -124,7 +123,6 @@ func TestInputValidation_PatternMatch_Integration(t *testing.T) {
 // Feature: C011 - Component: input_validation_tests
 // Strategy: Test values in and out of allowed set
 func TestInputValidation_EnumAllowedValues_Integration(t *testing.T) {
-
 	tests := []struct {
 		name      string
 		workflow  string
@@ -213,7 +211,6 @@ func TestInputValidation_EnumAllowedValues_Integration(t *testing.T) {
 // Feature: C011 - Component: input_validation_tests
 // Strategy: Test values within and outside bounds
 func TestInputValidation_NumericMinMax_Integration(t *testing.T) {
-
 	tests := []struct {
 		name      string
 		workflow  string
@@ -310,7 +307,6 @@ func TestInputValidation_NumericMinMax_Integration(t *testing.T) {
 // Feature: C011 - Component: input_validation_tests
 // Strategy: Test inputs that must satisfy multiple constraints
 func TestInputValidation_CombinedRules_Integration(t *testing.T) {
-
 	tests := []struct {
 		name      string
 		workflow  string
@@ -405,7 +401,6 @@ func TestInputValidation_CombinedRules_Integration(t *testing.T) {
 // Feature: C011 - Component: input_validation_tests
 // Strategy: Validate error messages include field name, rule type, and constraint
 func TestInputValidation_ErrorMessages_Integration(t *testing.T) {
-
 	tests := []struct {
 		name        string
 		workflow    string

--- a/tests/integration/interactive_test.go
+++ b/tests/integration/interactive_test.go
@@ -35,7 +35,6 @@ import (
 // -----------------------------------------------------------------------------
 
 func TestInteractive_ContinueThroughAllSteps_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -64,7 +63,6 @@ func TestInteractive_ContinueThroughAllSteps_Integration(t *testing.T) {
 }
 
 func TestInteractive_ShowsStepDetails_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -92,7 +90,6 @@ func TestInteractive_ShowsStepDetails_Integration(t *testing.T) {
 }
 
 func TestInteractive_ShowsStepResult_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -119,7 +116,6 @@ func TestInteractive_ShowsStepResult_Integration(t *testing.T) {
 }
 
 func TestInteractive_ShowsResolvedCommand_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -148,7 +144,6 @@ func TestInteractive_ShowsResolvedCommand_Integration(t *testing.T) {
 }
 
 func TestInteractive_ShowsTransitions_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -176,7 +171,6 @@ func TestInteractive_ShowsTransitions_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestInteractive_AbortStopsExecution_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -202,7 +196,6 @@ func TestInteractive_AbortStopsExecution_Integration(t *testing.T) {
 }
 
 func TestInteractive_AbortAfterFirstStep_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -230,7 +223,6 @@ func TestInteractive_AbortAfterFirstStep_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestInteractive_SkipJumpsToNextStep_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -257,7 +249,6 @@ func TestInteractive_SkipJumpsToNextStep_Integration(t *testing.T) {
 }
 
 func TestInteractive_SkipMultipleSteps_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -286,7 +277,6 @@ func TestInteractive_SkipMultipleSteps_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestInteractive_InspectShowsContext_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -317,7 +307,6 @@ func TestInteractive_InspectShowsContext_Integration(t *testing.T) {
 }
 
 func TestInteractive_InspectShowsStatesAfterExecution_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -341,7 +330,6 @@ func TestInteractive_InspectShowsStatesAfterExecution_Integration(t *testing.T) 
 }
 
 func TestInteractive_MultipleInspects_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -370,7 +358,6 @@ func TestInteractive_MultipleInspects_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestInteractive_EditModifiesInput_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -399,7 +386,6 @@ func TestInteractive_EditModifiesInput_Integration(t *testing.T) {
 }
 
 func TestInteractive_EditShowsCurrentValue_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -427,7 +413,6 @@ func TestInteractive_EditShowsCurrentValue_Integration(t *testing.T) {
 }
 
 func TestInteractive_EditEmptyKeepsCurrentValue_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -459,7 +444,6 @@ func TestInteractive_EditEmptyKeepsCurrentValue_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestInteractive_RetryReExecutesStep_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -487,7 +471,6 @@ func TestInteractive_RetryReExecutesStep_Integration(t *testing.T) {
 }
 
 func TestInteractive_RetryNotAvailableOnFirstPrompt_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -515,7 +498,6 @@ func TestInteractive_RetryNotAvailableOnFirstPrompt_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestInteractive_BreakpointPausesOnlyAtSpecified_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -546,7 +528,6 @@ func TestInteractive_BreakpointPausesOnlyAtSpecified_Integration(t *testing.T) {
 }
 
 func TestInteractive_MultipleBreakpoints_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -574,7 +555,6 @@ func TestInteractive_MultipleBreakpoints_Integration(t *testing.T) {
 }
 
 func TestInteractive_BreakpointWithSeparateFlags_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -607,7 +587,6 @@ func TestInteractive_BreakpointWithSeparateFlags_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestInteractive_InvalidInputRepromptsUser_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -631,7 +610,6 @@ func TestInteractive_InvalidInputRepromptsUser_Integration(t *testing.T) {
 }
 
 func TestInteractive_MultipleInvalidInputs_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -656,7 +634,6 @@ func TestInteractive_MultipleInvalidInputs_Integration(t *testing.T) {
 }
 
 func TestInteractive_EmptyInputRepromptsUser_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -679,7 +656,6 @@ func TestInteractive_EmptyInputRepromptsUser_Integration(t *testing.T) {
 }
 
 func TestInteractive_CaseInsensitiveActions_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -706,7 +682,6 @@ func TestInteractive_CaseInsensitiveActions_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestInteractive_WorkflowNotFound_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -724,7 +699,6 @@ func TestInteractive_WorkflowNotFound_Integration(t *testing.T) {
 }
 
 func TestInteractive_InvalidBreakpoint_StillRuns_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -755,7 +729,6 @@ func TestInteractive_InvalidBreakpoint_StillRuns_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestInteractive_AbortPersistsState_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -783,7 +756,6 @@ func TestInteractive_AbortPersistsState_Integration(t *testing.T) {
 }
 
 func TestInteractive_CompletionPersistsState_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -813,7 +785,6 @@ func TestInteractive_CompletionPersistsState_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestInteractive_WithInputs_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -842,7 +813,6 @@ func TestInteractive_WithInputs_Integration(t *testing.T) {
 }
 
 func TestInteractive_ParallelWorkflow_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -866,7 +836,6 @@ func TestInteractive_ParallelWorkflow_Integration(t *testing.T) {
 }
 
 func TestInteractive_LoopWorkflow_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -890,7 +859,6 @@ func TestInteractive_LoopWorkflow_Integration(t *testing.T) {
 }
 
 func TestInteractive_SimpleWorkflow_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -920,7 +888,6 @@ func TestInteractive_SimpleWorkflow_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestInteractive_ActionCombinations_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tests := []struct {
@@ -992,7 +959,6 @@ func TestInteractive_ActionCombinations_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestInteractive_DoesNotModifyWorkflowPath_Integration(t *testing.T) {
-
 	originalPath := os.Getenv("AWF_WORKFLOWS_PATH")
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
@@ -1023,7 +989,6 @@ func TestInteractive_DoesNotModifyWorkflowPath_Integration(t *testing.T) {
 }
 
 func TestInteractive_CanRunMultipleTimes_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	// Run interactive mode multiple times to ensure no state leaks
@@ -1049,7 +1014,6 @@ func TestInteractive_CanRunMultipleTimes_Integration(t *testing.T) {
 }
 
 func TestInteractive_FlagOrderDoesNotMatter_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -1081,7 +1045,6 @@ func TestInteractive_FlagOrderDoesNotMatter_Integration(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestInteractive_ShowsCorrectStepCount_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()
@@ -1108,7 +1071,6 @@ func TestInteractive_ShowsCorrectStepCount_Integration(t *testing.T) {
 }
 
 func TestInteractive_ShowsStepTypeForDifferentSteps_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	tmpDir := t.TempDir()

--- a/tests/integration/loop_dynamic_test.go
+++ b/tests/integration/loop_dynamic_test.go
@@ -25,7 +25,6 @@ import (
 
 // TestDynamicMaxIterations_FromInput tests US1: max_iterations from input variable
 func TestDynamicMaxIterations_FromInput(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "output.log")
 
@@ -90,7 +89,6 @@ states:
 
 // TestDynamicMaxIterations_FromInputDifferentValues tests various limit values
 func TestDynamicMaxIterations_FromInputDifferentValues(t *testing.T) {
-
 	tests := []struct {
 		name          string
 		limit         int
@@ -164,7 +162,6 @@ states:
 
 // TestDynamicMaxIterations_FromEnv tests US1: max_iterations from environment variable
 func TestDynamicMaxIterations_FromEnv(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "output.log")
 
@@ -226,7 +223,6 @@ states:
 
 // TestDynamicMaxIterations_Arithmetic tests US3: arithmetic expressions in max_iterations
 func TestDynamicMaxIterations_Arithmetic(t *testing.T) {
-
 	tests := []struct {
 		name          string
 		expression    string
@@ -305,7 +301,6 @@ states:
 
 // TestDynamicMaxIterations_MissingVariable tests error handling for missing variables
 func TestDynamicMaxIterations_MissingVariable(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	wfYAML := `name: missing-var
@@ -355,7 +350,6 @@ states:
 
 // TestDynamicMaxIterations_NonInteger tests error handling for non-integer result
 func TestDynamicMaxIterations_NonInteger(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	wfYAML := `name: non-integer
@@ -414,7 +408,6 @@ states:
 
 // TestDynamicMaxIterations_ZeroValue tests error handling for zero value
 func TestDynamicMaxIterations_ZeroValue(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	wfYAML := `name: zero-value
@@ -473,7 +466,6 @@ states:
 
 // TestDynamicMaxIterations_NegativeValue tests error handling for negative value
 func TestDynamicMaxIterations_NegativeValue(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	wfYAML := `name: negative-value
@@ -532,7 +524,6 @@ states:
 
 // TestDynamicMaxIterations_ExceedsMaxBound tests error handling when exceeding max allowed
 func TestDynamicMaxIterations_ExceedsMaxBound(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	wfYAML := `name: exceeds-max
@@ -592,7 +583,6 @@ states:
 
 // TestDynamicMaxIterations_BackwardCompatibility tests that static integer values still work
 func TestDynamicMaxIterations_BackwardCompatibility(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "output.log")
 
@@ -651,7 +641,6 @@ states:
 
 // TestDynamicMaxIterations_WithWhileLoop tests dynamic max_iterations with while loops
 func TestDynamicMaxIterations_WithWhileLoop(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "output.log")
 
@@ -714,7 +703,6 @@ states:
 
 // TestDynamicMaxIterations_UsingFixtureFiles tests with actual fixture YAML files
 func TestDynamicMaxIterations_UsingFixtureFiles(t *testing.T) {
-
 	// Path relative to tests/integration/ where the test runs
 	fixturesDir := "../fixtures/workflows"
 
@@ -787,7 +775,6 @@ func TestDynamicMaxIterations_UsingFixtureFiles(t *testing.T) {
 
 // TestDynamicLoopCondition_WithStepOutput tests US2: loop conditions referencing step outputs
 func TestDynamicLoopCondition_WithStepOutput(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "output.log")
 	counterFile := filepath.Join(tmpDir, "counter")
@@ -871,7 +858,6 @@ states:
 
 // TestDynamicLoopCondition_UntilCondition tests until condition with interpolated variables
 func TestDynamicLoopCondition_UntilCondition(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "output.log")
 	statusFile := filepath.Join(tmpDir, "status")
@@ -949,7 +935,6 @@ states:
 
 // TestDynamicMaxIterations_StringInputResolvesToInteger tests string input that parses to int
 func TestDynamicMaxIterations_StringInputResolvesToInteger(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "output.log")
 
@@ -1011,7 +996,6 @@ states:
 
 // TestDynamicMaxIterations_FloatInputTruncated tests float input is handled appropriately
 func TestDynamicMaxIterations_FloatInputTruncated(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "output.log")
 
@@ -1079,7 +1063,6 @@ states:
 
 // TestDynamicMaxIterations_ComplexArithmetic tests complex arithmetic expressions
 func TestDynamicMaxIterations_ComplexArithmetic(t *testing.T) {
-
 	tests := []struct {
 		name          string
 		expression    string
@@ -1179,7 +1162,6 @@ states:
 
 // TestDynamicMaxIterations_DivisionByZero tests error handling for division by zero
 func TestDynamicMaxIterations_DivisionByZero(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	wfYAML := `name: div-zero
@@ -1248,7 +1230,6 @@ states:
 
 // TestDynamicMaxIterations_ValidationWarning tests US4: awf validate warns about undefined variables
 func TestDynamicMaxIterations_ValidationWarning(t *testing.T) {
-
 	// Use the invalid fixture with undefined variable
 	fixturesDir := "../fixtures/workflows"
 
@@ -1280,7 +1261,6 @@ func TestDynamicMaxIterations_ValidationWarning(t *testing.T) {
 
 // TestDynamicMaxIterations_ValidationPasses tests US4: valid loop expressions pass validation
 func TestDynamicMaxIterations_ValidationPasses(t *testing.T) {
-
 	fixturesDir := "../fixtures/workflows"
 
 	tests := []struct {
@@ -1318,7 +1298,6 @@ func TestDynamicMaxIterations_ValidationPasses(t *testing.T) {
 
 // TestDynamicMaxIterations_WhitespaceHandling tests edge case: whitespace in expressions
 func TestDynamicMaxIterations_WhitespaceHandling(t *testing.T) {
-
 	tests := []struct {
 		name          string
 		expression    string
@@ -1404,7 +1383,6 @@ states:
 
 // TestDynamicMaxIterations_EmptyExpression tests edge case: empty expression string
 func TestDynamicMaxIterations_EmptyExpression(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Workflow with empty max_iterations expression
@@ -1466,7 +1444,6 @@ states:
 
 // TestDynamicMaxIterations_NestedTemplates tests edge case: nested template expressions
 func TestDynamicMaxIterations_NestedTemplates(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "output.log")
 
@@ -1533,7 +1510,6 @@ states:
 // AC1: {{.loop.Item}} passed to call_workflow produces valid JSON
 // AC2: Nested objects and arrays properly serialized
 func TestForEachLoop_WithObjectItems_Integration(t *testing.T) {
-
 	// Given: A parent workflow that iterates over JSON objects and passes them to a child workflow
 	fixturesDir := "../fixtures/workflows"
 
@@ -1576,7 +1552,6 @@ func TestForEachLoop_WithObjectItems_Integration(t *testing.T) {
 
 // TestForEachLoop_WithNestedStructures tests AC2: nested objects and arrays properly serialized
 func TestForEachLoop_WithNestedStructures(t *testing.T) {
-
 	// Given: A workflow with deeply nested JSON structures
 	fixturesDir := "../fixtures/workflows"
 
@@ -1615,7 +1590,6 @@ func TestForEachLoop_WithNestedStructures(t *testing.T) {
 
 // TestForEachLoop_MixedPrimitiveAndComplex tests mixed primitive and complex types in loop
 func TestForEachLoop_MixedPrimitiveAndComplex(t *testing.T) {
-
 	// Given: A workflow that can handle both primitive and complex types
 	tmpDir := t.TempDir()
 	outputFile := filepath.Join(tmpDir, "results.txt")
@@ -1694,7 +1668,6 @@ states:
 
 // TestForEachLoop_EmptyObjectsAndArrays tests edge case: empty objects and arrays
 func TestForEachLoop_EmptyObjectsAndArrays(t *testing.T) {
-
 	// Given: Workflow with empty objects and arrays
 	fixturesDir := "../fixtures/workflows"
 
@@ -1731,7 +1704,6 @@ func TestForEachLoop_EmptyObjectsAndArrays(t *testing.T) {
 
 // TestForEachLoop_UnicodeAndSpecialChars tests edge case: unicode and special characters
 func TestForEachLoop_UnicodeAndSpecialChars(t *testing.T) {
-
 	// Given: Workflow with unicode and special characters
 	fixturesDir := "../fixtures/workflows"
 
@@ -1768,7 +1740,6 @@ func TestForEachLoop_UnicodeAndSpecialChars(t *testing.T) {
 
 // TestForEachLoop_BackwardCompatibility_StringItems tests AC4: existing workflows work unchanged
 func TestForEachLoop_BackwardCompatibility_StringItems(t *testing.T) {
-
 	// Given: A workflow with simple string items (existing behavior)
 	tmpDir := t.TempDir()
 	outputFile := filepath.Join(tmpDir, "output.txt")

--- a/tests/integration/loop_json_child_test.go
+++ b/tests/integration/loop_json_child_test.go
@@ -28,7 +28,6 @@ import (
 // Item: T010
 // Feature: F047
 func TestLoopJSONChild_HappyPath_ValidJSONInput(t *testing.T) {
-
 	// Given: Child workflow fixture exists
 	fixturesDir := "../fixtures/workflows"
 	repo := repository.NewYAMLRepository(fixturesDir)
@@ -72,7 +71,6 @@ func TestLoopJSONChild_HappyPath_ValidJSONInput(t *testing.T) {
 // Item: T010
 // Feature: F047
 func TestLoopJSONChild_HappyPath_NestedJSON(t *testing.T) {
-
 	// Given: Child workflow fixture
 	fixturesDir := "../fixtures/workflows"
 	repo := repository.NewYAMLRepository(fixturesDir)
@@ -114,7 +112,6 @@ func TestLoopJSONChild_HappyPath_NestedJSON(t *testing.T) {
 // Item: T010
 // Feature: F047
 func TestLoopJSONChild_HappyPath_JSONArray(t *testing.T) {
-
 	// Given: Child workflow fixture
 	fixturesDir := "../fixtures/workflows"
 	repo := repository.NewYAMLRepository(fixturesDir)
@@ -155,7 +152,6 @@ func TestLoopJSONChild_HappyPath_JSONArray(t *testing.T) {
 // Item: T010
 // Feature: F047
 func TestLoopJSONChild_EdgeCase_EmptyFields(t *testing.T) {
-
 	// Given: Child workflow fixture
 	fixturesDir := "../fixtures/workflows"
 	repo := repository.NewYAMLRepository(fixturesDir)
@@ -196,7 +192,6 @@ func TestLoopJSONChild_EdgeCase_EmptyFields(t *testing.T) {
 // Item: T010
 // Feature: F047
 func TestLoopJSONChild_EdgeCase_UnicodeCharacters(t *testing.T) {
-
 	// Given: Child workflow fixture
 	fixturesDir := "../fixtures/workflows"
 	repo := repository.NewYAMLRepository(fixturesDir)
@@ -236,7 +231,6 @@ func TestLoopJSONChild_EdgeCase_UnicodeCharacters(t *testing.T) {
 // Item: T010
 // Feature: F047
 func TestLoopJSONChild_EdgeCase_MinimalJSON(t *testing.T) {
-
 	// Given: Child workflow fixture
 	fixturesDir := "../fixtures/workflows"
 	repo := repository.NewYAMLRepository(fixturesDir)
@@ -277,7 +271,6 @@ func TestLoopJSONChild_EdgeCase_MinimalJSON(t *testing.T) {
 // Item: T010
 // Feature: F047
 func TestLoopJSONChild_ErrorHandling_GoMapFormat(t *testing.T) {
-
 	// Given: Child workflow fixture
 	fixturesDir := "../fixtures/workflows"
 	repo := repository.NewYAMLRepository(fixturesDir)
@@ -321,7 +314,6 @@ func TestLoopJSONChild_ErrorHandling_GoMapFormat(t *testing.T) {
 // Item: T010
 // Feature: F047
 func TestLoopJSONChild_ErrorHandling_InvalidJSON(t *testing.T) {
-
 	// Given: Child workflow fixture
 	fixturesDir := "../fixtures/workflows"
 	repo := repository.NewYAMLRepository(fixturesDir)
@@ -376,7 +368,6 @@ func TestLoopJSONChild_ErrorHandling_InvalidJSON(t *testing.T) {
 // Item: T010
 // Feature: F047
 func TestLoopJSONChild_ErrorHandling_MissingRequiredInput(t *testing.T) {
-
 	// Given: Child workflow fixture
 	fixturesDir := "../fixtures/workflows"
 	repo := repository.NewYAMLRepository(fixturesDir)
@@ -415,7 +406,6 @@ func TestLoopJSONChild_ErrorHandling_MissingRequiredInput(t *testing.T) {
 // Item: T010
 // Feature: F047
 func TestLoopJSONChild_EdgeCase_IndexParameter(t *testing.T) {
-
 	// Given: Child workflow fixture
 	fixturesDir := "../fixtures/workflows"
 	repo := repository.NewYAMLRepository(fixturesDir)
@@ -469,7 +459,6 @@ func TestLoopJSONChild_EdgeCase_IndexParameter(t *testing.T) {
 // Item: T010
 // Feature: F047
 func TestLoopJSONChild_Integration_LoadsAndValidates(t *testing.T) {
-
 	// Given: Fixtures directory
 	fixturesDir := "../fixtures/workflows"
 	repo := repository.NewYAMLRepository(fixturesDir)

--- a/tests/integration/loop_json_serialization_test.go
+++ b/tests/integration/loop_json_serialization_test.go
@@ -36,7 +36,6 @@ import (
 // for_each loop passing JSON objects to call_workflow via {{.loop.Item}}
 // Feature: F047
 func TestF047_HappyPath_CallWorkflowWithJSONObjects(t *testing.T) {
-
 	// Given: Parent workflow iterates over JSON objects and calls child workflow
 	tmpDir := t.TempDir()
 	outputDir := filepath.Join(tmpDir, "output")
@@ -137,7 +136,6 @@ states:
 // Complex nested structures serialize correctly
 // Feature: F047
 func TestF047_HappyPath_NestedObjectsAndArrays(t *testing.T) {
-
 	// Given: Workflow with deeply nested JSON structures
 	tmpDir := t.TempDir()
 
@@ -218,7 +216,6 @@ states:
 // TestF047_EdgeCase_EmptyObjectsAndArrays tests edge cases with empty structures
 // Feature: F047
 func TestF047_EdgeCase_EmptyObjectsAndArrays(t *testing.T) {
-
 	// Given: Items with empty objects and arrays
 	tmpDir := t.TempDir()
 
@@ -277,7 +274,6 @@ states:
 // TestF047_EdgeCase_PrimitiveTypes tests AC4: primitives pass through unchanged
 // Feature: F047
 func TestF047_EdgeCase_PrimitiveTypes(t *testing.T) {
-
 	// Given: Loop items are primitive types (not objects)
 	tmpDir := t.TempDir()
 	outputFile := filepath.Join(tmpDir, "output.txt")
@@ -368,7 +364,6 @@ states:
 // TestF047_EdgeCase_UnicodeAndSpecialCharacters tests unicode handling
 // Feature: F047
 func TestF047_EdgeCase_UnicodeAndSpecialCharacters(t *testing.T) {
-
 	// Given: Items with unicode characters
 	tmpDir := t.TempDir()
 
@@ -434,7 +429,6 @@ states:
 // TestF047_Integration_RealWorldWorkflowPattern tests a realistic scenario
 // Feature: F047
 func TestF047_Integration_RealWorldWorkflowPattern(t *testing.T) {
-
 	// Given: A realistic PR review workflow pattern
 	tmpDir := t.TempDir()
 	outputFile := filepath.Join(tmpDir, "review-results.txt")
@@ -536,7 +530,6 @@ states:
 // Workflows created before F047 continue to work unchanged
 // Feature: F047
 func TestF047_BackwardCompatibility_ExistingWorkflows(t *testing.T) {
-
 	// Given: Pre-F047 workflows with simple string/number items
 	tmpDir := t.TempDir()
 	outputFile := filepath.Join(tmpDir, "output.txt")

--- a/tests/integration/loop_test.go
+++ b/tests/integration/loop_test.go
@@ -25,7 +25,6 @@ import (
 // =============================================================================
 
 func TestForEachLoop_Simple_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "output.log")
 
@@ -80,7 +79,6 @@ states:
 }
 
 func TestForEachLoop_WithIndex_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "index.log")
 
@@ -134,7 +132,6 @@ states:
 }
 
 func TestForEachLoop_WithBreak_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "break.log")
 
@@ -192,7 +189,6 @@ states:
 }
 
 func TestForEachLoop_MultipleBodySteps_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "multi.log")
 
@@ -261,7 +257,6 @@ states:
 // =============================================================================
 
 func TestWhileLoop_Simple_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	counterFile := filepath.Join(tmpDir, "counter")
 
@@ -326,7 +321,6 @@ states:
 }
 
 func TestWhileLoop_MaxIterations_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "max.log")
 
@@ -380,7 +374,6 @@ states:
 }
 
 func TestWhileLoop_WithBreak_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "break.log")
 
@@ -451,7 +444,6 @@ states:
 // =============================================================================
 
 func TestForEachLoop_StepError_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "error.log")
 
@@ -517,7 +509,6 @@ states:
 // =============================================================================
 
 func TestLoopFixtures_Integration(t *testing.T) {
-
 	fixturesPath := "../fixtures/workflows"
 
 	// Check if loop fixtures exist
@@ -566,7 +557,6 @@ func TestLoopFixtures_Integration(t *testing.T) {
 // =============================================================================
 
 func TestForEachLoop_WithIndex1_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "index1.log")
 
@@ -620,7 +610,6 @@ states:
 }
 
 func TestForEachLoop_Index1WithLength_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "progress.log")
 
@@ -818,7 +807,6 @@ func (m *mockLoggerWithCapture) WithContext(ctx map[string]any) ports.Logger {
 // TestF042_LoopAllVariables_Integration verifies all loop context variables
 // work correctly in step command templates.
 func TestF042_LoopAllVariables_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "all_vars.log")
 
@@ -880,7 +868,6 @@ idx=2 idx1=3 item=gamma first=false last=true len=3
 // TestF042_LoopFirst_ConditionalLogic_Integration tests using loop.First
 // to perform special handling on the first iteration.
 func TestF042_LoopFirst_ConditionalLogic_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "first.log")
 
@@ -948,7 +935,6 @@ DATA: row3
 // TestF042_LoopLast_ConditionalLogic_Integration tests using loop.Last
 // to perform special handling on the last iteration.
 func TestF042_LoopLast_ConditionalLogic_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "last.log")
 
@@ -1016,7 +1002,6 @@ item3
 // TestF042_LoopIndex1_ProgressOutput_Integration tests using Index1
 // for human-readable progress output.
 func TestF042_LoopIndex1_ProgressOutput_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "progress.log")
 
@@ -1080,7 +1065,6 @@ states:
 // TestF042_LoopContextClearedAfterCompletion_Integration verifies that
 // loop context is cleared after the loop completes.
 func TestF042_LoopContextClearedAfterCompletion_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "cleared.log")
 
@@ -1148,7 +1132,6 @@ AFTER LOOP: workflow=foreach-cleared
 
 // TestF042_LoopSingleItem_EdgeCase_Integration tests edge case with single item.
 func TestF042_LoopSingleItem_EdgeCase_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "single.log")
 
@@ -1207,7 +1190,6 @@ states:
 // TestF042_WhileLoopIndex_Integration tests loop variables in while loops.
 // While loops have Length=-1 since count is unknown upfront.
 func TestF042_WhileLoopIndex_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "while_idx.log")
 	counterFile := filepath.Join(tmpDir, "counter")
@@ -1281,7 +1263,6 @@ iteration=3 first=false length=-1
 
 // TestF042_LoopWithNumericItems_Integration tests loop with numeric items.
 func TestF042_LoopWithNumericItems_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "numeric.log")
 
@@ -1343,7 +1324,6 @@ Position 4: value=40 doubled=80
 
 // TestF042_LoopWithInputItems_Integration tests loop items from workflow inputs.
 func TestF042_LoopWithInputItems_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "input_items.log")
 
@@ -1413,7 +1393,6 @@ File 3/3: test.go
 // TestF042_LoopWithStatesReference_Integration tests using loop variables
 // combined with states reference to access previous step outputs.
 func TestF042_LoopWithStatesReference_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "states_ref.log")
 
@@ -1484,7 +1463,6 @@ Item 3: c | init=INITIALIZED
 
 // TestF042_EmptyLoop_EdgeCase_Integration tests edge case with empty items array.
 func TestF042_EmptyLoop_EdgeCase_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "empty.log")
 
@@ -1565,7 +1543,6 @@ FINISHED
 func TestF042_NestedForEachLoops_Integration(t *testing.T) {
 	// F043 implementation enables nested loops
 
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "nested.log")
 
@@ -1645,7 +1622,6 @@ OUTER[2/2]: row2 (first=false, last=true)
 // context is properly restored after inner loop completes.
 func TestF042_NestedLoops_ContextRestored_Integration(t *testing.T) {
 	// F043 implementation enables nested loops
-
 
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "context_restore.log")
@@ -1731,7 +1707,6 @@ AFTER: outer=B idx=1 (context restored)
 // a for_each loop.
 func TestF042_NestedWhileInForEach_Integration(t *testing.T) {
 	// F043 implementation enables nested loops
-
 
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "nested_while.log")
@@ -1821,7 +1796,6 @@ states:
 // TestF042_TripleNestedLoops_Integration tests three levels of nested loops.
 func TestF042_TripleNestedLoops_Integration(t *testing.T) {
 	// F043 implementation enables nested loops
-
 
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "triple.log")
@@ -1919,7 +1893,6 @@ CATEGORY: cat2
 // TestF042_LoopIndexZeroBasedVsOneBased_Integration explicitly compares
 // Index (0-based) vs Index1 (1-based) to ensure they differ correctly.
 func TestF042_LoopIndexZeroBasedVsOneBased_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "compare.log")
 
@@ -1989,7 +1962,6 @@ states:
 // outer loop context via {{.loop.Parent.*}} syntax.
 func TestF043_NestedLoops_ParentAccess_Integration(t *testing.T) {
 	// F043 implementation enables nested loops
-
 
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "parent_access.log")
@@ -2062,7 +2034,6 @@ outer=B inner=2
 func TestF043_NestedLoops_ParentIndexAccess_Integration(t *testing.T) {
 	// F043 implementation enables nested loops
 
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "parent_index.log")
 
@@ -2134,7 +2105,6 @@ states:
 // loop context via {{.loop.Parent.Parent.*}} for 3-level nesting.
 func TestF043_NestedLoops_DeepParentChain_Integration(t *testing.T) {
 	// F043 implementation enables nested loops
-
 
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "deep_parent.log")
@@ -2218,7 +2188,6 @@ L1=B L2=2 L3=y
 func TestF043_NestedLoops_ParentFirstLast_Integration(t *testing.T) {
 	// F043 implementation enables nested loops
 
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "parent_first_last.log")
 
@@ -2290,7 +2259,6 @@ outer=last (first=false last=true) inner=b
 // access when a while loop is nested inside a for_each loop.
 func TestF043_NestedLoops_WhileInsideForEach_ParentAccess_Integration(t *testing.T) {
 	// F043 implementation enables nested loops
-
 
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "while_parent.log")
@@ -2375,7 +2343,6 @@ batch=batch2 iter=3
 func TestF043_NestedLoops_ParentNilSafe_Integration(t *testing.T) {
 	// F043 implementation enables nested loops
 
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "nil_parent.log")
 
@@ -2443,7 +2410,6 @@ states:
 // TestF043_NestedLoops_EmptyInnerLoop_Integration tests that an empty inner loop
 // correctly completes without executing body and restores outer loop context.
 func TestF043_NestedLoops_EmptyInnerLoop_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "empty_inner.log")
 
@@ -2523,7 +2489,6 @@ AFTER: outer=B (context preserved)
 // TestF043_NestedLoops_InnerBreak_Integration tests break_when in nested loops.
 // When inner loop breaks via max_iterations, outer loop should continue normally.
 func TestF043_NestedLoops_InnerBreak_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "inner_break.log")
 
@@ -2595,7 +2560,6 @@ batch2/iter3
 // TestF043_NestedLoops_ErrorInInner_Propagate_Integration tests that errors in
 // inner loop can propagate to outer loop's on_failure handler.
 func TestF043_NestedLoops_ErrorInInner_Propagate_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "error_propagate.log")
 
@@ -2675,7 +2639,6 @@ states:
 // TestF043_NestedLoops_FourLevelDeep_Integration tests 4 levels of nested loops
 // to validate arbitrary depth support with parent chain access.
 func TestF043_NestedLoops_FourLevelDeep_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "four_level.log")
 
@@ -2763,7 +2726,6 @@ UK/LA/Main/102
 // TestF043_NestedLoops_ParentIndex1Arithmetic_Integration tests using Parent.Index1
 // in arithmetic expressions within shell commands.
 func TestF043_NestedLoops_ParentIndex1Arithmetic_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "arithmetic.log")
 
@@ -2835,7 +2797,6 @@ Cell[3,2]=R3-C2 position=5
 // TestF043_NestedLoops_MixedForEachWhile_ParentAccess_Integration tests nested
 // for_each inside while loop with parent access to while's context.
 func TestF043_NestedLoops_MixedForEachWhile_ParentAccess_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "mixed_while_foreach.log")
 	counterFile := filepath.Join(tmpDir, "counter")
@@ -2908,7 +2869,6 @@ while_iter=2 foreach_item=b
 // TestF043_NestedLoops_DynamicInnerItems_Integration tests inner loop with items
 // derived from outer loop context (using states).
 func TestF043_NestedLoops_DynamicInnerItems_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "dynamic_inner.log")
 
@@ -2994,7 +2954,6 @@ batch=3 item=item3
 // TestF043_NestedLoops_ParentLengthInCondition_Integration tests using Parent.Length
 // in template conditions within nested loops.
 func TestF043_NestedLoops_ParentLengthInCondition_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "parent_length.log")
 
@@ -3065,7 +3024,6 @@ states:
 // TestF043_NestedLoops_MaxIterationsInner_Integration tests that max_iterations
 // is correctly enforced on inner loops without affecting outer loop.
 func TestF043_NestedLoops_MaxIterationsInner_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "max_iter_inner.log")
 
@@ -3135,7 +3093,6 @@ batch2: iter=2
 // TestF043_NestedLoops_SingleItemBothLoops_Integration tests edge case where
 // both outer and inner loops have single items.
 func TestF043_NestedLoops_SingleItemBothLoops_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "single_both.log")
 
@@ -3202,7 +3159,6 @@ states:
 // TestF043_NestedLoops_MultipleBodyStepsWithParent_Integration tests nested loops
 // where inner loop has multiple body steps all accessing parent context.
 func TestF043_NestedLoops_MultipleBodyStepsWithParent_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "multi_body_parent.log")
 
@@ -3289,7 +3245,6 @@ S3: done with B/2
 // TestF043_NestedLoops_ParentAccessAfterInnerComplete_Integration verifies that
 // after inner loop completes, outer loop context is accessible in next outer step.
 func TestF043_NestedLoops_ParentAccessAfterInnerComplete_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "after_inner.log")
 
@@ -3382,7 +3337,6 @@ AFTER outer=Y idx=1 (restored)
 // WHEN a transition condition is met within the body
 // THEN subsequent steps should be skipped according to the transition target
 func TestF048_WhileLoop_BodyTransitions_SkipSteps(t *testing.T) {
-
 	// Item: T012
 	// Feature: F048
 	// Test happy path: Transitions within while loop body should skip subsequent steps
@@ -3489,7 +3443,6 @@ states:
 // WHEN that transition condition is met
 // THEN the loop should exit early and continue to the external target step
 func TestF048_WhileLoop_BodyTransitions_EarlyExit(t *testing.T) {
-
 	// Item: T012
 	// Feature: F048
 	// Test edge case: Transition to external step should exit loop early
@@ -3585,7 +3538,6 @@ states:
 // WHEN a transition condition is met within the body
 // THEN subsequent steps should be skipped according to the transition target
 func TestF048_ForEachLoop_BodyTransitions_SkipSteps(t *testing.T) {
-
 	// Item: T012
 	// Feature: F048
 	// Test happy path: Transitions within foreach loop body should work like while
@@ -3699,7 +3651,6 @@ states:
 // WHEN that transition is evaluated
 // THEN it should log a warning and continue sequential execution (graceful degradation)
 func TestF048_WhileLoop_BodyTransitions_InvalidTarget(t *testing.T) {
-
 	// Item: T012
 	// Feature: F048
 	// Test error handling: Invalid transition target should degrade gracefully
@@ -3796,7 +3747,6 @@ states:
 // WHEN the loop executes
 // THEN it should work exactly as before (sequential execution)
 func TestF048_WhileLoop_BodyTransitions_BackwardCompatibility(t *testing.T) {
-
 	// Item: T012
 	// Feature: F048
 	// Test backward compatibility: Loops without transitions should work unchanged

--- a/tests/integration/loop_transitions_test.go
+++ b/tests/integration/loop_transitions_test.go
@@ -205,7 +205,6 @@ func setupF048Test(t *testing.T, workflowYAML string) (*application.ExecutionSer
 // WHEN check_tests_passed outputs "TESTS_PASSED"
 // THEN it should transition to run_fmt, skipping prepare_impl_prompt and implement_item
 func TestF048_HappyPath_SkipStepsInBody(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	executionLog := filepath.Join(tmpDir, "execution.log")
 
@@ -297,7 +296,6 @@ func TestF048_HappyPath_ForEachWithTransitions(t *testing.T) {
 // WHEN the transition is triggered
 // THEN it should skip all intermediate steps
 func TestF048_EdgeCase_SkipToLastStep(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	executionLog := filepath.Join(tmpDir, "execution.log")
 
@@ -365,7 +363,6 @@ states:
 // WHEN the transition is triggered
 // THEN the loop should exit early and continue to the target step
 func TestF048_EdgeCase_EarlyLoopExit(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	executionLog := filepath.Join(tmpDir, "execution.log")
 
@@ -438,7 +435,6 @@ states:
 // WHEN that step has a transition outside the loop
 // THEN the transition should be honored (early exit)
 func TestF048_EdgeCase_SingleStepBodyWithTransition(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	executionLog := filepath.Join(tmpDir, "execution.log")
 
@@ -509,7 +505,6 @@ func TestF048_EdgeCase_EmptyLoopBody(t *testing.T) {
 // WHEN the transition is evaluated
 // THEN it should log a warning and continue sequential execution (ADR-005)
 func TestF048_ErrorHandling_InvalidTransitionTarget(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	executionLog := filepath.Join(tmpDir, "execution.log")
 
@@ -566,7 +561,6 @@ states:
 // WHEN the step has transitions
 // THEN the error should be propagated and transitions should not be evaluated
 func TestF048_ErrorHandling_TransitionWithError(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	executionLog := filepath.Join(tmpDir, "execution.log")
 
@@ -637,7 +631,6 @@ states:
 // WHEN innermost loop transitions to parent loop or outside
 // THEN it should properly exit nested loops and continue to target
 func TestDeeplyNestedLoops_TransitionToParent(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	executionLog := filepath.Join(tmpDir, "execution.log")
 
@@ -743,7 +736,6 @@ states:
 // WHEN the loop executes
 // THEN it should complete within reasonable time (<5s) and handle transitions correctly
 func TestLargeLoopBody_PerformanceValidation(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	executionLog := filepath.Join(tmpDir, "execution.log")
 
@@ -837,7 +829,6 @@ states:
 }
 
 func TestF048_Integration_FixtureWorkflow(t *testing.T) {
-
 	// Load the actual fixture
 	fixtureDir := "../../tests/fixtures/workflows"
 	tmpDir := t.TempDir()
@@ -898,7 +889,6 @@ func TestF048_Integration_FixtureWorkflow(t *testing.T) {
 // WHEN the loop executes
 // THEN it should work exactly as before (sequential execution)
 func TestF048_Integration_BackwardCompatibility(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	executionLog := filepath.Join(tmpDir, "execution.log")
 
@@ -958,7 +948,6 @@ states:
 // WHEN different conditions are met across iterations
 // THEN appropriate steps should be skipped or executed per iteration
 func TestF048_Integration_ConditionalTransitions(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	executionLog := filepath.Join(tmpDir, "execution.log")
 	counterFile := filepath.Join(tmpDir, "counter")
@@ -1206,7 +1195,6 @@ func (e *simpleExpressionEvaluatorT009) Evaluate(expr string, ctx *interpolation
 // WHEN check_tests_passed outputs "TESTS_PASSED"
 // THEN it should transition to run_fmt, skipping prepare_impl_prompt and implement_item
 func TestF048_WhileLoopBodyTransition_HappyPath(t *testing.T) {
-
 	// Arrange: Load the fixture workflow
 	fixtureDir := "../../tests/fixtures/workflows"
 	tmpDir := t.TempDir()
@@ -1270,7 +1258,6 @@ func TestF048_WhileLoopBodyTransition_HappyPath(t *testing.T) {
 // WHEN the transition is triggered
 // THEN it should skip all intermediate steps and execute the last step
 func TestF048_WhileLoopBodyTransition_EdgeCase_SkipToEnd(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	executionLog := filepath.Join(tmpDir, "execution.log")
 
@@ -1344,7 +1331,6 @@ states:
 // WHEN the transition is triggered
 // THEN the loop should exit early and continue to the target step
 func TestF048_WhileLoopBodyTransition_EdgeCase_EarlyExit(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	executionLog := filepath.Join(tmpDir, "execution.log")
 
@@ -1419,7 +1405,6 @@ states:
 // WHEN different conditions are met across iterations
 // THEN appropriate steps should be skipped or executed
 func TestF048_WhileLoopBodyTransition_EdgeCase_ConditionalSkip(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	executionLog := filepath.Join(tmpDir, "execution.log")
 	counterFile := filepath.Join(tmpDir, "counter")
@@ -1538,7 +1523,6 @@ states:
 // WHEN the transition is evaluated
 // THEN it should log a warning and continue sequential execution
 func TestF048_WhileLoopBodyTransition_ErrorHandling_InvalidTarget(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	executionLog := filepath.Join(tmpDir, "execution.log")
 
@@ -1610,7 +1594,6 @@ states:
 // WHEN that step has a transition
 // THEN the transition should be honored (early exit scenario)
 func TestF048_WhileLoopBodyTransition_EdgeCase_SingleStepBody(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	executionLog := filepath.Join(tmpDir, "execution.log")
 
@@ -1683,7 +1666,6 @@ states:
 // WHEN the loop executes
 // THEN it should work exactly as before (sequential execution)
 func TestF048_WhileLoopBodyTransition_EdgeCase_NoTransitions(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	executionLog := filepath.Join(tmpDir, "execution.log")
 

--- a/tests/integration/memory_leak_test.go
+++ b/tests/integration/memory_leak_test.go
@@ -27,7 +27,7 @@ import (
 // does not leak goroutines from signal handlers or other concurrent operations.
 // This test validates the fix for T001 (signal_handler_extraction).
 func TestNoGoroutineLeak_NormalWorkflow(t *testing.T) {
-		t.Skip("skipping goroutine leak test in short mode")
+	t.Skip("skipping goroutine leak test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -82,7 +82,7 @@ states:
 // properly clean up signal handler goroutines when the workflow completes.
 // This test validates the fix for T001 (signal_handler_extraction) in resume.go.
 func TestNoGoroutineLeak_ResumeWorkflow(t *testing.T) {
-		t.Skip("skipping goroutine leak test in short mode")
+	t.Skip("skipping goroutine leak test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -140,7 +140,7 @@ states:
 // TestNoGoroutineLeak_SignalInterruption verifies that signal handler goroutines
 // are properly cleaned up when a workflow is interrupted by a signal.
 func TestNoGoroutineLeak_SignalInterruption(t *testing.T) {
-		t.Skip("skipping goroutine leak test in short mode")
+	t.Skip("skipping goroutine leak test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -213,7 +213,7 @@ states:
 // stay under 2GB memory usage when MaxRetainedIterations is configured.
 // This test validates the fix for T004 (loop_iteration_pruning).
 func TestMemoryBounds_10000Iterations(t *testing.T) {
-		t.Skip("skipping memory test in short mode")
+	t.Skip("skipping memory test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -297,7 +297,7 @@ states:
 // are properly truncated when OutputLimit is configured, preventing unbounded memory growth.
 // This test validates the fix for T002 (output_limit_config) and T007 (output_truncation).
 func TestMemoryBounds_LargeOutputTruncation(t *testing.T) {
-		t.Skip("skipping memory test in short mode")
+	t.Skip("skipping memory test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -373,7 +373,7 @@ states:
 // are properly streamed to temp files when StreamLargeOutput is enabled.
 // This test validates the fix for T010 (output_streaming).
 func TestMemoryBounds_LargeOutputStreaming(t *testing.T) {
-		t.Skip("skipping memory test in short mode")
+	t.Skip("skipping memory test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -455,7 +455,7 @@ states:
 // TestBackwardCompatibility_DefaultBehavior verifies that workflows without
 // the new C019 configuration fields behave exactly as before (unlimited memory).
 func TestBackwardCompatibility_DefaultBehavior(t *testing.T) {
-		t.Skip("skipping backward compatibility test in short mode")
+	t.Skip("skipping backward compatibility test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -516,7 +516,7 @@ states:
 // TestBackwardCompatibility_ExplicitUnlimitedConfig verifies that workflows
 // with MaxRetainedIterations=0 explicitly configured behave as unlimited.
 func TestBackwardCompatibility_ExplicitUnlimitedConfig(t *testing.T) {
-		t.Skip("skipping backward compatibility test in short mode")
+	t.Skip("skipping backward compatibility test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")

--- a/tests/integration/memory_management_functional_test.go
+++ b/tests/integration/memory_management_functional_test.go
@@ -26,7 +26,7 @@ import (
 // TestMemoryManagement_HappyPath_SmallWorkflow verifies normal workflow execution
 // with minimal memory footprint when no special configuration is needed.
 func TestMemoryManagement_HappyPath_SmallWorkflow(t *testing.T) {
-		t.Skip("skipping functional test in short mode")
+	t.Skip("skipping functional test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -71,7 +71,7 @@ states:
 // TestMemoryManagement_HappyPath_ConfiguredLimits verifies workflow execution
 // with memory management configuration properly respected.
 func TestMemoryManagement_HappyPath_ConfiguredLimits(t *testing.T) {
-		t.Skip("skipping functional test in short mode")
+	t.Skip("skipping functional test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -122,7 +122,7 @@ states:
 // TestMemoryManagement_EdgeCase_ZeroIterations verifies behavior when loop
 // condition is false from the start.
 func TestMemoryManagement_EdgeCase_ZeroIterations(t *testing.T) {
-		t.Skip("skipping functional test in short mode")
+	t.Skip("skipping functional test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -175,7 +175,7 @@ states:
 // TestMemoryManagement_EdgeCase_SingleIteration verifies memory management
 // with minimal iteration count.
 func TestMemoryManagement_EdgeCase_SingleIteration(t *testing.T) {
-		t.Skip("skipping functional test in short mode")
+	t.Skip("skipping functional test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -219,7 +219,7 @@ states:
 // TestMemoryManagement_EdgeCase_EmptyOutput verifies handling of steps
 // that produce no output.
 func TestMemoryManagement_EdgeCase_EmptyOutput(t *testing.T) {
-		t.Skip("skipping functional test in short mode")
+	t.Skip("skipping functional test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -262,7 +262,7 @@ states:
 // TestMemoryManagement_EdgeCase_ExactlyAtLimit verifies behavior when output
 // is exactly at the configured limit.
 func TestMemoryManagement_EdgeCase_ExactlyAtLimit(t *testing.T) {
-		t.Skip("skipping functional test in short mode")
+	t.Skip("skipping functional test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -307,7 +307,7 @@ states:
 // TestMemoryManagement_EdgeCase_RetainedIterationsExceedsTotal verifies behavior
 // when max_retained_iterations is greater than actual iterations executed.
 func TestMemoryManagement_EdgeCase_RetainedIterationsExceedsTotal(t *testing.T) {
-		t.Skip("skipping functional test in short mode")
+	t.Skip("skipping functional test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -360,7 +360,7 @@ states:
 // TestMemoryManagement_ErrorHandling_InvalidOutputSize verifies rejection
 // of invalid output size configurations.
 func TestMemoryManagement_ErrorHandling_InvalidOutputSize(t *testing.T) {
-		t.Skip("skipping functional test in short mode")
+	t.Skip("skipping functional test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -406,7 +406,7 @@ states:
 // TestMemoryManagement_ErrorHandling_InvalidRetainedIterations verifies rejection
 // of invalid max_retained_iterations configurations.
 func TestMemoryManagement_ErrorHandling_InvalidRetainedIterations(t *testing.T) {
-		t.Skip("skipping functional test in short mode")
+	t.Skip("skipping functional test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -455,7 +455,7 @@ states:
 // TestMemoryManagement_ErrorHandling_FailedStepWithTruncation verifies that
 // truncation works correctly even when steps fail.
 func TestMemoryManagement_ErrorHandling_FailedStepWithTruncation(t *testing.T) {
-		t.Skip("skipping functional test in short mode")
+	t.Skip("skipping functional test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -509,7 +509,7 @@ states:
 // TestMemoryManagement_Integration_LoopWithOutputLimits verifies that
 // both loop iteration pruning and output truncation work together.
 func TestMemoryManagement_Integration_LoopWithOutputLimits(t *testing.T) {
-		t.Skip("skipping functional test in short mode")
+	t.Skip("skipping functional test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")
@@ -580,7 +580,7 @@ states:
 // TestMemoryManagement_Integration_SequentialLoopsWithPruning verifies memory management
 // with sequential loop execution (not nested, which AWF may not support).
 func TestMemoryManagement_Integration_SequentialLoopsWithPruning(t *testing.T) {
-		t.Skip("skipping functional test in short mode")
+	t.Skip("skipping functional test in short mode")
 
 	tmpDir := t.TempDir()
 	workflowsDir := filepath.Join(tmpDir, "workflows")

--- a/tests/integration/parallel_test.go
+++ b/tests/integration/parallel_test.go
@@ -29,7 +29,6 @@ import (
 // TestParallelExecution_AllSucceedStrategy validates all_succeed strategy
 // Strategy behavior: workflow fails if ANY branch fails
 func TestParallelExecution_AllSucceedStrategy(t *testing.T) {
-
 	tests := []struct {
 		name           string
 		workflowYAML   string
@@ -216,7 +215,6 @@ states:
 // TestParallelExecution_AnySucceedStrategy validates any_succeed strategy
 // Strategy behavior: workflow succeeds if AT LEAST ONE branch succeeds
 func TestParallelExecution_AnySucceedStrategy(t *testing.T) {
-
 	tests := []struct {
 		name           string
 		workflowYAML   string
@@ -403,7 +401,6 @@ states:
 // TestParallelExecution_BestEffortStrategy validates best_effort strategy
 // Strategy behavior: workflow completes REGARDLESS of branch failures
 func TestParallelExecution_BestEffortStrategy(t *testing.T) {
-
 	tests := []struct {
 		name           string
 		workflowYAML   string
@@ -592,7 +589,6 @@ states:
 // TestParallelExecution_MaxConcurrent validates max_concurrent limit enforcement
 // Uses timing-based assertions with ADR-004: 3x margin for CI variability
 func TestParallelExecution_MaxConcurrent(t *testing.T) {
-
 	tests := []struct {
 		name          string
 		workflowYAML  string
@@ -743,7 +739,6 @@ states:
 // TestParallelExecution_FailurePropagation validates error capture and propagation
 // Verifies that branch failures are captured in state and on_failure transitions work
 func TestParallelExecution_FailurePropagation(t *testing.T) {
-
 	tests := []struct {
 		name           string
 		workflowYAML   string

--- a/tests/integration/pkg_test_coverage_functional_test.go
+++ b/tests/integration/pkg_test_coverage_functional_test.go
@@ -34,7 +34,6 @@ import (
 // TestNestedLoops_HappyPath verifies that nested loops can access parent
 // loop data through LoopData.Parent field in workflow execution.
 func TestNestedLoops_HappyPath(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowYAML string
@@ -151,7 +150,6 @@ states:
 // TestAgentStepData_HappyPath verifies that StepStateData.Response and
 // StepStateData.Tokens fields can be accessed in workflow templates.
 func TestAgentStepData_HappyPath(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowYAML string
@@ -245,7 +243,6 @@ states:
 // TestExpressionNamespaces_HappyPath verifies that lowercase expression
 // namespaces (loop.*, context.*, error.*) work in workflow execution.
 func TestExpressionNamespaces_HappyPath(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowYAML string
@@ -379,7 +376,6 @@ states:
 
 // TestPkgCoverage_EdgeCases tests edge cases for pkg layer improvements.
 func TestPkgCoverage_EdgeCases(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowYAML string
@@ -531,7 +527,6 @@ states:
 
 // TestPkgCoverage_ErrorHandling tests error scenarios for pkg improvements.
 func TestPkgCoverage_ErrorHandling(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowYAML string

--- a/tests/integration/plugin_test.go
+++ b/tests/integration/plugin_test.go
@@ -29,7 +29,6 @@ import (
 // TestPluginDiscovery_Integration tests discovering plugins from a directory.
 // Acceptance Criteria: Plugin discovery from plugins/ directory
 func TestPluginDiscovery_Integration(t *testing.T) {
-
 	fixturesPath := "../fixtures/plugins"
 
 	parser := infrastructurePlugin.NewManifestParser()
@@ -60,7 +59,6 @@ func TestPluginDiscovery_Integration(t *testing.T) {
 // TestPluginLoadPlugin_Integration tests loading a single plugin.
 // Acceptance Criteria: Plugin lifecycle (load, init, shutdown)
 func TestPluginLoadPlugin_Integration(t *testing.T) {
-
 	fixturesPath := "../fixtures/plugins"
 
 	parser := infrastructurePlugin.NewManifestParser()
@@ -87,7 +85,6 @@ func TestPluginLoadPlugin_Integration(t *testing.T) {
 // TestPluginManifestFullFields_Integration tests loading a plugin with all manifest fields.
 // Acceptance Criteria: Plugin manifest (name, version, capabilities)
 func TestPluginManifestFullFields_Integration(t *testing.T) {
-
 	fixturesPath := "../fixtures/plugins"
 
 	parser := infrastructurePlugin.NewManifestParser()
@@ -154,7 +151,6 @@ func TestPluginManifestFullFields_Integration(t *testing.T) {
 // TestPluginManager_Lifecycle_Integration tests the full plugin lifecycle.
 // Acceptance Criteria: Plugin lifecycle (load, init, shutdown)
 func TestPluginManager_Lifecycle_Integration(t *testing.T) {
-
 	fixturesPath := "../fixtures/plugins"
 
 	parser := infrastructurePlugin.NewManifestParser()
@@ -191,7 +187,6 @@ func TestPluginManager_Lifecycle_Integration(t *testing.T) {
 // TestPluginService_EnableDisable_Integration tests enabling and disabling plugins.
 // Acceptance Criteria: Plugin enable/disable state persistence
 func TestPluginService_EnableDisable_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	fixturesPath := "../fixtures/plugins"
 
@@ -244,7 +239,6 @@ func TestPluginService_EnableDisable_Integration(t *testing.T) {
 
 // TestPluginService_ConfigStorage_Integration tests plugin configuration persistence.
 func TestPluginService_ConfigStorage_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	stateStore := infrastructurePlugin.NewJSONPluginStateStore(tmpDir)
@@ -328,7 +322,6 @@ func TestOperationRegistry_Integration(t *testing.T) {
 
 // TestCLI_Plugin_List_Integration tests the `awf plugin list` command.
 func TestCLI_Plugin_List_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	fixturesPath, _ := filepath.Abs("../fixtures/plugins")
 
@@ -350,7 +343,6 @@ func TestCLI_Plugin_List_Integration(t *testing.T) {
 
 // TestCLI_Plugin_List_JSON_Integration tests JSON output format.
 func TestCLI_Plugin_List_JSON_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	fixturesPath, _ := filepath.Abs("../fixtures/plugins")
 
@@ -372,7 +364,6 @@ func TestCLI_Plugin_List_JSON_Integration(t *testing.T) {
 
 // TestCLI_Plugin_EnableDisable_Integration tests enable/disable commands.
 func TestCLI_Plugin_EnableDisable_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	fixturesPath, _ := filepath.Abs("../fixtures/plugins")
 
@@ -435,7 +426,6 @@ func TestCLI_Plugin_Help_Integration(t *testing.T) {
 
 // TestPluginDiscovery_EmptyDirectory_Integration tests discovery with no plugins.
 func TestPluginDiscovery_EmptyDirectory_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	parser := infrastructurePlugin.NewManifestParser()
@@ -452,7 +442,6 @@ func TestPluginDiscovery_EmptyDirectory_Integration(t *testing.T) {
 
 // TestPluginDiscovery_MixedValidity_Integration tests discovery with valid and invalid plugins.
 func TestPluginDiscovery_MixedValidity_Integration(t *testing.T) {
-
 	// Use fixtures which contain both valid and invalid plugins
 	fixturesPath := "../fixtures/plugins"
 
@@ -486,7 +475,6 @@ func TestPluginDiscovery_MixedValidity_Integration(t *testing.T) {
 // TestPluginLoader_Validation_Integration tests manifest validation.
 // Acceptance Criteria: Plugin versioning and compatibility
 func TestPluginLoader_Validation_Integration(t *testing.T) {
-
 	parser := infrastructurePlugin.NewManifestParser()
 	loader := infrastructurePlugin.NewFileSystemLoader(parser)
 
@@ -558,7 +546,6 @@ func TestPluginLoader_Validation_Integration(t *testing.T) {
 
 // TestPluginStateStore_Concurrent_Integration tests concurrent access to state store.
 func TestPluginStateStore_Concurrent_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	stateStore := infrastructurePlugin.NewJSONPluginStateStore(tmpDir)
 
@@ -626,7 +613,6 @@ func TestOperationRegistry_Concurrent_Integration(t *testing.T) {
 
 // TestPluginLoad_InvalidPath_Integration tests loading from non-existent path.
 func TestPluginLoad_InvalidPath_Integration(t *testing.T) {
-
 	parser := infrastructurePlugin.NewManifestParser()
 	loader := infrastructurePlugin.NewFileSystemLoader(parser)
 
@@ -641,7 +627,6 @@ func TestPluginLoad_InvalidPath_Integration(t *testing.T) {
 
 // TestPluginLoad_NotDirectory_Integration tests loading a file instead of directory.
 func TestPluginLoad_NotDirectory_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "not-a-dir")
 	os.WriteFile(filePath, []byte("content"), 0o644)
@@ -660,7 +645,6 @@ func TestPluginLoad_NotDirectory_Integration(t *testing.T) {
 
 // TestPluginLoad_NoManifest_Integration tests loading a directory without plugin.yaml.
 func TestPluginLoad_NoManifest_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	parser := infrastructurePlugin.NewManifestParser()
@@ -677,7 +661,6 @@ func TestPluginLoad_NoManifest_Integration(t *testing.T) {
 
 // TestPluginLoad_InvalidYAML_Integration tests loading plugin with invalid YAML.
 func TestPluginLoad_InvalidYAML_Integration(t *testing.T) {
-
 	parser := infrastructurePlugin.NewManifestParser()
 	loader := infrastructurePlugin.NewFileSystemLoader(parser)
 
@@ -691,7 +674,6 @@ func TestPluginLoad_InvalidYAML_Integration(t *testing.T) {
 
 // TestPluginManager_LoadUnknown_Integration tests loading an unknown plugin.
 func TestPluginManager_LoadUnknown_Integration(t *testing.T) {
-
 	fixturesPath := "../fixtures/plugins"
 
 	parser := infrastructurePlugin.NewManifestParser()
@@ -709,7 +691,6 @@ func TestPluginManager_LoadUnknown_Integration(t *testing.T) {
 
 // TestPluginService_LoadDisabled_Integration tests that loading a disabled plugin fails.
 func TestPluginService_LoadDisabled_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	fixturesPath := "../fixtures/plugins"
 
@@ -827,7 +808,6 @@ func TestCLI_Plugin_Disable_NoArgs_Integration(t *testing.T) {
 
 // TestPluginDiscovery_ContextCancellation_Integration tests discovery with cancelled context.
 func TestPluginDiscovery_ContextCancellation_Integration(t *testing.T) {
-
 	fixturesPath := "../fixtures/plugins"
 
 	parser := infrastructurePlugin.NewManifestParser()
@@ -844,7 +824,6 @@ func TestPluginDiscovery_ContextCancellation_Integration(t *testing.T) {
 
 // TestPluginLoad_ContextCancellation_Integration tests loading with cancelled context.
 func TestPluginLoad_ContextCancellation_Integration(t *testing.T) {
-
 	fixturesPath := "../fixtures/plugins/valid-simple"
 
 	parser := infrastructurePlugin.NewManifestParser()
@@ -861,7 +840,6 @@ func TestPluginLoad_ContextCancellation_Integration(t *testing.T) {
 
 // TestPluginService_ContextCancellation_Integration tests service with cancelled context.
 func TestPluginService_ContextCancellation_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	fixturesPath := "../fixtures/plugins"
 
@@ -978,7 +956,6 @@ func TestManifest_HasCapability_Integration(t *testing.T) {
 
 // TestCLI_Plugin_List_EmptyDir_Integration tests list command with no plugins.
 func TestCLI_Plugin_List_EmptyDir_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	pluginsDir := filepath.Join(tmpDir, "plugins")
 	os.MkdirAll(pluginsDir, 0o755)

--- a/tests/integration/plugin_validation_functional_test.go
+++ b/tests/integration/plugin_validation_functional_test.go
@@ -20,7 +20,6 @@ import (
 // TestOperationSchemaValidate_ValidMinimal_Integration tests validation of a minimal valid operation schema.
 // Acceptance Criteria: OperationSchema.Validate() returns nil for valid schemas
 func TestOperationSchemaValidate_ValidMinimal_Integration(t *testing.T) {
-
 	schema := &plugin.OperationSchema{
 		Name:       "test.operation",
 		PluginName: "test-plugin",
@@ -36,7 +35,6 @@ func TestOperationSchemaValidate_ValidMinimal_Integration(t *testing.T) {
 // TestOperationSchemaValidate_ValidComplete_Integration tests validation of a complete operation schema.
 // Acceptance Criteria: OperationSchema.Validate() validates all fields including nested InputSchemas
 func TestOperationSchemaValidate_ValidComplete_Integration(t *testing.T) {
-
 	schema := &plugin.OperationSchema{
 		Name:        "slack.send",
 		Description: "Send a message to Slack",
@@ -71,7 +69,6 @@ func TestOperationSchemaValidate_ValidComplete_Integration(t *testing.T) {
 // TestInputSchemaValidate_AllValidTypes_Integration tests validation of all valid input types.
 // Acceptance Criteria: InputSchema.Validate() accepts all valid input types
 func TestInputSchemaValidate_AllValidTypes_Integration(t *testing.T) {
-
 	validTypes := []string{
 		plugin.InputTypeString,
 		plugin.InputTypeInteger,
@@ -97,7 +94,6 @@ func TestInputSchemaValidate_AllValidTypes_Integration(t *testing.T) {
 // TestGetRequiredInputs_MixedRequiredOptional_Integration tests filtering required inputs.
 // Acceptance Criteria: GetRequiredInputs() returns correct slice of required input names
 func TestGetRequiredInputs_MixedRequiredOptional_Integration(t *testing.T) {
-
 	schema := &plugin.OperationSchema{
 		Name:       "test.operation",
 		PluginName: "test-plugin",
@@ -121,7 +117,6 @@ func TestGetRequiredInputs_MixedRequiredOptional_Integration(t *testing.T) {
 // TestIsValidType_ValidTypes_Integration tests type validation for valid types.
 // Acceptance Criteria: IsValidType() returns true for all valid types
 func TestIsValidType_ValidTypes_Integration(t *testing.T) {
-
 	validTypes := []string{
 		plugin.InputTypeString,
 		plugin.InputTypeInteger,
@@ -148,7 +143,6 @@ func TestIsValidType_ValidTypes_Integration(t *testing.T) {
 // TestOperationSchemaValidate_EmptyInputsMap_Integration tests handling of empty inputs map.
 // Acceptance Criteria: OperationSchema.Validate() handles empty inputs gracefully
 func TestOperationSchemaValidate_EmptyInputsMap_Integration(t *testing.T) {
-
 	schema := &plugin.OperationSchema{
 		Name:       "test.operation",
 		PluginName: "test-plugin",
@@ -164,7 +158,6 @@ func TestOperationSchemaValidate_EmptyInputsMap_Integration(t *testing.T) {
 // TestOperationSchemaValidate_NilInputsMap_Integration tests handling of nil inputs map.
 // Acceptance Criteria: OperationSchema.Validate() handles nil inputs gracefully
 func TestOperationSchemaValidate_NilInputsMap_Integration(t *testing.T) {
-
 	schema := &plugin.OperationSchema{
 		Name:       "test.operation",
 		PluginName: "test-plugin",
@@ -180,7 +173,6 @@ func TestOperationSchemaValidate_NilInputsMap_Integration(t *testing.T) {
 // TestOperationSchemaValidate_EmptyOutputsList_Integration tests handling of empty outputs list.
 // Acceptance Criteria: OperationSchema.Validate() handles empty outputs gracefully
 func TestOperationSchemaValidate_EmptyOutputsList_Integration(t *testing.T) {
-
 	schema := &plugin.OperationSchema{
 		Name:       "test.operation",
 		PluginName: "test-plugin",
@@ -196,7 +188,6 @@ func TestOperationSchemaValidate_EmptyOutputsList_Integration(t *testing.T) {
 // TestGetRequiredInputs_EmptyInputs_Integration tests filtering with no inputs.
 // Acceptance Criteria: GetRequiredInputs() returns empty slice for empty inputs
 func TestGetRequiredInputs_EmptyInputs_Integration(t *testing.T) {
-
 	schema := &plugin.OperationSchema{
 		Name:       "test.operation",
 		PluginName: "test-plugin",
@@ -212,7 +203,6 @@ func TestGetRequiredInputs_EmptyInputs_Integration(t *testing.T) {
 // TestGetRequiredInputs_NilInputs_Integration tests filtering with nil inputs.
 // Acceptance Criteria: GetRequiredInputs() returns empty slice for nil inputs
 func TestGetRequiredInputs_NilInputs_Integration(t *testing.T) {
-
 	schema := &plugin.OperationSchema{
 		Name:       "test.operation",
 		PluginName: "test-plugin",
@@ -228,7 +218,6 @@ func TestGetRequiredInputs_NilInputs_Integration(t *testing.T) {
 // TestInputSchemaValidate_UnicodeDescriptions_Integration tests handling of unicode in descriptions.
 // Acceptance Criteria: InputSchema.Validate() handles unicode text correctly
 func TestInputSchemaValidate_UnicodeDescriptions_Integration(t *testing.T) {
-
 	schema := plugin.InputSchema{
 		Type:        plugin.InputTypeString,
 		Description: "Unicode test: こんにちは 世界 🌍 émojis 中文",
@@ -243,7 +232,6 @@ func TestInputSchemaValidate_UnicodeDescriptions_Integration(t *testing.T) {
 // TestInputSchemaValidate_DefaultValues_Integration tests various default value types.
 // Acceptance Criteria: InputSchema.Validate() validates default value types match declared type
 func TestInputSchemaValidate_DefaultValues_Integration(t *testing.T) {
-
 	tests := []struct {
 		name    string
 		schema  plugin.InputSchema
@@ -311,7 +299,6 @@ func TestInputSchemaValidate_DefaultValues_Integration(t *testing.T) {
 // TestOperationSchemaValidate_EmptyName_Integration tests rejection of empty name.
 // Acceptance Criteria: OperationSchema.Validate() rejects empty Name with descriptive error
 func TestOperationSchemaValidate_EmptyName_Integration(t *testing.T) {
-
 	schema := &plugin.OperationSchema{
 		Name:       "",
 		PluginName: "test-plugin",
@@ -326,7 +313,6 @@ func TestOperationSchemaValidate_EmptyName_Integration(t *testing.T) {
 // TestOperationSchemaValidate_WhitespaceName_Integration tests rejection of whitespace-only name.
 // Acceptance Criteria: OperationSchema.Validate() rejects whitespace-only Name
 func TestOperationSchemaValidate_WhitespaceName_Integration(t *testing.T) {
-
 	schema := &plugin.OperationSchema{
 		Name:       "   \t\n",
 		PluginName: "test-plugin",
@@ -341,7 +327,6 @@ func TestOperationSchemaValidate_WhitespaceName_Integration(t *testing.T) {
 // TestOperationSchemaValidate_EmptyPluginName_Integration tests rejection of empty plugin name.
 // Acceptance Criteria: OperationSchema.Validate() rejects empty PluginName
 func TestOperationSchemaValidate_EmptyPluginName_Integration(t *testing.T) {
-
 	schema := &plugin.OperationSchema{
 		Name:       "test.operation",
 		PluginName: "",
@@ -356,7 +341,6 @@ func TestOperationSchemaValidate_EmptyPluginName_Integration(t *testing.T) {
 // TestOperationSchemaValidate_InvalidInputSchema_Integration tests rejection of invalid input schemas.
 // Acceptance Criteria: OperationSchema.Validate() validates nested InputSchemas
 func TestOperationSchemaValidate_InvalidInputSchema_Integration(t *testing.T) {
-
 	schema := &plugin.OperationSchema{
 		Name:       "test.operation",
 		PluginName: "test-plugin",
@@ -378,7 +362,6 @@ func TestOperationSchemaValidate_InvalidInputSchema_Integration(t *testing.T) {
 // TestOperationSchemaValidate_DuplicateOutputs_Integration tests rejection of duplicate output names.
 // Acceptance Criteria: OperationSchema.Validate() rejects duplicate output names
 func TestOperationSchemaValidate_DuplicateOutputs_Integration(t *testing.T) {
-
 	schema := &plugin.OperationSchema{
 		Name:       "test.operation",
 		PluginName: "test-plugin",
@@ -395,7 +378,6 @@ func TestOperationSchemaValidate_DuplicateOutputs_Integration(t *testing.T) {
 // TestOperationSchemaValidate_EmptyOutputName_Integration tests rejection of empty output names.
 // Acceptance Criteria: OperationSchema.Validate() rejects empty output names
 func TestOperationSchemaValidate_EmptyOutputName_Integration(t *testing.T) {
-
 	schema := &plugin.OperationSchema{
 		Name:       "test.operation",
 		PluginName: "test-plugin",
@@ -411,7 +393,6 @@ func TestOperationSchemaValidate_EmptyOutputName_Integration(t *testing.T) {
 // TestInputSchemaValidate_EmptyType_Integration tests rejection of empty type.
 // Acceptance Criteria: InputSchema.Validate() rejects empty Type
 func TestInputSchemaValidate_EmptyType_Integration(t *testing.T) {
-
 	schema := plugin.InputSchema{
 		Type:     "",
 		Required: true,
@@ -426,7 +407,6 @@ func TestInputSchemaValidate_EmptyType_Integration(t *testing.T) {
 // TestInputSchemaValidate_InvalidType_Integration tests rejection of invalid types.
 // Acceptance Criteria: InputSchema.Validate() rejects invalid types with descriptive error
 func TestInputSchemaValidate_InvalidType_Integration(t *testing.T) {
-
 	invalidTypes := []string{"invalid", "float", "number", "text", "null"}
 
 	for _, invalidType := range invalidTypes {
@@ -448,7 +428,6 @@ func TestInputSchemaValidate_InvalidType_Integration(t *testing.T) {
 // TestInputSchemaValidate_InvalidValidationRule_Integration tests rejection of unknown validation rules.
 // Acceptance Criteria: InputSchema.Validate() rejects unknown validation rules
 func TestInputSchemaValidate_InvalidValidationRule_Integration(t *testing.T) {
-
 	schema := plugin.InputSchema{
 		Type:       plugin.InputTypeString,
 		Validation: "unknown_rule",
@@ -464,7 +443,6 @@ func TestInputSchemaValidate_InvalidValidationRule_Integration(t *testing.T) {
 // TestInputSchemaValidate_ValidValidationRules_Integration tests acceptance of valid validation rules.
 // Acceptance Criteria: InputSchema.Validate() accepts recognized validation rules
 func TestInputSchemaValidate_ValidValidationRules_Integration(t *testing.T) {
-
 	validRules := []string{"url", "email"}
 
 	for _, rule := range validRules {
@@ -484,7 +462,6 @@ func TestInputSchemaValidate_ValidValidationRules_Integration(t *testing.T) {
 // TestInputSchemaValidate_DefaultTypeMismatch_Integration tests rejection of mismatched default values.
 // Acceptance Criteria: InputSchema.Validate() rejects default values that don't match declared type
 func TestInputSchemaValidate_DefaultTypeMismatch_Integration(t *testing.T) {
-
 	tests := []struct {
 		name    string
 		schema  plugin.InputSchema
@@ -545,7 +522,6 @@ func TestInputSchemaValidate_DefaultTypeMismatch_Integration(t *testing.T) {
 // TestIsValidType_InvalidTypes_Integration tests type validation for invalid types.
 // Acceptance Criteria: IsValidType() returns false for invalid types
 func TestIsValidType_InvalidTypes_Integration(t *testing.T) {
-
 	invalidTypes := []string{"", "invalid", "float", "number", "null", "undefined"}
 
 	for _, invalidType := range invalidTypes {
@@ -566,7 +542,6 @@ func TestIsValidType_InvalidTypes_Integration(t *testing.T) {
 // TestOperationSchemaFullWorkflow_Integration tests complete validation workflow.
 // Acceptance Criteria: All validation methods work together correctly
 func TestOperationSchemaFullWorkflow_Integration(t *testing.T) {
-
 	// Create a complete operation schema
 	schema := &plugin.OperationSchema{
 		Name:        "github.create_issue",
@@ -630,7 +605,6 @@ func TestOperationSchemaFullWorkflow_Integration(t *testing.T) {
 // TestOperationSchemaComplexValidation_Integration tests validation with complex nested schemas.
 // Acceptance Criteria: Validation correctly handles complex, deeply nested structures
 func TestOperationSchemaComplexValidation_Integration(t *testing.T) {
-
 	schema := &plugin.OperationSchema{
 		Name:        "database.query",
 		Description: "Execute a database query",
@@ -687,7 +661,6 @@ func TestOperationSchemaComplexValidation_Integration(t *testing.T) {
 // TestOperationSchemaErrorPropagation_Integration tests error propagation from nested validations.
 // Acceptance Criteria: Errors from nested validations propagate correctly with context
 func TestOperationSchemaErrorPropagation_Integration(t *testing.T) {
-
 	schema := &plugin.OperationSchema{
 		Name:       "test.operation",
 		PluginName: "test-plugin",

--- a/tests/integration/plugin_validation_manifest_test.go
+++ b/tests/integration/plugin_validation_manifest_test.go
@@ -1,0 +1,640 @@
+//go:build integration
+
+// Feature: C031 - Manifest Validation
+// Component: T009
+// This file contains integration tests for plugin manifest validation.
+// Tests the integration between manifest parsing and validation logic.
+
+package integration_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vanoix/awf/internal/domain/plugin"
+	infrastructurePlugin "github.com/vanoix/awf/internal/infrastructure/plugin"
+)
+
+// =============================================================================
+// HAPPY PATH TESTS - Valid Manifests
+// =============================================================================
+
+// TestManifestValidation_ValidSimple_Integration tests validation of a minimal valid manifest.
+// Acceptance Criteria: Manifest.Validate() returns nil for valid simple manifests
+func TestManifestValidation_ValidSimple_Integration(t *testing.T) {
+	// Given: A simple valid plugin manifest fixture
+	fixturesPath := "../fixtures/plugins"
+	parser := infrastructurePlugin.NewManifestParser()
+	loader := infrastructurePlugin.NewFileSystemLoader(parser)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	pluginPath := filepath.Join(fixturesPath, "valid-simple")
+
+	// When: Loading the plugin which triggers manifest parsing and validation
+	pluginInfo, err := loader.LoadPlugin(ctx, pluginPath)
+
+	// Then: No validation errors occur
+	require.NoError(t, err, "valid simple manifest should pass validation")
+	require.NotNil(t, pluginInfo)
+	require.NotNil(t, pluginInfo.Manifest)
+
+	// Verify manifest fields
+	assert.Equal(t, "awf-plugin-simple", pluginInfo.Manifest.Name)
+	assert.Equal(t, "1.0.0", pluginInfo.Manifest.Version)
+	assert.Equal(t, ">=0.4.0", pluginInfo.Manifest.AWFVersion)
+	assert.Contains(t, pluginInfo.Manifest.Capabilities, plugin.CapabilityOperations)
+}
+
+// TestManifestValidation_ValidFull_Integration tests validation of a complete manifest with all fields.
+// Acceptance Criteria: Manifest.Validate() returns nil for manifests with all optional fields
+func TestManifestValidation_ValidFull_Integration(t *testing.T) {
+	// Given: A complete plugin manifest fixture with all fields
+	fixturesPath := "../fixtures/plugins"
+	parser := infrastructurePlugin.NewManifestParser()
+	loader := infrastructurePlugin.NewFileSystemLoader(parser)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	pluginPath := filepath.Join(fixturesPath, "valid-full")
+
+	// When: Loading the plugin
+	pluginInfo, err := loader.LoadPlugin(ctx, pluginPath)
+
+	// Then: No validation errors occur
+	require.NoError(t, err, "valid full manifest should pass validation")
+	require.NotNil(t, pluginInfo)
+	require.NotNil(t, pluginInfo.Manifest)
+
+	// Verify all fields are present and valid
+	assert.NotEmpty(t, pluginInfo.Manifest.Name)
+	assert.NotEmpty(t, pluginInfo.Manifest.Version)
+	assert.NotEmpty(t, pluginInfo.Manifest.AWFVersion)
+	assert.NotEmpty(t, pluginInfo.Manifest.Description)
+	assert.NotEmpty(t, pluginInfo.Manifest.Author)
+	assert.NotEmpty(t, pluginInfo.Manifest.License)
+}
+
+// =============================================================================
+// ERROR TESTS - Invalid Manifests
+// =============================================================================
+
+// TestManifestValidation_MissingName_Integration tests validation rejection for missing name.
+// Acceptance Criteria: Manifest.Validate() returns descriptive error for empty name
+func TestManifestValidation_MissingName_Integration(t *testing.T) {
+	// Given: A plugin manifest fixture missing the name field
+	fixturesPath := "../fixtures/plugins"
+	parser := infrastructurePlugin.NewManifestParser()
+	loader := infrastructurePlugin.NewFileSystemLoader(parser)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	pluginPath := filepath.Join(fixturesPath, "invalid-missing-name")
+
+	// When: Loading the plugin
+	pluginInfo, err := loader.LoadPlugin(ctx, pluginPath)
+
+	// Then: Validation error occurs mentioning "name"
+	assert.Error(t, err, "manifest with missing name should fail validation")
+	if err != nil {
+		assert.Contains(t, err.Error(), "name", "error should mention missing name field")
+	}
+	if pluginInfo != nil {
+		assert.Equal(t, plugin.StatusFailed, pluginInfo.Status)
+	}
+}
+
+// TestManifestValidation_MissingVersion_Integration tests validation rejection for missing version.
+// Acceptance Criteria: Manifest.Validate() returns descriptive error for empty version
+func TestManifestValidation_MissingVersion_Integration(t *testing.T) {
+	// Given: A plugin manifest fixture missing the version field
+	fixturesPath := "../fixtures/plugins"
+	parser := infrastructurePlugin.NewManifestParser()
+	loader := infrastructurePlugin.NewFileSystemLoader(parser)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	pluginPath := filepath.Join(fixturesPath, "invalid-missing-version")
+
+	// When: Loading the plugin
+	pluginInfo, err := loader.LoadPlugin(ctx, pluginPath)
+
+	// Then: Validation error occurs mentioning "version"
+	assert.Error(t, err, "manifest with missing version should fail validation")
+	if err != nil {
+		assert.Contains(t, err.Error(), "version", "error should mention missing version field")
+	}
+	if pluginInfo != nil {
+		assert.Equal(t, plugin.StatusFailed, pluginInfo.Status)
+	}
+}
+
+// TestManifestValidation_MissingAWFVersion_Integration tests validation rejection for missing awf_version.
+// Acceptance Criteria: Manifest.Validate() returns descriptive error for empty awf_version
+func TestManifestValidation_MissingAWFVersion_Integration(t *testing.T) {
+	// Given: A plugin manifest fixture missing the awf_version field
+	fixturesPath := "../fixtures/plugins"
+	parser := infrastructurePlugin.NewManifestParser()
+	loader := infrastructurePlugin.NewFileSystemLoader(parser)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	pluginPath := filepath.Join(fixturesPath, "invalid-missing-awf-version")
+
+	// When: Loading the plugin
+	pluginInfo, err := loader.LoadPlugin(ctx, pluginPath)
+
+	// Then: Validation error occurs mentioning "awf_version"
+	assert.Error(t, err, "manifest with missing awf_version should fail validation")
+	if err != nil {
+		assert.Contains(t, err.Error(), "awf_version", "error should mention missing awf_version field")
+	}
+	if pluginInfo != nil {
+		assert.Equal(t, plugin.StatusFailed, pluginInfo.Status)
+	}
+}
+
+// TestManifestValidation_BadCapability_Integration tests validation rejection for invalid capability.
+// Acceptance Criteria: Manifest.Validate() rejects unknown capability strings
+func TestManifestValidation_BadCapability_Integration(t *testing.T) {
+	// Given: A plugin manifest fixture with an invalid capability
+	fixturesPath := "../fixtures/plugins"
+	parser := infrastructurePlugin.NewManifestParser()
+	loader := infrastructurePlugin.NewFileSystemLoader(parser)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	pluginPath := filepath.Join(fixturesPath, "invalid-bad-capability")
+
+	// When: Loading the plugin (parsing only, no validation)
+	pluginInfo, err := loader.LoadPlugin(ctx, pluginPath)
+
+	// Then: Loading succeeds but manifest validation should fail
+	require.NoError(t, err, "loading should succeed")
+	require.NotNil(t, pluginInfo)
+	require.NotNil(t, pluginInfo.Manifest)
+
+	// When: Explicitly validating the manifest
+	validationErr := pluginInfo.Manifest.Validate()
+
+	// Then: Validation error occurs mentioning "capability"
+	require.Error(t, validationErr, "manifest with invalid capability should fail validation")
+	assert.Contains(t, validationErr.Error(), "capability", "error should mention invalid capability")
+}
+
+// =============================================================================
+// EDGE CASE TESTS
+// =============================================================================
+
+// TestManifestValidation_EmptyCapabilities_Integration tests validation with empty capabilities list.
+// Acceptance Criteria: Empty capabilities list is valid (plugins without capabilities are allowed)
+func TestManifestValidation_EmptyCapabilities_Integration(t *testing.T) {
+	// Given: A manifest with empty capabilities list
+	manifest := &plugin.Manifest{
+		Name:         "test-plugin",
+		Version:      "1.0.0",
+		AWFVersion:   ">=0.4.0",
+		Description:  "Test plugin",
+		Capabilities: []string{},
+		Config:       nil,
+	}
+
+	// When: Validating the manifest
+	err := manifest.Validate()
+
+	// Then: No error occurs (empty capabilities is valid)
+	assert.NoError(t, err, "empty capabilities list should be valid")
+}
+
+// TestManifestValidation_NilConfigMap_Integration tests validation with nil config map.
+// Acceptance Criteria: Nil config map is valid (plugins without config are allowed)
+func TestManifestValidation_NilConfigMap_Integration(t *testing.T) {
+	// Given: A manifest with nil config map
+	manifest := &plugin.Manifest{
+		Name:         "test-plugin",
+		Version:      "1.0.0",
+		AWFVersion:   ">=0.4.0",
+		Description:  "Test plugin",
+		Capabilities: []string{plugin.CapabilityOperations},
+		Config:       nil,
+	}
+
+	// When: Validating the manifest
+	err := manifest.Validate()
+
+	// Then: No error occurs (nil config is valid)
+	assert.NoError(t, err, "nil config map should be valid")
+}
+
+// =============================================================================
+// NAME VALIDATION TESTS
+// =============================================================================
+
+// TestManifestValidation_InvalidNamePattern_Integration tests rejection of names with invalid patterns.
+// Acceptance Criteria: Manifest.Validate() rejects names not matching ^[a-z][a-z0-9-]*$
+func TestManifestValidation_InvalidNamePattern_Integration(t *testing.T) {
+	tests := []struct {
+		name         string
+		manifestName string
+		wantErr      string
+	}{
+		{
+			name:         "uppercase letters",
+			manifestName: "MyPlugin",
+			wantErr:      "invalid name",
+		},
+		{
+			name:         "starts with digit",
+			manifestName: "1plugin",
+			wantErr:      "invalid name",
+		},
+		{
+			name:         "contains underscore",
+			manifestName: "my_plugin",
+			wantErr:      "invalid name",
+		},
+		{
+			name:         "contains space",
+			manifestName: "my plugin",
+			wantErr:      "invalid name",
+		},
+		{
+			name:         "contains special chars",
+			manifestName: "my@plugin",
+			wantErr:      "invalid name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given: A manifest with an invalid name pattern
+			manifest := &plugin.Manifest{
+				Name:       tt.manifestName,
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			}
+
+			// When: Validating the manifest
+			err := manifest.Validate()
+
+			// Then: Validation error occurs
+			require.Error(t, err, "invalid name pattern should fail validation")
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestManifestValidation_ValidNamePattern_Integration tests acceptance of valid name patterns.
+// Acceptance Criteria: Manifest.Validate() accepts names matching ^[a-z][a-z0-9-]*$
+func TestManifestValidation_ValidNamePattern_Integration(t *testing.T) {
+	tests := []struct {
+		name         string
+		manifestName string
+	}{
+		{
+			name:         "simple lowercase",
+			manifestName: "plugin",
+		},
+		{
+			name:         "with hyphens",
+			manifestName: "awf-plugin-slack",
+		},
+		{
+			name:         "with digits",
+			manifestName: "plugin2",
+		},
+		{
+			name:         "mixed alphanumeric and hyphens",
+			manifestName: "my-plugin-v2",
+		},
+		{
+			name:         "single letter",
+			manifestName: "a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given: A manifest with a valid name pattern
+			manifest := &plugin.Manifest{
+				Name:       tt.manifestName,
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+			}
+
+			// When: Validating the manifest
+			err := manifest.Validate()
+
+			// Then: No validation error occurs
+			assert.NoError(t, err, "valid name pattern should pass validation")
+		})
+	}
+}
+
+// =============================================================================
+// CONFIG FIELD VALIDATION TESTS
+// =============================================================================
+
+// TestManifestValidation_InvalidConfigType_Integration tests rejection of invalid config field types.
+// Acceptance Criteria: Manifest.Validate() rejects config fields with invalid types
+func TestManifestValidation_InvalidConfigType_Integration(t *testing.T) {
+	// Given: A manifest with an invalid config field type
+	manifest := &plugin.Manifest{
+		Name:       "test-plugin",
+		Version:    "1.0.0",
+		AWFVersion: ">=0.4.0",
+		Config: map[string]plugin.ConfigField{
+			"invalid_field": {
+				Type:     "invalid_type",
+				Required: false,
+			},
+		},
+	}
+
+	// When: Validating the manifest
+	err := manifest.Validate()
+
+	// Then: Validation error occurs mentioning config field and type
+	require.Error(t, err, "invalid config type should fail validation")
+	assert.Contains(t, err.Error(), "config field")
+	assert.Contains(t, err.Error(), "invalid_field")
+	assert.Contains(t, err.Error(), "invalid type")
+}
+
+// TestManifestValidation_EnumOnNonStringType_Integration tests rejection of enum on non-string types.
+// Acceptance Criteria: Manifest.Validate() rejects enum constraint on non-string config fields
+func TestManifestValidation_EnumOnNonStringType_Integration(t *testing.T) {
+	tests := []struct {
+		name       string
+		configType string
+	}{
+		{
+			name:       "integer with enum",
+			configType: plugin.ConfigTypeInteger,
+		},
+		{
+			name:       "boolean with enum",
+			configType: plugin.ConfigTypeBoolean,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given: A manifest with enum on non-string type
+			manifest := &plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"field": {
+						Type: tt.configType,
+						Enum: []string{"value1", "value2"},
+					},
+				},
+			}
+
+			// When: Validating the manifest
+			err := manifest.Validate()
+
+			// Then: Validation error occurs mentioning enum restriction
+			require.Error(t, err, "enum on non-string type should fail validation")
+			assert.Contains(t, err.Error(), "enum")
+		})
+	}
+}
+
+// TestManifestValidation_ConfigDefaultTypeMismatch_Integration tests rejection of mismatched default types.
+// Acceptance Criteria: Manifest.Validate() rejects config fields where default value doesn't match declared type
+func TestManifestValidation_ConfigDefaultTypeMismatch_Integration(t *testing.T) {
+	tests := []struct {
+		name         string
+		configType   string
+		defaultValue any
+		wantErr      string
+	}{
+		{
+			name:         "string type with integer default",
+			configType:   plugin.ConfigTypeString,
+			defaultValue: 42,
+			wantErr:      "type mismatch",
+		},
+		{
+			name:         "integer type with string default",
+			configType:   plugin.ConfigTypeInteger,
+			defaultValue: "not a number",
+			wantErr:      "type mismatch",
+		},
+		{
+			name:         "boolean type with string default",
+			configType:   plugin.ConfigTypeBoolean,
+			defaultValue: "true",
+			wantErr:      "type mismatch",
+		},
+		{
+			name:         "integer type with boolean default",
+			configType:   plugin.ConfigTypeInteger,
+			defaultValue: true,
+			wantErr:      "type mismatch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given: A manifest with mismatched default value type
+			manifest := &plugin.Manifest{
+				Name:       "test-plugin",
+				Version:    "1.0.0",
+				AWFVersion: ">=0.4.0",
+				Config: map[string]plugin.ConfigField{
+					"field": {
+						Type:    tt.configType,
+						Default: tt.defaultValue,
+					},
+				},
+			}
+
+			// When: Validating the manifest
+			err := manifest.Validate()
+
+			// Then: Validation error occurs mentioning type mismatch
+			require.Error(t, err, "mismatched default type should fail validation")
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestManifestValidation_ValidConfigDefaults_Integration tests acceptance of valid default values.
+// Acceptance Criteria: Manifest.Validate() accepts config fields with correctly typed defaults
+func TestManifestValidation_ValidConfigDefaults_Integration(t *testing.T) {
+	// Given: A manifest with correctly typed default values
+	manifest := &plugin.Manifest{
+		Name:       "test-plugin",
+		Version:    "1.0.0",
+		AWFVersion: ">=0.4.0",
+		Config: map[string]plugin.ConfigField{
+			"string_field": {
+				Type:    plugin.ConfigTypeString,
+				Default: "default value",
+			},
+			"integer_field": {
+				Type:    plugin.ConfigTypeInteger,
+				Default: 42,
+			},
+			"boolean_field": {
+				Type:    plugin.ConfigTypeBoolean,
+				Default: true,
+			},
+			"integer_from_json": {
+				Type:    plugin.ConfigTypeInteger,
+				Default: float64(10), // JSON unmarshaling produces float64
+			},
+		},
+	}
+
+	// When: Validating the manifest
+	err := manifest.Validate()
+
+	// Then: No validation error occurs
+	assert.NoError(t, err, "valid config defaults should pass validation")
+}
+
+// =============================================================================
+// CAPABILITIES VALIDATION TESTS
+// =============================================================================
+
+// TestManifestValidation_MultipleValidCapabilities_Integration tests validation with multiple valid capabilities.
+// Acceptance Criteria: Manifest.Validate() accepts manifests with multiple valid capabilities
+func TestManifestValidation_MultipleValidCapabilities_Integration(t *testing.T) {
+	// Given: A manifest with all valid capabilities
+	manifest := &plugin.Manifest{
+		Name:       "test-plugin",
+		Version:    "1.0.0",
+		AWFVersion: ">=0.4.0",
+		Capabilities: []string{
+			plugin.CapabilityOperations,
+			plugin.CapabilityCommands,
+			plugin.CapabilityValidators,
+		},
+	}
+
+	// When: Validating the manifest
+	err := manifest.Validate()
+
+	// Then: No validation error occurs
+	assert.NoError(t, err, "multiple valid capabilities should pass validation")
+}
+
+// TestManifestValidation_DuplicateCapabilities_Integration tests validation with duplicate capabilities.
+// Acceptance Criteria: Manifest.Validate() accepts duplicate capabilities (idempotent)
+func TestManifestValidation_DuplicateCapabilities_Integration(t *testing.T) {
+	// Given: A manifest with duplicate capabilities
+	manifest := &plugin.Manifest{
+		Name:       "test-plugin",
+		Version:    "1.0.0",
+		AWFVersion: ">=0.4.0",
+		Capabilities: []string{
+			plugin.CapabilityOperations,
+			plugin.CapabilityOperations,
+		},
+	}
+
+	// When: Validating the manifest
+	err := manifest.Validate()
+
+	// Then: No validation error occurs (duplicates are allowed)
+	assert.NoError(t, err, "duplicate capabilities should be valid")
+}
+
+// =============================================================================
+// INTEGRATION WORKFLOW TESTS
+// =============================================================================
+
+// TestManifestValidation_CompleteWorkflow_Integration tests the complete validation workflow.
+// Acceptance Criteria: All validation methods work together correctly
+func TestManifestValidation_CompleteWorkflow_Integration(t *testing.T) {
+	// Given: A complete and valid manifest
+	manifest := &plugin.Manifest{
+		Name:        "awf-plugin-github",
+		Version:     "2.1.0",
+		Description: "GitHub integration for AWF",
+		AWFVersion:  ">=0.4.0",
+		Author:      "John Developer <john@example.com>",
+		License:     "Apache-2.0",
+		Homepage:    "https://github.com/example/awf-plugin-github",
+		Capabilities: []string{
+			plugin.CapabilityOperations,
+			plugin.CapabilityCommands,
+		},
+		Config: map[string]plugin.ConfigField{
+			"token": {
+				Type:        plugin.ConfigTypeString,
+				Required:    true,
+				Description: "GitHub personal access token",
+			},
+			"api_url": {
+				Type:        plugin.ConfigTypeString,
+				Required:    false,
+				Default:     "https://api.github.com",
+				Description: "GitHub API base URL",
+			},
+			"timeout": {
+				Type:        plugin.ConfigTypeInteger,
+				Required:    false,
+				Default:     30,
+				Description: "Request timeout in seconds",
+			},
+			"verify_ssl": {
+				Type:        plugin.ConfigTypeBoolean,
+				Required:    false,
+				Default:     true,
+				Description: "Verify SSL certificates",
+			},
+			"log_level": {
+				Type:        plugin.ConfigTypeString,
+				Required:    false,
+				Default:     "info",
+				Description: "Logging verbosity",
+				Enum:        []string{"debug", "info", "warn", "error"},
+			},
+		},
+	}
+
+	// When: Validating the complete manifest
+	err := manifest.Validate()
+
+	// Then: No validation errors occur
+	assert.NoError(t, err, "complete valid manifest should pass validation")
+
+	// Verify HasCapability works correctly
+	assert.True(t, manifest.HasCapability(plugin.CapabilityOperations))
+	assert.True(t, manifest.HasCapability(plugin.CapabilityCommands))
+	assert.False(t, manifest.HasCapability(plugin.CapabilityValidators))
+}
+
+// TestManifestValidation_MultipleErrors_Integration tests error propagation with multiple invalid fields.
+// Acceptance Criteria: Validation fails fast on first error encountered
+func TestManifestValidation_MultipleErrors_Integration(t *testing.T) {
+	// Given: A manifest with multiple validation errors
+	manifest := &plugin.Manifest{
+		Name:       "", // Empty name (first error)
+		Version:    "", // Empty version (would be second error)
+		AWFVersion: "", // Empty awf_version (would be third error)
+	}
+
+	// When: Validating the manifest
+	err := manifest.Validate()
+
+	// Then: Validation fails fast with first error
+	require.Error(t, err, "manifest with multiple errors should fail validation")
+	assert.Contains(t, err.Error(), "name", "should fail on first error: empty name")
+}

--- a/tests/integration/prompt_discovery_test.go
+++ b/tests/integration/prompt_discovery_test.go
@@ -23,7 +23,6 @@ import (
 // =============================================================================
 
 func TestPromptDiscovery_ListPrompts_LocalOnly_Integration(t *testing.T) {
-
 	// Setup: Create temp directory with local prompts only
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
@@ -74,7 +73,6 @@ func TestPromptDiscovery_ListPrompts_LocalOnly_Integration(t *testing.T) {
 }
 
 func TestPromptDiscovery_ListPrompts_GlobalOnly_Integration(t *testing.T) {
-
 	// Setup: Create temp directory with global prompts only
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
@@ -121,7 +119,6 @@ func TestPromptDiscovery_ListPrompts_GlobalOnly_Integration(t *testing.T) {
 }
 
 func TestPromptDiscovery_ListPrompts_BothSources_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	localPrompts := filepath.Join(projectDir, ".awf", "prompts")
@@ -181,7 +178,6 @@ func TestPromptDiscovery_ListPrompts_BothSources_Integration(t *testing.T) {
 // =============================================================================
 
 func TestPromptDiscovery_LocalOverridesGlobal_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	localPrompts := filepath.Join(projectDir, ".awf", "prompts")
@@ -245,7 +241,6 @@ func TestPromptDiscovery_LocalOverridesGlobal_Integration(t *testing.T) {
 // =============================================================================
 
 func TestPromptDiscovery_NestedDirectories_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	localPrompts := filepath.Join(projectDir, ".awf", "prompts")
@@ -295,7 +290,6 @@ func TestPromptDiscovery_NestedDirectories_Integration(t *testing.T) {
 }
 
 func TestPromptDiscovery_NestedOverride_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	localPrompts := filepath.Join(projectDir, ".awf", "prompts")
@@ -364,7 +358,6 @@ func TestPromptDiscovery_NestedOverride_Integration(t *testing.T) {
 // =============================================================================
 
 func TestPromptDiscovery_EmptyDirectories_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	localPrompts := filepath.Join(projectDir, ".awf", "prompts")
@@ -404,7 +397,6 @@ func TestPromptDiscovery_EmptyDirectories_Integration(t *testing.T) {
 }
 
 func TestPromptDiscovery_MissingDirectories_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	require.NoError(t, os.MkdirAll(projectDir, 0o755))
@@ -438,7 +430,6 @@ func TestPromptDiscovery_MissingDirectories_Integration(t *testing.T) {
 }
 
 func TestPromptDiscovery_VariousFileExtensions_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	localPrompts := filepath.Join(projectDir, ".awf", "prompts")
@@ -495,7 +486,6 @@ func TestPromptDiscovery_VariousFileExtensions_Integration(t *testing.T) {
 // =============================================================================
 
 func TestPromptDiscovery_JSONFormat_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	localPrompts := filepath.Join(projectDir, ".awf", "prompts")
@@ -552,7 +542,6 @@ func TestPromptDiscovery_JSONFormat_Integration(t *testing.T) {
 // =============================================================================
 
 func TestPromptResolution_LocalPrompt_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	localPrompts := filepath.Join(projectDir, ".awf", "prompts")
@@ -625,7 +614,6 @@ states:
 }
 
 func TestPromptResolution_GlobalPrompt_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	wfDir := filepath.Join(projectDir, ".awf", "workflows")
@@ -700,7 +688,6 @@ states:
 }
 
 func TestPromptResolution_LocalOverridesGlobal_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	localPrompts := filepath.Join(projectDir, ".awf", "prompts")
@@ -783,7 +770,6 @@ states:
 }
 
 func TestPromptResolution_NestedPath_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	localPrompts := filepath.Join(projectDir, ".awf", "prompts")
@@ -860,7 +846,6 @@ states:
 // =============================================================================
 
 func TestPromptResolution_NotFound_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	wfDir := filepath.Join(projectDir, ".awf", "workflows")
@@ -921,7 +906,6 @@ states:
 }
 
 func TestPromptResolution_PathTraversal_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	wfDir := filepath.Join(projectDir, ".awf", "workflows")
@@ -991,7 +975,6 @@ states:
 // =============================================================================
 
 func TestInitGlobal_CreatesDirectory_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	require.NoError(t, os.MkdirAll(projectDir, 0o755))
@@ -1035,7 +1018,6 @@ func TestInitGlobal_CreatesDirectory_Integration(t *testing.T) {
 }
 
 func TestInitGlobal_PreservesExisting_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	require.NoError(t, os.MkdirAll(projectDir, 0o755))
@@ -1082,7 +1064,6 @@ func TestInitGlobal_PreservesExisting_Integration(t *testing.T) {
 }
 
 func TestInitGlobal_XDGCompliance_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "project")
 	require.NoError(t, os.MkdirAll(projectDir, 0o755))
@@ -1124,7 +1105,6 @@ func TestInitGlobal_XDGCompliance_Integration(t *testing.T) {
 // =============================================================================
 
 func TestPromptDiscovery_WithFixtures_Integration(t *testing.T) {
-
 	// Get project root
 	origDir, err := os.Getwd()
 	require.NoError(t, err)

--- a/tests/integration/retry_test.go
+++ b/tests/integration/retry_test.go
@@ -69,7 +69,6 @@ func (m *retryMockLogger) WithContext(ctx map[string]any) ports.Logger {
 // =============================================================================
 
 func TestRetry_SucceedsOnNthAttempt_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	counterFile := filepath.Join(tmpDir, "counter")
 
@@ -139,7 +138,6 @@ states:
 }
 
 func TestRetry_ExhaustsAllAttempts_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "attempts.log")
 
@@ -201,7 +199,6 @@ states:
 }
 
 func TestRetry_ExitCodeFiltering_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	counterFile := filepath.Join(tmpDir, "counter")
 
@@ -267,7 +264,6 @@ states:
 }
 
 func TestRetry_ExponentialBackoff_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	counterFile := filepath.Join(tmpDir, "counter")
 	timestampFile := filepath.Join(tmpDir, "timestamps")
@@ -333,7 +329,6 @@ states:
 }
 
 func TestRetry_LinearBackoff_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	counterFile := filepath.Join(tmpDir, "counter")
 
@@ -395,7 +390,6 @@ states:
 }
 
 func TestRetry_WithJitter_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	counterFile := filepath.Join(tmpDir, "counter")
 
@@ -454,7 +448,6 @@ states:
 }
 
 func TestRetry_MaxDelayCap_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	counterFile := filepath.Join(tmpDir, "counter")
 
@@ -515,7 +508,6 @@ states:
 }
 
 func TestRetry_NoRetryOnSuccess_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	counterFile := filepath.Join(tmpDir, "counter")
 

--- a/tests/integration/run_help_test.go
+++ b/tests/integration/run_help_test.go
@@ -19,7 +19,6 @@ import (
 // Given a workflow with inputs, when running `awf run <workflow> --help`,
 // displays all inputs with their types and required/optional status.
 func TestRunHelp_WorkflowWithInputs_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -83,7 +82,6 @@ states:
 // Given a workflow with no inputs defined, when running `awf run <workflow> --help`,
 // displays a message indicating the workflow has no input arguments.
 func TestRunHelp_WorkflowNoInputs_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -117,7 +115,6 @@ states:
 // Given a non-existent workflow, when running `awf run <workflow> --help`,
 // displays an error message with exit code 1.
 func TestRunHelp_NonExistentWorkflow_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -159,7 +156,6 @@ func TestRunHelp_NonExistentWorkflow_Integration(t *testing.T) {
 // Given a workflow with inputs that have description fields, when running `--help`,
 // displays the description next to each input.
 func TestRunHelp_InputDescriptions_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -207,7 +203,6 @@ states:
 // Given a workflow with inputs missing description fields, when running `--help`,
 // displays "No description" placeholder for those inputs.
 func TestRunHelp_InputMissingDescriptions_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -245,7 +240,6 @@ states:
 // Given a workflow with optional inputs that have defaults, when running `--help`,
 // displays the default values next to those inputs.
 func TestRunHelp_DefaultValues_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -297,7 +291,6 @@ states:
 // Given a workflow with an optional input without a default, when running `--help`,
 // displays "-" for that input's default column.
 func TestRunHelp_OptionalWithoutDefault_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -347,7 +340,6 @@ states:
 // Given a workflow with a description field, when running `--help`,
 // displays the description at the top before the inputs list.
 func TestRunHelp_WorkflowDescription_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -394,7 +386,6 @@ states:
 // Given a workflow without a description field, when running `--help`,
 // displays inputs without a description section.
 func TestRunHelp_WorkflowNoDescription_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -437,7 +428,6 @@ states:
 // Uses valid-full.yaml fixture which has all features: description, multiple inputs,
 // required/optional, defaults, and input descriptions.
 func TestRunHelp_FullWorkflowExample_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -472,7 +462,6 @@ func TestRunHelp_FullWorkflowExample_Integration(t *testing.T) {
 // TestRunHelp_SimpleWorkflowExample_Integration tests basic help output
 // Uses valid-simple.yaml fixture as a basic test case.
 func TestRunHelp_SimpleWorkflowExample_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -505,7 +494,6 @@ func TestRunHelp_SimpleWorkflowExample_Integration(t *testing.T) {
 // TestRunHelp_NoColorFlag_Integration tests --no-color flag with help
 // Verifies that --no-color flag is respected in help output.
 func TestRunHelp_NoColorFlag_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	cmd := cli.NewRootCommand()
@@ -530,7 +518,6 @@ func TestRunHelp_NoColorFlag_Integration(t *testing.T) {
 // TestRunHelp_Performance_Integration tests NFR-001: < 50ms response
 // Help display should complete quickly as it only parses YAML, no execution.
 func TestRunHelp_Performance_Integration(t *testing.T) {
-
 	t.Setenv("AWF_WORKFLOWS_PATH", "../fixtures/workflows")
 
 	// Run multiple times and measure
@@ -562,7 +549,6 @@ func TestRunHelp_Performance_Integration(t *testing.T) {
 // TestRunHelp_HelpTakesPrecedence_Integration tests FR-005: --help takes precedence
 // Verifies that --help flag takes precedence over other flags (workflow is not executed).
 func TestRunHelp_HelpTakesPrecedence_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -610,7 +596,6 @@ states:
 // TestRunHelp_MixedInputTypes_Integration tests table-driven scenarios
 // for various input type combinations.
 func TestRunHelp_MixedInputTypes_Integration(t *testing.T) {
-
 	tests := []struct {
 		name           string
 		workflowYAML   string
@@ -691,7 +676,6 @@ states:
 // TestRunHelp_TerminalWidth_Integration tests NFR-002: 80-column readability
 // Help output must be readable in 80-column terminals.
 func TestRunHelp_TerminalWidth_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -742,7 +726,6 @@ states:
 // TestRunHelp_SpecialCharactersInInputs_Integration tests edge case with special characters
 // Verifies that input names and descriptions with special characters are displayed correctly.
 func TestRunHelp_SpecialCharactersInInputs_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -791,7 +774,6 @@ states:
 // TestRunHelp_InvalidYAMLWorkflow_Integration tests error handling for malformed YAML
 // Verifies that invalid YAML produces appropriate error message.
 func TestRunHelp_InvalidYAMLWorkflow_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -835,7 +817,6 @@ states:
 // TestRunHelp_EmptyInputName_Integration tests edge case with empty or whitespace input names
 // Verifies graceful handling of edge cases in input definitions.
 func TestRunHelp_EmptyInputName_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -880,7 +861,6 @@ states:
 // TestRunHelp_ExitCode_Integration tests FR-004: exit code 1 for user error
 // Verifies that non-existent workflow returns exit code 1.
 func TestRunHelp_ExitCode_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -910,7 +890,6 @@ func TestRunHelp_ExitCode_Integration(t *testing.T) {
 // TestRunHelp_EnvPathOverride_Integration tests NFR-003: workflows from env path
 // Verifies that AWF_WORKFLOWS_PATH environment variable is respected.
 func TestRunHelp_EnvPathOverride_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "custom-workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -951,7 +930,6 @@ states:
 // TestRunHelp_AllInputTypes_Integration tests comprehensive input type coverage
 // Verifies all supported input types are displayed correctly.
 func TestRunHelp_AllInputTypes_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -1019,7 +997,6 @@ states:
 // TestRunHelp_LongDescription_Integration tests handling of long descriptions
 // Verifies that long workflow and input descriptions are handled gracefully.
 func TestRunHelp_LongDescription_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -1061,7 +1038,6 @@ states:
 // TestRunHelp_UnicodeContent_Integration tests Unicode support
 // Verifies that Unicode characters in workflow names and descriptions are handled.
 func TestRunHelp_UnicodeContent_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -1103,7 +1079,6 @@ states:
 // TestRunHelp_OnlyRequiredInputs_Integration tests workflow with only required inputs
 // Verifies display when all inputs are required (no optional column needed).
 func TestRunHelp_OnlyRequiredInputs_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))
@@ -1153,7 +1128,6 @@ states:
 // TestRunHelp_OnlyOptionalInputs_Integration tests workflow with only optional inputs
 // Verifies display when all inputs are optional with defaults.
 func TestRunHelp_OnlyOptionalInputs_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	wfDir := filepath.Join(tmpDir, "workflows")
 	require.NoError(t, os.MkdirAll(wfDir, 0o755))

--- a/tests/integration/secret_masking_test.go
+++ b/tests/integration/secret_masking_test.go
@@ -35,7 +35,6 @@ import (
 // Feature: C011 - Task T007
 // Strategy: Run workflow with SECRET_* variable in command output, verify masked as ***
 func TestSecretMasking_SECRET_Prefix_Integration(t *testing.T) {
-
 	tests := []struct {
 		name            string
 		workflowFile    string
@@ -146,7 +145,6 @@ func TestSecretMasking_SECRET_Prefix_Integration(t *testing.T) {
 // Feature: C011 - Task T007
 // Strategy: Run workflow with API_KEY* variable, verify masked in logs
 func TestSecretMasking_API_KEY_Prefix_Integration(t *testing.T) {
-
 	tests := []struct {
 		name            string
 		workflowFile    string
@@ -251,7 +249,6 @@ func TestSecretMasking_API_KEY_Prefix_Integration(t *testing.T) {
 // Feature: C011 - Task T007
 // Strategy: Run workflow with PASSWORD* variable, verify masked in logs
 func TestSecretMasking_PASSWORD_Prefix_Integration(t *testing.T) {
-
 	tests := []struct {
 		name            string
 		workflowFile    string
@@ -356,7 +353,6 @@ func TestSecretMasking_PASSWORD_Prefix_Integration(t *testing.T) {
 // Feature: C011 - Task T007
 // Strategy: Run workflow with mixed secret/non-secret vars, verify only secrets masked
 func TestSecretMasking_NonSecrets_Integration(t *testing.T) {
-
 	tests := []struct {
 		name            string
 		workflowFile    string
@@ -467,7 +463,6 @@ func TestSecretMasking_NonSecrets_Integration(t *testing.T) {
 // Feature: C011 - Task T007
 // Strategy: Run workflow that fails with secret in error output, verify masked
 func TestSecretMasking_ErrorOutput_Integration(t *testing.T) {
-
 	tests := []struct {
 		name            string
 		workflowFile    string
@@ -566,7 +561,6 @@ func TestSecretMasking_ErrorOutput_Integration(t *testing.T) {
 // Feature: C011 - Task T007 (Edge case)
 // Strategy: Test secret_, api_key_, password_ (lowercase) also get masked
 func TestSecretMasking_CaseInsensitive_Integration(t *testing.T) {
-
 	tests := []struct {
 		name            string
 		workflowYAML    string // Inline YAML for custom scenarios

--- a/tests/integration/signal_test.go
+++ b/tests/integration/signal_test.go
@@ -34,7 +34,6 @@ import (
 // TestSignalHandling_SIGINTGracefulShutdown verifies graceful shutdown on SIGINT
 // Strategy: Cancel context during long-running step, verify StatusCancelled
 func TestSignalHandling_SIGINTGracefulShutdown(t *testing.T) {
-
 	tests := []struct {
 		name           string
 		workflowFile   string
@@ -129,7 +128,6 @@ func TestSignalHandling_SIGINTGracefulShutdown(t *testing.T) {
 // TestSignalHandling_SIGTERMGracefulShutdown verifies graceful shutdown on SIGTERM
 // Strategy: Cancel context during multi-step workflow, verify state preservation
 func TestSignalHandling_SIGTERMGracefulShutdown(t *testing.T) {
-
 	tests := []struct {
 		name           string
 		workflowFile   string
@@ -218,7 +216,6 @@ func TestSignalHandling_SIGTERMGracefulShutdown(t *testing.T) {
 // TestSignalHandling_StatePreservation verifies state is persisted on interruption
 // Strategy: Interrupt workflow with intermediate outputs, verify JSON validity
 func TestSignalHandling_StatePreservation(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowFile string
@@ -305,7 +302,6 @@ func TestSignalHandling_StatePreservation(t *testing.T) {
 // TestSignalHandling_ParallelBranchCancellation verifies all parallel branches cancelled
 // Strategy: Cancel during parallel execution, verify no branches complete
 func TestSignalHandling_ParallelBranchCancellation(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowFile string
@@ -401,7 +397,6 @@ func TestSignalHandling_ParallelBranchCancellation(t *testing.T) {
 // TestSignalHandling_ResumabilityAfterInterruption verifies workflow can resume
 // Strategy: Cancel at step 2, then resume and verify completion
 func TestSignalHandling_ResumabilityAfterInterruption(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowFile string
@@ -492,7 +487,6 @@ func TestSignalHandling_ResumabilityAfterInterruption(t *testing.T) {
 // TestSignalHandling_RapidSuccessiveSignals verifies idempotent cancellation
 // Strategy: Cancel multiple times rapidly, verify single graceful shutdown
 func TestSignalHandling_RapidSuccessiveSignals(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowFile string
@@ -578,7 +572,6 @@ func TestSignalHandling_RapidSuccessiveSignals(t *testing.T) {
 // TestSignalHandling_ChildProcessCleanup verifies child processes terminated
 // Strategy: Spawn child process, cancel parent, verify child also terminates
 func TestSignalHandling_ChildProcessCleanup(t *testing.T) {
-
 	tests := []struct {
 		name         string
 		workflowFile string

--- a/tests/integration/sqlite_store_test.go
+++ b/tests/integration/sqlite_store_test.go
@@ -1571,7 +1571,7 @@ func TestSQLiteHistoryStore_VeryLongErrorMessage(t *testing.T) {
 // multiple processes trying to access the same database simultaneously.
 // This test spawns actual child processes to verify SQLite handles this correctly.
 func TestSQLiteHistoryStore_MultiProcessConcurrency(t *testing.T) {
-		t.Skip("skipping multi-process test in short mode")
+	t.Skip("skipping multi-process test in short mode")
 
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "multiproc.db")
@@ -1686,7 +1686,7 @@ func TestSQLiteHistoryStore_WALModeEnabled(t *testing.T) {
 // TestSQLiteHistoryStore_SimulateWorkflowExecution simulates the actual workflow
 // execution pattern: open store, record execution, close store
 func TestSQLiteHistoryStore_SimulateWorkflowExecution(t *testing.T) {
-		t.Skip("skipping workflow simulation in short mode")
+	t.Skip("skipping workflow simulation in short mode")
 
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "workflow.db")

--- a/tests/integration/state_persistence_functional_test.go
+++ b/tests/integration/state_persistence_functional_test.go
@@ -28,7 +28,6 @@ import (
 // TestJSONStore_ConcurrentAccess verifies that the JSON store handles
 // concurrent access correctly after C016 improvements.
 func TestJSONStore_ConcurrentAccess(t *testing.T) {
-
 	// Arrange
 	tmpDir := t.TempDir()
 	statesDir := filepath.Join(tmpDir, "states")
@@ -74,7 +73,6 @@ func TestJSONStore_ConcurrentAccess(t *testing.T) {
 // TestJSONStore_FileCorruption verifies that the JSON store handles
 // file corruption gracefully after C016 improvements.
 func TestJSONStore_FileCorruption(t *testing.T) {
-
 	tests := []struct {
 		name          string
 		setupFile     func(t *testing.T, path string)
@@ -153,7 +151,6 @@ func TestJSONStore_FileCorruption(t *testing.T) {
 // TestSQLiteHistoryStore_Integration verifies that the SQLite history
 // store works correctly after C016 improvements.
 func TestSQLiteHistoryStore_Integration(t *testing.T) {
-
 	// Arrange
 	tmpDir := t.TempDir()
 	historyPath := filepath.Join(tmpDir, "history.db")

--- a/tests/integration/subworkflow_fixtures_test.go
+++ b/tests/integration/subworkflow_fixtures_test.go
@@ -51,7 +51,6 @@ type rawOutput struct {
 
 // TestSubworkflowFixtures_Exist verifies all required fixture files are present.
 func TestSubworkflowFixtures_Exist(t *testing.T) {
-
 	requiredFixtures := []string{
 		"subworkflow-simple.yaml",
 		"subworkflow-child.yaml",
@@ -75,7 +74,6 @@ func TestSubworkflowFixtures_Exist(t *testing.T) {
 
 // TestSubworkflowFixtures_ValidYAML verifies all fixtures are syntactically valid YAML.
 func TestSubworkflowFixtures_ValidYAML(t *testing.T) {
-
 	fixtures := []string{
 		"subworkflow-simple.yaml",
 		"subworkflow-child.yaml",
@@ -105,7 +103,6 @@ func TestSubworkflowFixtures_ValidYAML(t *testing.T) {
 
 // TestSubworkflowFixtures_RequiredFields verifies fixtures have required workflow fields.
 func TestSubworkflowFixtures_RequiredFields(t *testing.T) {
-
 	fixtures := []struct {
 		filename    string
 		wantName    string
@@ -149,7 +146,6 @@ func TestSubworkflowFixtures_RequiredFields(t *testing.T) {
 
 // TestSubworkflowFixtures_ChildHasInputsAndOutputs verifies child workflow has proper I/O.
 func TestSubworkflowFixtures_ChildHasInputsAndOutputs(t *testing.T) {
-
 	path := filepath.Join(subworkflowFixturesPath, "subworkflow-child.yaml")
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -204,7 +200,6 @@ func TestSubworkflowFixtures_ChildHasInputsAndOutputs(t *testing.T) {
 
 // TestSubworkflowFixtures_SimpleParentHasCallWorkflow verifies parent has call_workflow step.
 func TestSubworkflowFixtures_SimpleParentHasCallWorkflow(t *testing.T) {
-
 	path := filepath.Join(subworkflowFixturesPath, "subworkflow-simple.yaml")
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -266,7 +261,6 @@ func TestSubworkflowFixtures_SimpleParentHasCallWorkflow(t *testing.T) {
 
 // TestSubworkflowFixtures_NestedChain verifies the A -> B -> C nesting chain.
 func TestSubworkflowFixtures_NestedChain(t *testing.T) {
-
 	// Verify A calls B
 	t.Run("A_calls_B", func(t *testing.T) {
 		path := filepath.Join(subworkflowFixturesPath, "subworkflow-nested-a.yaml")
@@ -346,7 +340,6 @@ func TestSubworkflowFixtures_NestedChain(t *testing.T) {
 
 // TestSubworkflowFixtures_CircularReference verifies A -> B -> A pattern.
 func TestSubworkflowFixtures_CircularReference(t *testing.T) {
-
 	// Verify A calls B
 	t.Run("A_calls_B", func(t *testing.T) {
 		path := filepath.Join(subworkflowFixturesPath, "subworkflow-circular-a.yaml")
@@ -398,7 +391,6 @@ func TestSubworkflowFixtures_CircularReference(t *testing.T) {
 
 // TestSubworkflowFixtures_SelfCircularReference verifies A → A (direct self-call) pattern.
 func TestSubworkflowFixtures_SelfCircularReference(t *testing.T) {
-
 	path := filepath.Join(subworkflowFixturesPath, "subworkflow-circular.yaml")
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -439,7 +431,6 @@ func TestSubworkflowFixtures_SelfCircularReference(t *testing.T) {
 
 // TestSubworkflowFixtures_TimeoutSpecified verifies call_workflow steps have timeout.
 func TestSubworkflowFixtures_TimeoutSpecified(t *testing.T) {
-
 	fixtures := []struct {
 		filename string
 		stepName string

--- a/tests/integration/subworkflow_functional_test.go
+++ b/tests/integration/subworkflow_functional_test.go
@@ -38,7 +38,6 @@ import (
 // TestSubworkflow_StateVisibleInParent_Functional verifies that sub-workflow step state
 // is properly recorded in parent's execution context (AC7).
 func TestSubworkflow_StateVisibleInParent_Functional(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create child that produces known output
@@ -113,7 +112,6 @@ states:
 // TestSubworkflow_InsideForEachLoop_Functional verifies sub-workflows can be called
 // from within a for_each loop body.
 func TestSubworkflow_InsideForEachLoop_Functional(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "loop.log")
 
@@ -198,7 +196,6 @@ states:
 
 // TestSubworkflow_MultipleOutputs_Functional verifies mapping multiple outputs from child.
 func TestSubworkflow_MultipleOutputs_Functional(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "multi.log")
 
@@ -282,7 +279,6 @@ states:
 // TestSubworkflow_MissingRequiredInput_Functional verifies error when child requires
 // an input not provided by parent.
 func TestSubworkflow_MissingRequiredInput_Functional(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create child requiring a specific input
@@ -358,7 +354,6 @@ states:
 // TestSubworkflow_DefaultInputValue_Functional verifies child uses default when
 // parent omits optional input.
 func TestSubworkflow_DefaultInputValue_Functional(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "default.log")
 
@@ -432,7 +427,6 @@ states:
 // TestSubworkflow_CallStackInErrorMessage_Functional verifies that circular call
 // errors include the full call stack for debugging.
 func TestSubworkflow_CallStackInErrorMessage_Functional(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create A that calls B
@@ -507,7 +501,6 @@ states:
 // TestSubworkflow_ParentInputPassedToChild_Functional verifies parent workflow inputs
 // are correctly interpolated and passed to child workflow.
 func TestSubworkflow_ParentInputPassedToChild_Functional(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "pass.log")
 
@@ -586,7 +579,6 @@ states:
 // TestSubworkflow_ContinueOnError_Functional verifies continue_on_error behavior
 // with failing sub-workflows.
 func TestSubworkflow_ContinueOnError_Functional(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "continue.log")
 
@@ -659,7 +651,6 @@ states:
 
 // TestSubworkflow_WithHooks_Functional verifies pre and post hooks work with sub-workflows.
 func TestSubworkflow_WithHooks_Functional(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "hooks.log")
 
@@ -745,7 +736,6 @@ states:
 // TestSubworkflow_EmptyInputsAndOutputs_Functional verifies sub-workflow works with
 // no inputs or outputs configured.
 func TestSubworkflow_EmptyInputsAndOutputs_Functional(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "empty.log")
 
@@ -813,7 +803,6 @@ states:
 // TestSubworkflow_UsesPreviousStepOutput_Functional verifies parent can pass previous
 // step output to child workflow.
 func TestSubworkflow_UsesPreviousStepOutput_Functional(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "prev.log")
 

--- a/tests/integration/subworkflow_test.go
+++ b/tests/integration/subworkflow_test.go
@@ -35,7 +35,6 @@ import (
 // TestSubworkflow_Simple_Integration verifies basic parent → child sub-workflow invocation.
 // Tests: call_workflow loads child, passes inputs, captures outputs
 func TestSubworkflow_Simple_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "simple.log")
 
@@ -137,7 +136,6 @@ states:
 // TestSubworkflow_NestedThreeLevels_Integration verifies 3-level nesting: A → B → C.
 // Uses fixtures: subworkflow-nested-a.yaml, subworkflow-nested-b.yaml, subworkflow-nested-c.yaml
 func TestSubworkflow_NestedThreeLevels_Integration(t *testing.T) {
-
 	// Use existing fixtures
 	fixturesPath := "../fixtures/workflows"
 
@@ -170,7 +168,6 @@ func TestSubworkflow_NestedThreeLevels_Integration(t *testing.T) {
 // TestSubworkflow_CircularDetection_Integration verifies circular call A → B → A is detected.
 // Uses fixtures: subworkflow-circular-a.yaml, subworkflow-circular-b.yaml
 func TestSubworkflow_CircularDetection_Integration(t *testing.T) {
-
 	fixturesPath := "../fixtures/workflows"
 
 	repo := repository.NewYAMLRepository(fixturesPath)
@@ -197,7 +194,6 @@ func TestSubworkflow_CircularDetection_Integration(t *testing.T) {
 // TestSubworkflow_SelfReference_Integration verifies direct self-reference A → A is detected.
 // Uses fixture: subworkflow-circular.yaml
 func TestSubworkflow_SelfReference_Integration(t *testing.T) {
-
 	fixturesPath := "../fixtures/workflows"
 
 	repo := repository.NewYAMLRepository(fixturesPath)
@@ -223,7 +219,6 @@ func TestSubworkflow_SelfReference_Integration(t *testing.T) {
 
 // TestSubworkflow_Timeout_Integration verifies sub-workflow respects timeout configuration.
 func TestSubworkflow_Timeout_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create slow child workflow
@@ -295,7 +290,6 @@ states:
 
 // TestSubworkflow_ErrorPropagation_Integration verifies child failure propagates to parent.
 func TestSubworkflow_ErrorPropagation_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create failing child
@@ -366,7 +360,6 @@ states:
 
 // TestSubworkflow_OutputMapping_Integration verifies child outputs are accessible in parent.
 func TestSubworkflow_OutputMapping_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "output.log")
 
@@ -446,7 +439,6 @@ states:
 
 // TestSubworkflow_NotFound_Integration verifies error when sub-workflow doesn't exist.
 func TestSubworkflow_NotFound_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create parent calling non-existent child
@@ -499,7 +491,6 @@ states:
 
 // TestSubworkflow_ContextCancellation_Integration verifies parent cancellation propagates to child.
 func TestSubworkflow_ContextCancellation_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "cancel.log")
 
@@ -574,7 +565,6 @@ states:
 
 // TestSubworkflow_InputMapping_Integration verifies input mapping with interpolation.
 func TestSubworkflow_InputMapping_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "inputs.log")
 
@@ -666,7 +656,6 @@ states:
 
 // TestSubworkflow_WithExistingFixtures_Integration runs using the pre-defined fixtures.
 func TestSubworkflow_WithExistingFixtures_Integration(t *testing.T) {
-
 	fixturesPath := "../fixtures/workflows"
 
 	repo := repository.NewYAMLRepository(fixturesPath)
@@ -694,7 +683,6 @@ func TestSubworkflow_WithExistingFixtures_Integration(t *testing.T) {
 
 // TestSubworkflow_MaxNestingDepth_Integration verifies max nesting depth is enforced.
 func TestSubworkflow_MaxNestingDepth_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 
 	// Create a chain of workflows that exceeds max depth (default is 10)

--- a/tests/integration/template_test.go
+++ b/tests/integration/template_test.go
@@ -25,7 +25,6 @@ const templatesFixturePath = "../fixtures/templates"
 // =============================================================================
 
 func TestTemplateRepository_LoadFromFixtures_Integration(t *testing.T) {
-
 	repo := repository.NewYAMLTemplateRepository([]string{templatesFixturePath})
 
 	tests := []struct {
@@ -90,7 +89,6 @@ func TestTemplateRepository_LoadFromFixtures_Integration(t *testing.T) {
 }
 
 func TestTemplateRepository_ListTemplates_Integration(t *testing.T) {
-
 	repo := repository.NewYAMLTemplateRepository([]string{templatesFixturePath})
 	ctx := context.Background()
 
@@ -112,7 +110,6 @@ func TestTemplateRepository_ListTemplates_Integration(t *testing.T) {
 }
 
 func TestTemplateRepository_Exists_Integration(t *testing.T) {
-
 	repo := repository.NewYAMLTemplateRepository([]string{templatesFixturePath})
 	ctx := context.Background()
 
@@ -126,7 +123,6 @@ func TestTemplateRepository_Exists_Integration(t *testing.T) {
 // =============================================================================
 
 func TestTemplateService_ExpandWorkflow_Integration(t *testing.T) {
-
 	templateRepo := repository.NewYAMLTemplateRepository([]string{templatesFixturePath})
 	logger := &mockLogger{}
 
@@ -175,7 +171,6 @@ func TestTemplateService_ExpandWorkflow_Integration(t *testing.T) {
 }
 
 func TestTemplateService_ExpandWorkflow_OverrideDefaults_Integration(t *testing.T) {
-
 	templateRepo := repository.NewYAMLTemplateRepository([]string{templatesFixturePath})
 	logger := &mockLogger{}
 
@@ -213,7 +208,6 @@ func TestTemplateService_ExpandWorkflow_OverrideDefaults_Integration(t *testing.
 }
 
 func TestTemplateService_ValidateTemplateRef_Integration(t *testing.T) {
-
 	templateRepo := repository.NewYAMLTemplateRepository([]string{templatesFixturePath})
 	logger := &mockLogger{}
 
@@ -263,7 +257,6 @@ func TestTemplateService_ValidateTemplateRef_Integration(t *testing.T) {
 // =============================================================================
 
 func TestWorkflowWithTemplate_Execution_Integration(t *testing.T) {
-
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "output.log")
 
@@ -311,7 +304,6 @@ states:
 // =============================================================================
 
 func TestTemplateService_CircularReference_Integration(t *testing.T) {
-
 	// The circular-a and circular-b fixtures reference each other
 	templateRepo := repository.NewYAMLTemplateRepository([]string{templatesFixturePath})
 	logger := &mockLogger{}
@@ -345,7 +337,6 @@ func TestTemplateService_CircularReference_Integration(t *testing.T) {
 }
 
 func TestTemplateService_InvalidTemplate_Integration(t *testing.T) {
-
 	templateRepo := repository.NewYAMLTemplateRepository([]string{templatesFixturePath})
 
 	t.Run("invalid syntax", func(t *testing.T) {
@@ -366,7 +357,6 @@ func TestTemplateService_InvalidTemplate_Integration(t *testing.T) {
 // =============================================================================
 
 func TestMultipleTemplates_SameWorkflow_Integration(t *testing.T) {
-
 	templateRepo := repository.NewYAMLTemplateRepository([]string{templatesFixturePath})
 	logger := &mockLogger{}
 
@@ -436,7 +426,6 @@ func TestMultipleTemplates_SameWorkflow_Integration(t *testing.T) {
 // =============================================================================
 
 func TestTemplateService_ComplexParameters_Integration(t *testing.T) {
-
 	templateRepo := repository.NewYAMLTemplateRepository([]string{templatesFixturePath})
 	logger := &mockLogger{}
 
@@ -508,7 +497,6 @@ func TestTemplateService_ComplexParameters_Integration(t *testing.T) {
 // =============================================================================
 
 func TestTemplateRepository_PathPriority_Integration(t *testing.T) {
-
 	// Create temp directory with override template
 	tmpDir := t.TempDir()
 	overrideContent := `
@@ -568,7 +556,6 @@ states:
 // =============================================================================
 
 func TestTemplateRepository_Caching_Integration(t *testing.T) {
-
 	repo := repository.NewYAMLTemplateRepository([]string{templatesFixturePath})
 	ctx := context.Background()
 

--- a/tests/integration/validation_providers_test.go
+++ b/tests/integration/validation_providers_test.go
@@ -36,7 +36,6 @@ import (
 // =============================================================================
 
 func TestClaudeProvider_Execute_WithTypeCheckedOptions(t *testing.T) {
-
 	provider := agents.NewClaudeProvider()
 	if err := provider.Validate(); err != nil {
 		t.Skip("Claude CLI not installed, skipping")
@@ -94,7 +93,6 @@ func TestClaudeProvider_Execute_WithTypeCheckedOptions(t *testing.T) {
 }
 
 func TestCodexProvider_ExecuteConversation_WithTypeCheckedOptions(t *testing.T) {
-
 	provider := agents.NewCodexProvider()
 	if err := provider.Validate(); err != nil {
 		t.Skip("Codex CLI not installed, skipping")
@@ -163,7 +161,6 @@ func TestCodexProvider_ExecuteConversation_WithTypeCheckedOptions(t *testing.T) 
 }
 
 func TestGeminiProvider_ExecuteConversation_WithTypeCheckedOptions(t *testing.T) {
-
 	provider := agents.NewGeminiProvider()
 	if err := provider.Validate(); err != nil {
 		t.Skip("Gemini CLI not installed, skipping")
@@ -217,7 +214,6 @@ func TestGeminiProvider_ExecuteConversation_WithTypeCheckedOptions(t *testing.T)
 // =============================================================================
 
 func TestClaudeProvider_Execute_EmptyAndNilOptions(t *testing.T) {
-
 	provider := agents.NewClaudeProvider()
 	if err := provider.Validate(); err != nil {
 		t.Skip("Claude CLI not installed, skipping")
@@ -257,7 +253,6 @@ func TestClaudeProvider_Execute_EmptyAndNilOptions(t *testing.T) {
 }
 
 func TestSharedHelpers_TokenEstimation(t *testing.T) {
-
 	// Test that token estimation is consistent across providers after extraction
 	tests := []struct {
 		name     string
@@ -299,7 +294,6 @@ func TestSharedHelpers_TokenEstimation(t *testing.T) {
 }
 
 func TestConversationState_Cloning(t *testing.T) {
-
 	// Test that state cloning works correctly after helper extraction
 	provider := agents.NewCodexProvider()
 	if err := provider.Validate(); err != nil {
@@ -341,7 +335,6 @@ func TestConversationState_Cloning(t *testing.T) {
 // =============================================================================
 
 func TestClaudeProvider_Execute_InvalidOptionTypes(t *testing.T) {
-
 	provider := agents.NewClaudeProvider()
 	if err := provider.Validate(); err != nil {
 		t.Skip("Claude CLI not installed, skipping")
@@ -390,7 +383,6 @@ func TestClaudeProvider_Execute_InvalidOptionTypes(t *testing.T) {
 }
 
 func TestCodexProvider_ExecuteConversation_EmptyPrompt(t *testing.T) {
-
 	provider := agents.NewCodexProvider()
 	if err := provider.Validate(); err != nil {
 		t.Skip("Codex CLI not installed, skipping")
@@ -409,7 +401,6 @@ func TestCodexProvider_ExecuteConversation_EmptyPrompt(t *testing.T) {
 }
 
 func TestGeminiProvider_ExecuteConversation_NilState(t *testing.T) {
-
 	provider := agents.NewGeminiProvider()
 	if err := provider.Validate(); err != nil {
 		t.Skip("Gemini CLI not installed, skipping")
@@ -425,7 +416,6 @@ func TestGeminiProvider_ExecuteConversation_NilState(t *testing.T) {
 }
 
 func TestAllProviders_ContextCancellation(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		provider ports.AgentProvider
@@ -463,7 +453,6 @@ func TestAllProviders_ContextCancellation(t *testing.T) {
 }
 
 func TestAllProviders_ContextTimeout(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		provider ports.AgentProvider
@@ -507,7 +496,6 @@ func TestAllProviders_ContextTimeout(t *testing.T) {
 // =============================================================================
 
 func TestIntegration_MultiTurnConversation_WithTokenEstimation(t *testing.T) {
-
 	provider := agents.NewCodexProvider()
 	if err := provider.Validate(); err != nil {
 		t.Skip("Codex CLI not installed, skipping")
@@ -548,7 +536,6 @@ func TestIntegration_MultiTurnConversation_WithTokenEstimation(t *testing.T) {
 }
 
 func TestIntegration_JSONParsing_SharedHelper(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		provider ports.AgentProvider
@@ -590,7 +577,6 @@ func TestIntegration_JSONParsing_SharedHelper(t *testing.T) {
 }
 
 func TestIntegration_ProviderSpecificValidation_Preserved(t *testing.T) {
-
 	// Test that provider-specific validations still work after refactoring
 	// (ADR-003: Preserve provider-specific validation)
 
@@ -657,7 +643,6 @@ func TestIntegration_ProviderSpecificValidation_Preserved(t *testing.T) {
 // =============================================================================
 
 func TestBackwardCompatibility_ExistingWorkflows(t *testing.T) {
-
 	// Test that refactored providers work with existing workflow fixtures
 	// This ensures no behavioral changes (AC5)
 
@@ -707,7 +692,6 @@ func TestBackwardCompatibility_ExistingWorkflows(t *testing.T) {
 // =============================================================================
 
 func TestPerformance_NoRegressionFromHelpers(t *testing.T) {
-
 	// Basic smoke test to ensure helper extraction doesn't cause performance issues
 	// (Risk: Performance regression from function call overhead - P2 Very Low)
 
@@ -731,7 +715,6 @@ func TestPerformance_NoRegressionFromHelpers(t *testing.T) {
 }
 
 func TestRegression_AllOptionTypesCombined(t *testing.T) {
-
 	// Comprehensive regression test with all option types
 	// Validates C001 pattern (type-checked wrappers) works correctly
 

--- a/tests/integration/validation_test.go
+++ b/tests/integration/validation_test.go
@@ -20,7 +20,6 @@ import (
 
 // TestValidateRules_HappyPath validates normal usage with all validation types
 func TestValidateRules_HappyPath(t *testing.T) {
-
 	tests := []struct {
 		name        string
 		definitions []validation.Input
@@ -122,7 +121,6 @@ func TestValidateRules_HappyPath(t *testing.T) {
 
 // TestValidateRules_EdgeCases validates boundary conditions and edge cases
 func TestValidateRules_EdgeCases(t *testing.T) {
-
 	tests := []struct {
 		name        string
 		definitions []validation.Input
@@ -328,7 +326,6 @@ func TestValidateRules_EdgeCases(t *testing.T) {
 
 // TestValidateRules_ErrorHandling validates invalid inputs are rejected properly
 func TestValidateRules_ErrorHandling(t *testing.T) {
-
 	tests := []struct {
 		name        string
 		definitions []validation.Input
@@ -447,7 +444,6 @@ func TestValidateRules_ErrorHandling(t *testing.T) {
 
 // TestValidateRules_FileValidation validates file-based validation rules
 func TestValidateRules_FileValidation(t *testing.T) {
-
 	// create temp files for testing
 	tmpDir := t.TempDir()
 	validFile := filepath.Join(tmpDir, "valid.txt")
@@ -604,7 +600,6 @@ func TestValidateRules_FileValidation(t *testing.T) {
 
 // TestValidateRules_Integration validates full workflow execution with validation
 func TestValidateRules_Integration(t *testing.T) {
-
 	// define complex input schema with all validation types
 	definitions := []validation.Input{
 		{
@@ -711,7 +706,6 @@ func TestValidateRules_Integration(t *testing.T) {
 
 // TestValidateRules_BackwardCompatibility ensures refactoring maintains exact behavior
 func TestValidateRules_BackwardCompatibility(t *testing.T) {
-
 	// Test scenarios that should work identically before and after refactoring
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary

- Replace `Manifest.Validate()` stub with fail-fast validation logic
- Add 130+ table-driven unit tests covering all validation paths
- Add 18 integration tests for parser-to-validation workflow
- Achieve 99% test coverage (exceeds 80% requirement)

## Changes

### Core Implementation (`internal/domain/plugin/manifest.go`)

| Validation | Rule |
|------------|------|
| Name | `^[a-z][a-z0-9-]*$` regex pattern |
| Version | Non-empty string required |
| AWFVersion | Non-empty constraint required |
| Capabilities | Whitelist: `operations`, `commands`, `validators` |
| Config fields | Type validation, enum constraints (string-only), default type matching |

New helpers: `validateConfigField()`, `validateDefaultType()` with JSON float64 quirk handling.

### Tests

- **Unit tests** (`manifest_test.go`): +2391 lines, 130+ test cases
- **Integration tests** (`plugin_validation_manifest_test.go`): 640 lines, 18 tests with Given/When/Then structure

### Formatting Cleanup

42 integration test files: blank line removals after function signatures (triggered by `make lint`).

## Breaking Changes

- `Manifest.Validate()` now returns `nil` for valid manifests instead of `ErrNotImplemented`
- Invalid plugin manifests are now rejected during loading

## Test Plan

- [x] Unit tests pass (`make test-unit`)
- [x] Integration tests pass (`make test-integration`)
- [x] Lint passes (`make lint`)
- [x] Coverage: 99% for manifest validation

Closes #135