### PR TITLE
fix(test): correct conversation workflow fixtures

### DIFF
--- a/tests/fixtures/workflows/conversation-error.yaml
+++ b/tests/fixtures/workflows/conversation-error.yaml
@@ -36,9 +36,6 @@ states:
         - command: echo "Starting conversation attempt"
       post:
         - command: echo "Conversation completed"
-      error:
-        - command: echo "Conversation failed: {{error.Message}}"
-        - log: "Error occurred in conversation step"
     on_success: conversation_with_error_transition
     on_failure: handle_failure
 
@@ -56,44 +53,11 @@ states:
     timeout: 30
     on_success: done
     on_failure: handle_failure
-    on_error:
-      provider_timeout: timeout_recovery
-      invalid_response: response_recovery
-
-  timeout_recovery:
-    type: agent
-    provider: codex
-    mode: conversation
-    system_prompt: "Provide quick response."
-    initial_prompt: "Recover from timeout for: {{inputs.task}}"
-    conversation:
-      max_turns: 2
-      strategy: sliding_window
-    timeout: 20
-    on_success: done
-    on_failure: handle_failure
-
-  response_recovery:
-    type: agent
-    provider: claude
-    mode: conversation
-    system_prompt: "Handle invalid responses gracefully."
-    initial_prompt: "Retry with: {{inputs.task}}"
-    options:
-      model: claude-haiku-4-5
-    conversation:
-      max_turns: 3
-      strategy: sliding_window
-      stop_condition: "turn_count >= 2"
-    timeout: 30
-    on_success: done
-    on_failure: handle_failure
 
   handle_failure:
-    type: step
+    type: command
     command: |
       echo "Workflow failed at conversation step"
-      echo "Error details: {{error.Message}}"
       exit 1
     on_success: error
     on_failure: error

--- a/tests/fixtures/workflows/conversation-parallel.yaml
+++ b/tests/fixtures/workflows/conversation-parallel.yaml
@@ -15,60 +15,58 @@ states:
   parallel_conversations:
     type: parallel
     strategy: all_succeed
-    branches:
-      - name: claude_research
-        steps:
-          - name: claude_convo
-            type: agent
-            provider: claude
-            mode: conversation
-            system_prompt: "You are a research assistant specializing in technical analysis."
-            initial_prompt: "Research: {{inputs.task}}"
-            options:
-              model: claude-haiku-4-5
-              max_tokens: 2000
-            conversation:
-              max_turns: 5
-              max_context_tokens: 60000
-              strategy: sliding_window
-              stop_condition: "response contains 'RESEARCH COMPLETE'"
-            timeout: 90
-            on_success: done
-
-      - name: gemini_research
-        steps:
-          - name: gemini_convo
-            type: agent
-            provider: gemini
-            mode: conversation
-            system_prompt: "You are a research assistant focusing on practical applications."
-            initial_prompt: "Investigate: {{inputs.task}}"
-            options:
-              model: gemini-pro
-            conversation:
-              max_turns: 5
-              max_context_tokens: 50000
-              strategy: sliding_window
-              stop_condition: "turn_count >= 4"
-            timeout: 90
-            on_success: done
-
-      - name: codex_research
-        steps:
-          - name: codex_convo
-            type: agent
-            provider: codex
-            mode: conversation
-            system_prompt: "You are a research assistant emphasizing code examples."
-            initial_prompt: "Analyze: {{inputs.task}}"
-            conversation:
-              max_turns: 6
-              strategy: sliding_window
-              stop_condition: "response contains 'ANALYSIS DONE'"
-            timeout: 90
-            on_success: done
+    parallel:
+      - claude_convo
+      - gemini_convo
+      - codex_convo
     on_success: synthesize
     on_failure: error
+
+  claude_convo:
+    type: agent
+    provider: claude
+    mode: conversation
+    system_prompt: "You are a research assistant specializing in technical analysis."
+    initial_prompt: "Research: {{inputs.task}}"
+    options:
+      model: claude-haiku-4-5
+      max_tokens: 2000
+    conversation:
+      max_turns: 5
+      max_context_tokens: 60000
+      strategy: sliding_window
+      stop_condition: "response contains 'RESEARCH COMPLETE'"
+    timeout: 90
+    on_success: done
+
+  gemini_convo:
+    type: agent
+    provider: gemini
+    mode: conversation
+    system_prompt: "You are a research assistant focusing on practical applications."
+    initial_prompt: "Investigate: {{inputs.task}}"
+    options:
+      model: gemini-pro
+    conversation:
+      max_turns: 5
+      max_context_tokens: 50000
+      strategy: sliding_window
+      stop_condition: "turn_count >= 4"
+    timeout: 90
+    on_success: done
+
+  codex_convo:
+    type: agent
+    provider: codex
+    mode: conversation
+    system_prompt: "You are a research assistant emphasizing code examples."
+    initial_prompt: "Analyze: {{inputs.task}}"
+    conversation:
+      max_turns: 6
+      strategy: sliding_window
+      stop_condition: "response contains 'ANALYSIS DONE'"
+    timeout: 90
+    on_success: done
 
   synthesize:
     type: agent
@@ -78,11 +76,11 @@ states:
     initial_prompt: |
       Synthesize these research findings:
 
-      Claude findings: {{states.parallel_conversations.branches.claude_research.steps.claude_convo.Output}}
+      Claude findings: {{states.claude_convo.output}}
 
-      Gemini findings: {{states.parallel_conversations.branches.gemini_research.steps.gemini_convo.Output}}
+      Gemini findings: {{states.gemini_convo.output}}
 
-      Codex findings: {{states.parallel_conversations.branches.codex_research.steps.codex_convo.Output}}
+      Codex findings: {{states.codex_convo.output}}
     options:
       model: claude-haiku-4-5
       max_tokens: 3000

--- a/tests/integration/conversation_test.go
+++ b/tests/integration/conversation_test.go
@@ -85,12 +85,12 @@ func TestFeature33_ConversationModeRecognizedByValidator(t *testing.T) {
 		{
 			name:         "parallel_conversation_workflow",
 			workflowName: "conversation-parallel",
-			shouldPass:   false, // FIXME(#130): Fixture has invalid parallel structure
+			shouldPass:   true,
 		},
 		{
 			name:         "error_handling_conversation_workflow",
 			workflowName: "conversation-error",
-			shouldPass:   false, // FIXME(#130): Fixture has YAML syntax error
+			shouldPass:   true,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Fixed FIXME markers in conversation workflow fixtures that prevented validation in test suite
- Restructured `conversation-parallel.yaml` from nested branches to flat parallel array pattern required by domain model
- Removed unsupported YAML fields (`hooks.error`, `on_error`) and corrected step type from `step` to `command`

## Changes

### Modified
- `tests/fixtures/workflows/conversation-error.yaml`: Removed unsupported `hooks.error` and `on_error` fields, changed `type: step` to `type: command` for error handling state
- `tests/fixtures/workflows/conversation-parallel.yaml`: Refactored from nested branch object structure to flat parallel array of step name references with separate state definitions, fixed output interpolation to use `{{states.step_name.output}}` pattern
- `tests/integration/conversation_test.go`: Updated `shouldPass` boolean from `false` to `true` for `conversation-parallel` and `conversation-error` fixtures (lines 88 and 93), removed FIXME(#130) comments

## Related

Fixes #138