### PR TITLE
chore(c053): clean up 50+ test skips and dead code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixes: conversation-simple, conversation-multiturn, conversation-max-turns, conversation-error workflows
   - Impact: 391 lines added, 102 lines removed across 4 application layer files
 
+### Chores
+
+- **C053**: Clean up 50+ problematic test skips across codebase
+  - Removed 12 commented-out `t.Skip()` lines from T009 tests
+  - Removed 19 dead `defer recover()` blocks from graphviz tests
+  - Removed 7 dead conditional skips for existing directories/fixtures
+  - Deleted 7 untestable/duplicate test stubs
+  - Deleted 8 feature placeholder tests
+  - Implemented nil-guard checks in `HandleExecutionError` and `HandleNonZeroExit`
+  - Converted 1 unconditional skip to `testing.Short()` pattern
+
 ### Breaking Changes
 
 - **[B001] Expression context normalization to PascalCase**

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -468,7 +468,7 @@ func BenchmarkInterpolate(b *testing.B)
 
 ## Skip Policy
 
-AWF minimizes runtime test skips to maintain accurate coverage metrics and test signal. Follow these guidelines:
+AWF minimizes runtime test skips to maintain accurate coverage metrics and test signal. This policy was enforced by C053, which cleaned up 50+ problematic `t.Skip()` calls: removing dead code, deleting empty stubs, implementing missing nil-guard behavior, and converting unconditional skips to proper `testing.Short()` patterns. Follow these guidelines:
 
 ### When NOT to Skip
 

--- a/internal/application/execution_service.go
+++ b/internal/application/execution_service.go
@@ -1238,8 +1238,9 @@ func (s *ExecutionService) IsProblematicMaxIterationPattern(
 	return hadFailures || hasComplexSteps
 }
 
-// HandleMaxIterationFailure handles the failure case when a loop hits max iterations with problematic patterns.
-// It updates the loop state, executes post-hooks, and returns the appropriate next step or error.
+// HandleMaxIterationFailure handles the case when a loop hits max iterations with problematic patterns.
+// If OnComplete is configured, completes successfully via that transition (e.g., retry patterns).
+// Otherwise, treats as failure and returns error or transitions via OnFailure.
 func (s *ExecutionService) HandleMaxIterationFailure(
 	ctx context.Context,
 	result *workflow.LoopResult,
@@ -1251,7 +1252,22 @@ func (s *ExecutionService) HandleMaxIterationFailure(
 	// Use extracted helper to determine pattern type
 	hadFailures, hasComplexSteps := s.detectLoopPatterns(result, wf)
 
-	// Update loop state with failure status
+	// If OnComplete is configured, treat max iterations as successful completion
+	// This supports retry patterns where on_failure loops back until max iterations
+	if step.Loop != nil && step.Loop.OnComplete != "" {
+		loopState.Status = workflow.StatusCompleted
+		if result != nil {
+			loopState.Output = fmt.Sprintf("completed %d iterations", result.TotalCount)
+		}
+		execCtx.SetStepState(step.Name, *loopState)
+
+		// Use extracted helper to execute post-hooks
+		s.executeLoopPostHooks(ctx, step, execCtx)
+
+		return step.Loop.OnComplete, nil
+	}
+
+	// No OnComplete configured - treat as failure
 	loopState.Status = workflow.StatusFailed
 
 	// Use extracted helper to build error message

--- a/internal/application/execution_service_retry_test.go
+++ b/internal/application/execution_service_retry_test.go
@@ -459,7 +459,9 @@ func TestExecutionService_Run_WithRetry_MultipleStepsWithRetry(t *testing.T) {
 // SKIP: This test is slow due to buildInterpolationContext overhead per iteration.
 // Retry pattern behavior is covered by unit tests in loop_executor_transitions_test.go
 func TestStepExecutorCallback_RetryPattern_ReturnsLoopNameAndNil(t *testing.T) {
-	t.Skip("Slow integration test - retry pattern covered by loop_executor unit tests")
+	if testing.Short() {
+		t.Skip("skipping slow retry pattern integration test")
+	}
 
 	// Arrange: Setup workflow with retry pattern (on_failure -> loop)
 	repo := newMockRepository()

--- a/internal/application/execution_service_t009_test.go
+++ b/internal/application/execution_service_t009_test.go
@@ -39,8 +39,6 @@ import (
 // executeConversationStep successfully delegates a single-turn conversation
 // to ConversationManager and maps the result to StepState.
 func TestExecuteConversationStep_T009_HappyPath_SingleTurnSuccess(t *testing.T) {
-	// t.Skip("T009: RED phase - implement executeConversationStep delegation")
-
 	// Arrange
 	step := &workflow.Step{
 		Name: "chat",
@@ -107,8 +105,6 @@ func TestExecuteConversationStep_T009_HappyPath_SingleTurnSuccess(t *testing.T) 
 // TestExecuteConversationStep_T009_HappyPath_MultiTurnSuccess tests that
 // executeConversationStep handles multi-turn conversations correctly.
 func TestExecuteConversationStep_T009_HappyPath_MultiTurnSuccess(t *testing.T) {
-	// 	t.Skip("T009: RED phase - implement executeConversationStep delegation")
-
 	// Arrange
 	step := &workflow.Step{
 		Name: "chat",
@@ -180,8 +176,6 @@ func TestExecuteConversationStep_T009_HappyPath_MultiTurnSuccess(t *testing.T) {
 // executeConversationStep passes buildContext function to ConversationManager
 // for interpolating InitialPrompt with workflow inputs and step states.
 func TestExecuteConversationStep_T009_HappyPath_WithInputInterpolation(t *testing.T) {
-	// 	t.Skip("T009: RED phase - implement executeConversationStep delegation")
-
 	// Arrange
 	step := &workflow.Step{
 		Name: "analyze",
@@ -241,8 +235,6 @@ func TestExecuteConversationStep_T009_HappyPath_WithInputInterpolation(t *testin
 // TestExecuteConversationStep_T009_EdgeCase_MinimalConfig tests that
 // executeConversationStep works with minimal conversation config (defaults).
 func TestExecuteConversationStep_T009_EdgeCase_MinimalConfig(t *testing.T) {
-	// 	t.Skip("T009: RED phase - implement executeConversationStep delegation")
-
 	// Arrange
 	step := &workflow.Step{
 		Name: "chat",
@@ -286,8 +278,6 @@ func TestExecuteConversationStep_T009_EdgeCase_MinimalConfig(t *testing.T) {
 // TestExecuteConversationStep_T009_EdgeCase_EmptyOutput tests handling of
 // conversations where final turn produces empty assistant response.
 func TestExecuteConversationStep_T009_EdgeCase_EmptyOutput(t *testing.T) {
-	// 	t.Skip("T009: RED phase - implement executeConversationStep delegation")
-
 	// Arrange
 	step := &workflow.Step{
 		Name: "chat",
@@ -343,8 +333,6 @@ func TestExecuteConversationStep_T009_EdgeCase_EmptyOutput(t *testing.T) {
 // TestExecuteConversationStep_T009_EdgeCase_ContextCancellation tests that
 // executeConversationStep respects context cancellation.
 func TestExecuteConversationStep_T009_EdgeCase_ContextCancellation(t *testing.T) {
-	// 	t.Skip("T009: RED phase - implement executeConversationStep delegation")
-
 	// Arrange
 	step := &workflow.Step{
 		Name: "chat",
@@ -393,8 +381,6 @@ func TestExecuteConversationStep_T009_EdgeCase_ContextCancellation(t *testing.T)
 // TestExecuteConversationStep_T009_Error_NoConversationManager tests that
 // executeConversationStep returns error when ConversationManager is nil.
 func TestExecuteConversationStep_T009_Error_NoConversationManager(t *testing.T) {
-	// 	t.Skip("T009: RED phase - implement executeConversationStep delegation")
-
 	// Arrange
 	step := &workflow.Step{
 		Name: "chat",
@@ -426,8 +412,6 @@ func TestExecuteConversationStep_T009_Error_NoConversationManager(t *testing.T) 
 // TestExecuteConversationStep_T009_Error_NilConversationConfig tests that
 // executeConversationStep returns error when step.Agent.Conversation is nil.
 func TestExecuteConversationStep_T009_Error_NilConversationConfig(t *testing.T) {
-	// 	t.Skip("T009: RED phase - implement executeConversationStep delegation")
-
 	// Arrange
 	step := &workflow.Step{
 		Name: "chat",
@@ -459,8 +443,6 @@ func TestExecuteConversationStep_T009_Error_NilConversationConfig(t *testing.T) 
 // TestExecuteConversationStep_T009_Error_NilAgentConfig tests that
 // executeConversationStep returns error when step.Agent is nil.
 func TestExecuteConversationStep_T009_Error_NilAgentConfig(t *testing.T) {
-	// 	t.Skip("T009: RED phase - implement executeConversationStep delegation")
-
 	// Arrange
 	step := &workflow.Step{
 		Name:  "chat",
@@ -487,8 +469,6 @@ func TestExecuteConversationStep_T009_Error_NilAgentConfig(t *testing.T) {
 // TestExecuteConversationStep_T009_Error_ConversationManagerFailure tests that
 // executeConversationStep propagates errors from ConversationManager.
 func TestExecuteConversationStep_T009_Error_ConversationManagerFailure(t *testing.T) {
-	// 	t.Skip("T009: RED phase - implement executeConversationStep delegation")
-
 	// Arrange
 	step := &workflow.Step{
 		Name: "chat",
@@ -524,8 +504,6 @@ func TestExecuteConversationStep_T009_Error_ConversationManagerFailure(t *testin
 // TestExecuteConversationStep_T009_Error_ProviderNotFound tests error handling
 // when agent provider is not registered in the registry.
 func TestExecuteConversationStep_T009_Error_ProviderNotFound(t *testing.T) {
-	// 	t.Skip("T009: RED phase - implement executeConversationStep delegation")
-
 	// Arrange
 	step := &workflow.Step{
 		Name: "chat",
@@ -561,8 +539,6 @@ func TestExecuteConversationStep_T009_Error_ProviderNotFound(t *testing.T) {
 // TestExecuteConversationStep_T009_Error_InterpolationFailure tests error handling
 // when initial prompt interpolation fails.
 func TestExecuteConversationStep_T009_Error_InterpolationFailure(t *testing.T) {
-	// 	t.Skip("T009: RED phase - implement executeConversationStep delegation")
-
 	// Arrange
 	step := &workflow.Step{
 		Name: "chat",

--- a/internal/application/interactive_executor.go
+++ b/internal/application/interactive_executor.go
@@ -564,6 +564,9 @@ func (e *InteractiveExecutor) HandleExecutionError(
 	execErr error,
 	intCtx *interpolation.Context,
 ) (string, error) {
+	if step == nil {
+		return "", fmt.Errorf("HandleExecutionError: step cannot be nil")
+	}
 	// Execute post-hooks even on failure
 	if err := e.hookExecutor.ExecuteHooks(ctx, step.Hooks.Post, intCtx); err != nil {
 		e.logger.Warn("post-hook failed", "step", step.Name, "error", err)
@@ -589,6 +592,12 @@ func (e *InteractiveExecutor) HandleNonZeroExit(
 	result *ports.CommandResult,
 	intCtx *interpolation.Context,
 ) (string, error) {
+	if step == nil {
+		return "", fmt.Errorf("HandleNonZeroExit: step cannot be nil")
+	}
+	if result == nil {
+		return "", fmt.Errorf("HandleNonZeroExit: result cannot be nil")
+	}
 	// Execute post-hooks
 	if err := e.hookExecutor.ExecuteHooks(ctx, step.Hooks.Post, intCtx); err != nil {
 		e.logger.Warn("post-hook failed", "step", step.Name, "error", err)

--- a/internal/application/interactive_executor_handlers_test.go
+++ b/internal/application/interactive_executor_handlers_test.go
@@ -771,17 +771,44 @@ func TestHandleSuccess_MultipleTransitions_ReturnsFirstMatch(t *testing.T) {
 // Edge Cases and Error Scenarios
 // =============================================================================
 
-func TestHandleExecutionError_NilStep_Panics(t *testing.T) {
-	// Feature: C005
-	// Defensive test: nil step should be handled gracefully or panic explicitly
-	// This test documents expected behavior for invalid input
-	t.Skip("Implementation should handle nil step - define expected behavior")
+func TestHandleExecutionError_NilStep_ReturnsError(t *testing.T) {
+	// Feature: C053 - T008
+	// Defensive test: nil step should return descriptive error per ADR-002
+	wfSvc := application.NewWorkflowService(newMockRepository(), newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	executor := application.NewInteractiveExecutor(
+		wfSvc, newMockExecutor(), newMockParallelExecutor(),
+		newMockStateStore(), &mockLogger{}, newMockResolver(), nil, newMockPrompt(),
+	)
+	_, err := executor.HandleExecutionError(context.Background(), nil, &workflow.StepState{}, errors.New("test"), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "step cannot be nil")
 }
 
-func TestHandleNonZeroExit_NilResult_Panics(t *testing.T) {
-	// Feature: C005
-	// Defensive test: nil result should be handled gracefully or panic explicitly
-	t.Skip("Implementation should handle nil result - define expected behavior")
+func TestHandleNonZeroExit_NilStep_ReturnsError(t *testing.T) {
+	// Feature: C053 - T008
+	// Defensive test: nil step should return descriptive error per ADR-002
+	wfSvc := application.NewWorkflowService(newMockRepository(), newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	executor := application.NewInteractiveExecutor(
+		wfSvc, newMockExecutor(), newMockParallelExecutor(),
+		newMockStateStore(), &mockLogger{}, newMockResolver(), nil, newMockPrompt(),
+	)
+	_, err := executor.HandleNonZeroExit(context.Background(), nil, &workflow.StepState{}, &ports.CommandResult{ExitCode: 1}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "step cannot be nil")
+}
+
+func TestHandleNonZeroExit_NilResult_ReturnsError(t *testing.T) {
+	// Feature: C053 - T008
+	// Defensive test: nil result should return descriptive error per ADR-002
+	wfSvc := application.NewWorkflowService(newMockRepository(), newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	executor := application.NewInteractiveExecutor(
+		wfSvc, newMockExecutor(), newMockParallelExecutor(),
+		newMockStateStore(), &mockLogger{}, newMockResolver(), nil, newMockPrompt(),
+	)
+	step := &workflow.Step{Name: "test_step", Command: "echo test"}
+	_, err := executor.HandleNonZeroExit(context.Background(), step, &workflow.StepState{}, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "result cannot be nil")
 }
 
 func TestHandleSuccess_NilEvaluator_WithTransitions_ReturnsError(t *testing.T) {

--- a/internal/application/loop_transitions_foreach_test.go
+++ b/internal/application/loop_transitions_foreach_test.go
@@ -33,16 +33,6 @@ import (
 // Git History: Maintains traceability per ADR-004
 // =============================================================================
 
-// ForEach transition behavior end-to-end.
-func TestExecuteForEach_TransitionSupport(t *testing.T) {
-	t.Skip("Transition logic is identical for ForEach and While loops - covered by While tests")
-
-	// The actual implementation is tested through:
-	// 1. TestEvaluateBodyTransition_* tests (all scenarios)
-	// 2. TestEvaluateBodyTransition_MultiIteration_ConsistentBehavior
-	// 3. Integration tests will verify ForEach-specific behavior
-}
-
 // =============================================================================
 // Happy Path Tests: Intra-Body Skip Forward/Backward and Early Exit
 // =============================================================================

--- a/internal/application/loop_transitions_intrabody_test.go
+++ b/internal/application/loop_transitions_intrabody_test.go
@@ -1517,23 +1517,6 @@ func TestEvaluateBodyTransition_ErrorHandling_DuplicateStepNames(t *testing.T) {
 	require.Contains(t, err.Error(), "indices 0 and 2")
 }
 
-// TestEvaluateBodyTransition_ErrorHandling_NilBodyStepIndices tests nil index map.
-// Given: bodyStepIndices is nil (should never happen but test robustness)
-// When: Transition is returned
-// Then: Should handle gracefully without panic
-func TestEvaluateBodyTransition_ErrorHandling_NilBodyStepIndices(t *testing.T) {
-	// This is a theoretical edge case - in practice, buildBodyStepIndices
-	// always returns a valid map (empty for empty body). But we test
-	// the evaluateBodyTransition function's robustness if called incorrectly.
-
-	t.Skip("evaluateBodyTransition is private and always called with valid map from buildBodyStepIndices")
-
-	// If we could test directly:
-	// shouldBreak, newIdx := evaluateBodyTransition("target", nil, []string{"step1"}, 0)
-	// assert.False(t, shouldBreak, "Should not panic on nil map")
-	// assert.Equal(t, -1, newIdx, "Should return -1 for invalid state")
-}
-
 // =============================================================================
 // Integration Tests: ExecuteForEach Transition Support
 // =============================================================================
@@ -2366,27 +2349,6 @@ func TestHandleIntraBodyJump_ErrorHandling_JumpWithStepError(t *testing.T) {
 	assert.Equal(t, []string{"step1"}, executionOrder,
 		"Should stop after step1 error, regardless of nextStep value")
 	_ = result // May be nil on error
-}
-
-// TestHandleIntraBodyJump_ErrorHandling_NegativeIndexInput tests behavior
-// when newIdx is negative (but not -1).
-// Given: handleIntraBodyJump receives newIdx = -2
-// When: Called with invalid negative index
-// Then: Should handle gracefully (likely return -1 for no jump)
-func TestHandleIntraBodyJump_ErrorHandling_NegativeIndexInput(t *testing.T) {
-	// Note: This is a theoretical edge case testing the function's robustness.
-	// In practice, evaluateBodyTransition should never pass negative indices
-	// other than -1, but testing defensive programming is good practice.
-
-	// This test is challenging to write because handleIntraBodyJump is private.
-	// We would test this if the function were exported or via integration tests
-	// that somehow trigger this condition.
-
-	// For now, documenting expected behavior:
-	// - newIdx < 0 (other than -1): treat as -1 (no jump)
-	// - The function should not crash or return invalid indices
-
-	t.Skip("Cannot test private function directly; behavior verified via integration tests")
 }
 
 // =============================================================================

--- a/internal/application/output_streamer.go
+++ b/internal/application/output_streamer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"github.com/vanoix/awf/internal/domain/workflow"
@@ -12,7 +13,8 @@ import (
 // OutputStreamer handles streaming large outputs to temporary files.
 // C019: Prevents OOM from unbounded StepState.Output/Stderr growth by streaming to disk.
 type OutputStreamer struct {
-	config workflow.OutputLimits
+	config  workflow.OutputLimits
+	counter uint64 // atomic counter for unique filenames
 }
 
 // NewOutputStreamer creates a new OutputStreamer with the given configuration.
@@ -43,10 +45,11 @@ func (s *OutputStreamer) StreamOutput(content string) (string, error) {
 	}
 
 	// Create unique temp file with awf-output prefix
-	// Use timestamp and PID for uniqueness to prevent collisions
+	// Use atomic counter, timestamp, and PID for uniqueness to prevent collisions
+	count := atomic.AddUint64(&s.counter, 1)
 	timestamp := time.Now().UnixNano()
 	pid := os.Getpid()
-	filename := fmt.Sprintf("awf-output-%d-%d.txt", pid, timestamp)
+	filename := fmt.Sprintf("awf-output-%d-%d-%d.txt", pid, timestamp, count)
 	path := filepath.Join(tempDir, filename)
 
 	// Write content to file with restrictive permissions

--- a/internal/domain/errors/errors_test.go
+++ b/internal/domain/errors/errors_test.go
@@ -30,29 +30,6 @@ func TestPackageStructure(t *testing.T) {
 	})
 }
 
-// TestDocumentationCoverage validates that key types mentioned in doc.go will be defined.
-// These tests will initially pass (no types to check yet) but serve as placeholders
-// for future type validation tests once the actual error types are implemented.
-func TestDocumentationCoverage(t *testing.T) {
-	t.Run("error code type will be defined", func(t *testing.T) {
-		// TODO: Verify errors.ErrorCode type exists
-		// This test is a placeholder for T002 (codes.go)
-		t.Skip("ErrorCode type not yet implemented (T002)")
-	})
-
-	t.Run("structured error type will be defined", func(t *testing.T) {
-		// TODO: Verify errors.StructuredError type exists
-		// This test is a placeholder for T003 (structured_error.go)
-		t.Skip("StructuredError type not yet implemented (T003)")
-	})
-
-	t.Run("error catalog will be defined", func(t *testing.T) {
-		// TODO: Verify errors.GetErrorInfo function exists
-		// This test is a placeholder for T004 (catalog.go)
-		t.Skip("Error catalog not yet implemented (T004)")
-	})
-}
-
 // TestDomainLayerPurity validates the package imports only stdlib.
 // According to C047 plan, domain layer must have zero infrastructure dependencies.
 func TestDomainLayerPurity(t *testing.T) {
@@ -65,86 +42,4 @@ func TestDomainLayerPurity(t *testing.T) {
 		// - strings (stdlib)
 		// No infrastructure, application, or interfaces layer imports allowed
 	})
-}
-
-// TestHierarchicalErrorCodeFormat tests the documented error code format.
-// Error codes should follow CATEGORY.SUBCATEGORY.SPECIFIC format.
-func TestHierarchicalErrorCodeFormat(t *testing.T) {
-	tests := []struct {
-		name     string
-		code     string
-		category string
-		valid    bool
-	}{
-		{
-			name:     "valid user input error",
-			code:     "USER.INPUT.MISSING_FILE",
-			category: "USER",
-			valid:    true,
-		},
-		{
-			name:     "valid workflow error",
-			code:     "WORKFLOW.VALIDATION.CYCLE_DETECTED",
-			category: "WORKFLOW",
-			valid:    true,
-		},
-		{
-			name:     "valid execution error",
-			code:     "EXECUTION.COMMAND.FAILED",
-			category: "EXECUTION",
-			valid:    true,
-		},
-		{
-			name:     "valid system error",
-			code:     "SYSTEM.IO.PERMISSION_DENIED",
-			category: "SYSTEM",
-			valid:    true,
-		},
-		{
-			name:     "invalid format - missing subcategory",
-			code:     "USER.MISSING_FILE",
-			category: "USER",
-			valid:    false,
-		},
-		{
-			name:     "invalid format - no dots",
-			code:     "USERERROR",
-			category: "",
-			valid:    false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// TODO: Implement validation logic once ErrorCode type exists
-			// This test documents the expected format for future implementation
-			t.Skip("ErrorCode validation not yet implemented (T002)")
-		})
-	}
-}
-
-// TestExitCodeMapping validates the documented exit code mapping.
-// According to doc.go:
-// - USER.* → exit code 1
-// - WORKFLOW.* → exit code 2
-// - EXECUTION.* → exit code 3
-// - SYSTEM.* → exit code 4
-func TestExitCodeMapping(t *testing.T) {
-	tests := []struct {
-		category string
-		exitCode int
-	}{
-		{"USER", 1},
-		{"WORKFLOW", 2},
-		{"EXECUTION", 3},
-		{"SYSTEM", 4},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.category+" maps to exit code", func(t *testing.T) {
-			// TODO: Verify ExitCode() method returns correct value
-			// This test documents the expected mapping for future implementation
-			t.Skip("ExitCode() method not yet implemented (T003)")
-		})
-	}
 }

--- a/internal/infrastructure/diagram/graphviz_test.go
+++ b/internal/infrastructure/diagram/graphviz_test.go
@@ -9,15 +9,6 @@ import (
 func TestCheckGraphviz_ReturnsBoolean(t *testing.T) {
 	// CheckGraphviz should return a boolean indicating if dot is available.
 	// The actual result depends on the system, but it should not panic.
-	defer func() {
-		if r := recover(); r != nil {
-			// Expected: stub panics with "not implemented"
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-		}
-	}()
-
 	_ = CheckGraphviz()
 }
 
@@ -25,15 +16,6 @@ func TestCheckGraphviz_DetectsDotCommand(t *testing.T) {
 	// This test verifies that CheckGraphviz correctly detects the dot command.
 	// On systems with graphviz installed, it should return true.
 	// On systems without graphviz, it should return false.
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	result := CheckGraphviz()
 
 	// Result should be consistent - calling twice should return same value
@@ -44,15 +26,6 @@ func TestCheckGraphviz_DetectsDotCommand(t *testing.T) {
 }
 
 func TestExport_PNGFormat(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	dot := `digraph G { a -> b; }`
 	outputPath := filepath.Join(t.TempDir(), "test.png")
 
@@ -68,15 +41,6 @@ func TestExport_PNGFormat(t *testing.T) {
 }
 
 func TestExport_SVGFormat(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	dot := `digraph G { a -> b; }`
 	outputPath := filepath.Join(t.TempDir(), "test.svg")
 
@@ -90,15 +54,6 @@ func TestExport_SVGFormat(t *testing.T) {
 }
 
 func TestExport_PDFFormat(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	dot := `digraph G { a -> b; }`
 	outputPath := filepath.Join(t.TempDir(), "test.pdf")
 
@@ -112,15 +67,6 @@ func TestExport_PDFFormat(t *testing.T) {
 }
 
 func TestExport_DOTFormat_NoConversion(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	dot := `digraph G { a -> b; }`
 	outputPath := filepath.Join(t.TempDir(), "test.dot")
 
@@ -156,15 +102,6 @@ func TestExport_FormatDetection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer func() {
-				if r := recover(); r != nil {
-					if r != "not implemented" {
-						t.Errorf("unexpected panic: %v", r)
-					}
-					t.Skip("stub not implemented yet")
-				}
-			}()
-
 			dot := `digraph G { a -> b; }`
 			outputPath := filepath.Join(t.TempDir(), "test"+tt.extension)
 
@@ -175,15 +112,6 @@ func TestExport_FormatDetection(t *testing.T) {
 }
 
 func TestExport_EmptyDOT(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	outputPath := filepath.Join(t.TempDir(), "empty.dot")
 
 	err := Export("", outputPath)
@@ -194,15 +122,6 @@ func TestExport_EmptyDOT(t *testing.T) {
 }
 
 func TestExport_InvalidDOT_WithGraphviz(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	// Invalid DOT syntax
 	invalidDOT := `digraph G { invalid syntax here }`
 	outputPath := filepath.Join(t.TempDir(), "invalid.png")
@@ -219,15 +138,6 @@ func TestExport_InvalidDOT_WithGraphviz(t *testing.T) {
 func TestExport_GraphvizNotInstalled_Error(t *testing.T) {
 	// This test verifies the error message when graphviz is not installed
 	// and an image format is requested.
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	if CheckGraphviz() {
 		t.Skip("graphviz is installed, cannot test missing graphviz error")
 	}
@@ -249,15 +159,6 @@ func TestExport_GraphvizNotInstalled_Error(t *testing.T) {
 }
 
 func TestExport_OutputPathWithSpaces(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	dot := `digraph G { a -> b; }`
 	tmpDir := t.TempDir()
 	outputPath := filepath.Join(tmpDir, "path with spaces", "test.dot")
@@ -274,15 +175,6 @@ func TestExport_OutputPathWithSpaces(t *testing.T) {
 }
 
 func TestExport_OutputPathWithSpecialChars(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	dot := `digraph G { a -> b; }`
 	outputPath := filepath.Join(t.TempDir(), "test-file_v1.2.dot")
 
@@ -293,15 +185,6 @@ func TestExport_OutputPathWithSpecialChars(t *testing.T) {
 }
 
 func TestExport_DOTWithUnicodeLabels(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	// DOT with unicode characters in labels
 	dot := `digraph G {
 		start [label="Début"];
@@ -326,15 +209,6 @@ func TestExport_DOTWithUnicodeLabels(t *testing.T) {
 }
 
 func TestExport_LargeDOT(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	// Generate a large DOT with 100 nodes
 	var dot string
 	dot = "digraph G {\n"
@@ -355,15 +229,6 @@ func TestExport_LargeDOT(t *testing.T) {
 }
 
 func TestExport_UnknownExtension(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	dot := `digraph G { a -> b; }`
 	outputPath := filepath.Join(t.TempDir(), "test.xyz")
 
@@ -376,15 +241,6 @@ func TestExport_UnknownExtension(t *testing.T) {
 }
 
 func TestExport_NoExtension(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	dot := `digraph G { a -> b; }`
 	outputPath := filepath.Join(t.TempDir(), "noextension")
 
@@ -397,15 +253,6 @@ func TestExport_NoExtension(t *testing.T) {
 }
 
 func TestExport_EmptyPath(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	dot := `digraph G { a -> b; }`
 
 	err := Export(dot, "")
@@ -417,15 +264,6 @@ func TestExport_EmptyPath(t *testing.T) {
 }
 
 func TestExport_NonexistentDirectory(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	dot := `digraph G { a -> b; }`
 	outputPath := "/nonexistent/path/that/does/not/exist/test.dot"
 
@@ -438,15 +276,6 @@ func TestExport_NonexistentDirectory(t *testing.T) {
 }
 
 func TestExport_ComplexDOTStructure(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			if r != "not implemented" {
-				t.Errorf("unexpected panic: %v", r)
-			}
-			t.Skip("stub not implemented yet")
-		}
-	}()
-
 	// Complex DOT with subgraphs, styling, and various attributes
 	dot := `digraph workflow {
 		rankdir=LR;

--- a/internal/infrastructure/errors/json_formatter_test.go
+++ b/internal/infrastructure/errors/json_formatter_test.go
@@ -796,28 +796,6 @@ func TestJSONErrorFormatter_HintGeneration_EdgeCases(t *testing.T) {
 			},
 		},
 		{
-			name: "generator panics - should not crash formatter",
-			generators: []domainerrors.HintGenerator{
-				func(err *domainerrors.StructuredError) []domainerrors.Hint {
-					// This test verifies proper error handling
-					// In production, generators should never panic
-					panic("generator error")
-				},
-			},
-			errCode: domainerrors.ErrorCodeUserInputMissingFile,
-			message: "test error",
-			validate: func(t *testing.T, output string) {
-				// If we reach here, the formatter recovered from panic
-				// This test should be implemented with recover() in generateHints
-				var result map[string]any
-				err := json.Unmarshal([]byte(output), &result)
-				require.NoError(t, err)
-				// At minimum, error_code and message should be present
-				assert.Contains(t, result, "error_code")
-				assert.Contains(t, result, "message")
-			},
-		},
-		{
 			name: "mixed generators - some empty, some with hints",
 			generators: []domainerrors.HintGenerator{
 				func(err *domainerrors.StructuredError) []domainerrors.Hint {
@@ -928,11 +906,6 @@ func TestJSONErrorFormatter_HintGeneration_EdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Skip panic test for now - requires implementation support
-			if strings.Contains(tt.name, "panics") {
-				t.Skip("Panic recovery test - implement in GREEN phase")
-			}
-
 			// Arrange
 			formatter := NewJSONErrorFormatter(false, tt.generators...)
 			structuredErr := domainerrors.NewStructuredError(

--- a/internal/interfaces/cli/signal_handler_test.go
+++ b/internal/interfaces/cli/signal_handler_test.go
@@ -315,28 +315,6 @@ func TestSetupSignalHandler_Boundary_ZeroDelayBetweenSetupAndCleanup(t *testing.
 	// This tests race condition between goroutine start and cleanup
 }
 
-func TestSetupSignalHandler_Boundary_CallbackPanicsDoesNotCrashHandler(t *testing.T) {
-	// Arrange
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	panicCallback := func() {
-		panic("intentional panic in callback")
-	}
-
-	// Act: Setup signal handler with panicking callback
-	cleanup := setupSignalHandler(ctx, cancel, panicCallback)
-	defer cleanup()
-
-	// Note: This test verifies that a panicking callback doesn't crash the handler
-	// In the real implementation, the panic may still crash, so this test
-	// documents the expected behavior (panic should be handled or propagated)
-
-	// For now, we skip sending signal to avoid crashing the test
-	// This test documents that callback panics are a concern
-	t.Skip("This test would crash - documents that callback panics need handling")
-}
-
 func TestSetupSignalHandler_Integration_WorkflowCompletionScenario(t *testing.T) {
 	// Arrange: Simulate a workflow execution scenario
 	beforeGoroutines := runtime.NumGoroutine()

--- a/internal/testutil/cli_fixtures_test.go
+++ b/internal/testutil/cli_fixtures_test.go
@@ -447,23 +447,3 @@ func TestIntegration_AllFixtureConstants_AreNonEmpty(t *testing.T) {
 		})
 	}
 }
-
-// =============================================================================
-// Error Handling Tests
-// =============================================================================
-
-// TestCreateTestWorkflow_NonExistentBaseDir tests behavior when base directory doesn't exist
-func TestCreateTestWorkflow_NonExistentBaseDir(t *testing.T) {
-	// Note: This test verifies current stub behavior
-	// The stub implementation will likely panic or fail when directory doesn't exist
-	// This is expected behavior - CreateTestWorkflow should only be called after SetupTestDir
-
-	// We don't test invalid usage patterns in the stub
-	t.Skip("Skipping negative test - stub doesn't handle error cases")
-}
-
-// TestSetupWorkflowsDir_NilMap tests behavior with nil map (edge case)
-func TestSetupWorkflowsDir_NilMap(t *testing.T) {
-	// Note: This tests an edge case that the stub may not handle
-	t.Skip("Skipping edge case - will be tested after implementation")
-}

--- a/tests/integration/cleanup/test_cleanup_functional_test.go
+++ b/tests/integration/cleanup/test_cleanup_functional_test.go
@@ -1,0 +1,518 @@
+//go:build integration
+
+package cleanup_test
+
+// Feature: C053
+//
+// Functional tests for C053: Clean Up Skipped Tests Across Codebase.
+// This chore removes ~50 dead/stale test skips (commented-out t.Skip, dead recover blocks,
+// dead conditional skips, untestable stubs, feature placeholders), implements nil-guard checks
+// in HandleExecutionError/HandleNonZeroExit, and converts 1 unconditional skip to testing.Short().
+//
+// Tests validate:
+// - Dead code removal is thorough (acceptance criteria scan)
+// - Nil-guard implementation uses correct patterns
+// - Short-mode skip pattern is correctly applied
+// - Legitimate conditional skips are preserved
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// Happy Path Tests - Acceptance Criteria Verification
+// =============================================================================
+
+// TestDeadCode_Removal_Integration verifies that all dead test code identified
+// in C053 has been removed. Scans source files for patterns that should no longer exist.
+func TestDeadCode_Removal_Integration(t *testing.T) {
+	repoRoot := getRepoRoot(t)
+
+	t.Run("no commented-out t.Skip in T009 tests", func(t *testing.T) {
+		// AC1: Zero commented-out t.Skip() lines remain in execution_service_t009_test.go
+		filePath := filepath.Join(repoRoot, "internal/application/execution_service_t009_test.go")
+		content := readFileContent(t, filePath)
+
+		commentedSkipPattern := regexp.MustCompile(`//\s*t\.Skip\(`)
+		matches := commentedSkipPattern.FindAllString(content, -1)
+
+		assert.Empty(t, matches,
+			"no commented-out t.Skip() should remain in execution_service_t009_test.go, found %d", len(matches))
+	})
+
+	t.Run("no dead recover blocks in graphviz tests", func(t *testing.T) {
+		// AC2: Zero defer recover() blocks with "stub not implemented" in graphviz_test.go
+		filePath := filepath.Join(repoRoot, "internal/infrastructure/diagram/graphviz_test.go")
+		content := readFileContent(t, filePath)
+
+		assert.NotContains(t, content, "stub not implemented",
+			"graphviz_test.go should not contain dead 'stub not implemented' recover blocks")
+		assert.NotContains(t, content, "recover()",
+			"graphviz_test.go should not contain dead recover() calls")
+	})
+
+	t.Run("no dead conditional skips for existing directories", func(t *testing.T) {
+		// AC3: Zero conditional skips for existing directories/fixtures remain
+
+		// Migration tests: removed os.Stat + t.Skip blocks that checked directory existence
+		// from within that same directory (condition always passed, skip never triggered).
+		// Note: a helper function uses os.Stat + os.IsNotExist legitimately (returns 0, not skip).
+		migrationPath := filepath.Join(repoRoot, "tests/integration/cli/migration_test.go")
+		migrationContent := readFileContent(t, migrationPath)
+
+		// The dead pattern was: os.Stat check followed by t.Skip within the same block
+		deadSkipCount := countPatternOccurrences(migrationContent, `os\.IsNotExist.*\n.*t\.Skip`)
+		assert.Equal(t, 0, deadSkipCount,
+			"migration_test.go should not contain os.Stat + t.Skip directory existence guards")
+
+		// Loop tests: existence checks for fixtures that exist
+		loopPath := filepath.Join(repoRoot, "tests/integration/loop_test.go")
+		loopContent := readFileContent(t, loopPath)
+
+		loopFixtureSkipPattern := regexp.MustCompile(`os\.Stat\([^)]*loop-(foreach|while)\.yaml`)
+		loopMatches := loopFixtureSkipPattern.FindAllString(loopContent, -1)
+		assert.Empty(t, loopMatches,
+			"loop_test.go should not contain dead os.Stat checks for loop fixtures, found %d", len(loopMatches))
+	})
+
+	t.Run("no untestable test stubs remain", func(t *testing.T) {
+		// AC4: Verify specific stubs were deleted
+
+		// T004a: foreach transition duplicate removed
+		foreachPath := filepath.Join(repoRoot, "internal/application/loop_transitions_foreach_test.go")
+		foreachContent := readFileContent(t, foreachPath)
+		assert.NotContains(t, foreachContent, "TestExecuteForEach_TransitionSupport",
+			"duplicate transition test should be removed")
+
+		// T004b/c: intrabody stubs removed
+		intrabodyPath := filepath.Join(repoRoot, "internal/application/loop_transitions_intrabody_test.go")
+		intrabodyContent := readFileContent(t, intrabodyPath)
+		assert.NotContains(t, intrabodyContent, "NilBodyStepIndices",
+			"private function nil-body stub should be removed")
+		assert.NotContains(t, intrabodyContent, "NegativeIndex",
+			"private function negative-index stub should be removed")
+
+		// T004d: signal handler crash test removed
+		signalPath := filepath.Join(repoRoot, "internal/interfaces/cli/signal_handler_test.go")
+		signalContent := readFileContent(t, signalPath)
+		assert.NotContains(t, signalContent, "CallbackPanics",
+			"crash test stub should be removed from signal handler tests")
+
+		// T004e/f: testutil stubs removed
+		testutilPath := filepath.Join(repoRoot, "internal/testutil/cli_fixtures_test.go")
+		testutilContent := readFileContent(t, testutilPath)
+		assert.NotContains(t, testutilContent, "NonExistentBaseDir",
+			"non-existent base dir stub should be removed")
+		assert.NotContains(t, testutilContent, "NilMap",
+			"nil-map stub should be removed")
+	})
+
+	t.Run("no feature placeholder tests remain", func(t *testing.T) {
+		// AC5: Verify placeholders were deleted
+
+		// Domain error placeholders
+		errorsPath := filepath.Join(repoRoot, "internal/domain/errors/errors_test.go")
+		errorsContent := readFileContent(t, errorsPath)
+		assert.NotContains(t, errorsContent, "ErrorCode type not yet implemented",
+			"error code placeholder should be removed")
+		assert.NotContains(t, errorsContent, "StructuredError type not yet implemented",
+			"structured error placeholder should be removed")
+		assert.NotContains(t, errorsContent, "Error catalog not yet implemented",
+			"error catalog placeholder should be removed")
+
+		// Conversation deferred tests
+		conversationPath := filepath.Join(repoRoot, "tests/integration/conversation_test.go")
+		conversationContent := readFileContent(t, conversationPath)
+		assert.NotContains(t, conversationContent, "MaxTurnsZero",
+			"max turns zero placeholder should be removed")
+		assert.NotContains(t, conversationContent, "HighMaxTurns",
+			"high max turns placeholder should be removed")
+
+		// Memory management deferred test
+		memoryPath := filepath.Join(repoRoot, "tests/integration/memory_management_functional_test.go")
+		memoryContent := readFileContent(t, memoryPath)
+		assert.NotContains(t, memoryContent, "ResumeWithPruning",
+			"resume with pruning placeholder should be removed")
+	})
+
+	t.Run("json formatter panic skip guard removed", func(t *testing.T) {
+		// T004g: panic skip guard and test case removed from json_formatter table-driven test
+		jsonFmtPath := filepath.Join(repoRoot, "internal/infrastructure/errors/json_formatter_test.go")
+		jsonFmtContent := readFileContent(t, jsonFmtPath)
+		assert.NotContains(t, jsonFmtContent, "panics",
+			"panic skip guard and test case should be removed from json_formatter_test.go")
+	})
+}
+
+// TestShortModeSkip_Pattern_Integration verifies the retry test uses
+// the proper testing.Short() conditional skip pattern instead of unconditional skip.
+func TestShortModeSkip_Pattern_Integration(t *testing.T) {
+	repoRoot := getRepoRoot(t)
+
+	t.Run("retry test uses testing.Short pattern", func(t *testing.T) {
+		// AC7: Slow retry test uses testing.Short() pattern
+		filePath := filepath.Join(repoRoot, "internal/application/execution_service_retry_test.go")
+		content := readFileContent(t, filePath)
+
+		// Find the retry pattern test function
+		require.Contains(t, content, "TestStepExecutorCallback_RetryPattern_ReturnsLoopNameAndNil",
+			"retry pattern test should exist")
+
+		// Extract the function body to verify the skip pattern
+		funcBody := extractFunctionBody(t, content, "TestStepExecutorCallback_RetryPattern_ReturnsLoopNameAndNil")
+
+		// Should contain testing.Short() conditional skip
+		assert.Contains(t, funcBody, "testing.Short()",
+			"retry test should use testing.Short() conditional skip")
+		assert.Contains(t, funcBody, "t.Skip(",
+			"retry test should call t.Skip inside the conditional")
+	})
+}
+
+// =============================================================================
+// Edge Cases
+// =============================================================================
+
+// TestCleanup_LegitimateSkips_Preserved_Integration verifies that legitimate
+// conditional skips (testing.Short, root, CI, platform, CLI tools) are untouched.
+func TestCleanup_LegitimateSkips_Preserved_Integration(t *testing.T) {
+	repoRoot := getRepoRoot(t)
+
+	t.Run("testing.Short skips preserved in codebase", func(t *testing.T) {
+		// Legitimate testing.Short() skips should still exist across the codebase
+		count := countPatternInDir(t, repoRoot, "internal", `testing\.Short\(\)`)
+		assert.Greater(t, count, 0,
+			"legitimate testing.Short() skips should be preserved")
+	})
+
+	t.Run("CI environment skips preserved", func(t *testing.T) {
+		// skipInCI helper should still be used
+		count := countPatternInDir(t, repoRoot, "tests/integration", `skipInCI\(t\)`)
+		assert.Greater(t, count, 0,
+			"legitimate CI environment skips should be preserved")
+	})
+
+	t.Run("CLI tool skips preserved", func(t *testing.T) {
+		// skipIfCLIMissing should still be used
+		count := countPatternInDir(t, repoRoot, "tests/integration", `skipIfCLIMissing\(t,`)
+		assert.Greater(t, count, 0,
+			"legitimate CLI tool availability skips should be preserved")
+	})
+
+	t.Run("platform skips preserved", func(t *testing.T) {
+		// skipOnPlatform should still be defined
+		helperPath := filepath.Join(repoRoot, "tests/integration/test_helpers_test.go")
+		content := readFileContent(t, helperPath)
+		assert.Contains(t, content, "func skipOnPlatform",
+			"skipOnPlatform helper should still be defined")
+	})
+}
+
+// TestCleanup_FileIntegrity_Integration verifies that modified files still contain
+// expected structure after cleanup.
+func TestCleanup_FileIntegrity_Integration(t *testing.T) {
+	repoRoot := getRepoRoot(t)
+
+	t.Run("graphviz test file has test functions", func(t *testing.T) {
+		// After removing 19 recover blocks, tests should still exist
+		filePath := filepath.Join(repoRoot, "internal/infrastructure/diagram/graphviz_test.go")
+		content := readFileContent(t, filePath)
+
+		funcPattern := regexp.MustCompile(`func Test\w+\(t \*testing\.T\)`)
+		matches := funcPattern.FindAllString(content, -1)
+		assert.GreaterOrEqual(t, len(matches), 5,
+			"graphviz_test.go should still have at least 5 test functions after cleanup")
+	})
+
+	t.Run("T009 test file has test functions", func(t *testing.T) {
+		// After removing 12 commented skips, tests should still exist
+		filePath := filepath.Join(repoRoot, "internal/application/execution_service_t009_test.go")
+		content := readFileContent(t, filePath)
+
+		funcPattern := regexp.MustCompile(`func Test\w+\(t \*testing\.T\)`)
+		matches := funcPattern.FindAllString(content, -1)
+		assert.GreaterOrEqual(t, len(matches), 10,
+			"execution_service_t009_test.go should still have at least 10 test functions after cleanup")
+	})
+
+	t.Run("handler test file has nil-guard tests", func(t *testing.T) {
+		// After replacing stubs, proper nil-guard tests should exist
+		filePath := filepath.Join(repoRoot, "internal/application/interactive_executor_handlers_test.go")
+		content := readFileContent(t, filePath)
+
+		assert.Contains(t, content, "TestHandleExecutionError_NilStep_ReturnsError",
+			"nil-step test for HandleExecutionError should exist")
+		assert.Contains(t, content, "TestHandleNonZeroExit_NilStep_ReturnsError",
+			"nil-step test for HandleNonZeroExit should exist")
+		assert.Contains(t, content, "TestHandleNonZeroExit_NilResult_ReturnsError",
+			"nil-result test for HandleNonZeroExit should exist")
+	})
+}
+
+// =============================================================================
+// Error Handling Tests - Nil Guard Implementation
+// =============================================================================
+
+// TestNilGuard_ErrorMessages_Integration verifies that nil-guard error messages
+// are descriptive and actionable for debugging.
+func TestNilGuard_ErrorMessages_Integration(t *testing.T) {
+	repoRoot := getRepoRoot(t)
+
+	t.Run("error messages include method name for traceability", func(t *testing.T) {
+		// Verify the nil-guard implementation includes method names in errors
+		filePath := filepath.Join(repoRoot, "internal/application/interactive_executor.go")
+		content := readFileContent(t, filePath)
+
+		// HandleExecutionError nil guard should mention its name
+		assert.Contains(t, content, `HandleExecutionError: step cannot be nil`,
+			"HandleExecutionError nil-guard should include method name")
+
+		// HandleNonZeroExit nil guards should mention their name
+		assert.Contains(t, content, `HandleNonZeroExit: step cannot be nil`,
+			"HandleNonZeroExit step nil-guard should include method name")
+		assert.Contains(t, content, `HandleNonZeroExit: result cannot be nil`,
+			"HandleNonZeroExit result nil-guard should include method name")
+	})
+
+	t.Run("nil guards return errors not panics", func(t *testing.T) {
+		// Verify the implementation uses fmt.Errorf (returns error) not panic()
+		filePath := filepath.Join(repoRoot, "internal/application/interactive_executor.go")
+		content := readFileContent(t, filePath)
+
+		// Extract the HandleExecutionError and HandleNonZeroExit method bodies
+		execErrBody := extractMethodBody(t, content, "HandleExecutionError")
+		nonZeroBody := extractMethodBody(t, content, "HandleNonZeroExit")
+
+		// Both should use fmt.Errorf for nil guards, not panic
+		assert.Contains(t, execErrBody, "fmt.Errorf",
+			"HandleExecutionError should use fmt.Errorf for nil guard")
+		assert.NotContains(t, execErrBody, "panic(",
+			"HandleExecutionError should not use panic for nil guard")
+
+		assert.Contains(t, nonZeroBody, "fmt.Errorf",
+			"HandleNonZeroExit should use fmt.Errorf for nil guard")
+		assert.NotContains(t, nonZeroBody, "panic(",
+			"HandleNonZeroExit should not use panic for nil guard")
+	})
+
+	t.Run("nil guard tests use require.Error assertions", func(t *testing.T) {
+		// Verify test implementations follow the project's assertion pattern
+		filePath := filepath.Join(repoRoot, "internal/application/interactive_executor_handlers_test.go")
+		content := readFileContent(t, filePath)
+
+		// All three nil-guard tests should use require.Error + assert.Contains
+		nilGuardTests := []string{
+			"TestHandleExecutionError_NilStep_ReturnsError",
+			"TestHandleNonZeroExit_NilStep_ReturnsError",
+			"TestHandleNonZeroExit_NilResult_ReturnsError",
+		}
+
+		for _, testName := range nilGuardTests {
+			funcBody := extractFunctionBody(t, content, testName)
+			assert.Contains(t, funcBody, "require.Error",
+				"%s should use require.Error assertion", testName)
+			assert.Contains(t, funcBody, "assert.Contains",
+				"%s should use assert.Contains to verify error message", testName)
+		}
+	})
+}
+
+// =============================================================================
+// Integration Tests - Overall Cleanup Validation
+// =============================================================================
+
+// TestCleanup_Metrics_Integration validates the overall cleanup metrics match expectations.
+func TestCleanup_Metrics_Integration(t *testing.T) {
+	repoRoot := getRepoRoot(t)
+
+	t.Run("graphviz test file reduced after recover block removal", func(t *testing.T) {
+		// After removing 19 recover blocks (~171 lines), the file should be smaller
+		filePath := filepath.Join(repoRoot, "internal/infrastructure/diagram/graphviz_test.go")
+		content := readFileContent(t, filePath)
+		lineCount := strings.Count(content, "\n")
+
+		assert.Less(t, lineCount, 350,
+			"graphviz_test.go should be significantly smaller after removing 19 recover blocks")
+	})
+
+	t.Run("errors_test.go has no 'not yet implemented' placeholders", func(t *testing.T) {
+		filePath := filepath.Join(repoRoot, "internal/domain/errors/errors_test.go")
+		content := readFileContent(t, filePath)
+
+		assert.NotContains(t, content, "not yet implemented",
+			"no 'not yet implemented' placeholders should remain")
+	})
+
+	t.Run("all affected files exist", func(t *testing.T) {
+		// C053 affects 15 files across 6 packages
+		affectedFiles := []string{
+			"internal/application/execution_service_t009_test.go",
+			"internal/application/execution_service_retry_test.go",
+			"internal/application/interactive_executor.go",
+			"internal/application/interactive_executor_handlers_test.go",
+			"internal/application/loop_transitions_foreach_test.go",
+			"internal/application/loop_transitions_intrabody_test.go",
+			"internal/domain/errors/errors_test.go",
+			"internal/infrastructure/diagram/graphviz_test.go",
+			"internal/infrastructure/errors/json_formatter_test.go",
+			"internal/interfaces/cli/signal_handler_test.go",
+			"internal/testutil/cli_fixtures_test.go",
+			"tests/integration/cli/migration_test.go",
+			"tests/integration/conversation_test.go",
+			"tests/integration/loop_test.go",
+			"tests/integration/memory_management_functional_test.go",
+		}
+
+		for _, relPath := range affectedFiles {
+			absPath := filepath.Join(repoRoot, relPath)
+			_, err := os.Stat(absPath)
+			assert.NoError(t, err, "affected file should exist: %s", relPath)
+		}
+	})
+
+	t.Run("changelog documents C053", func(t *testing.T) {
+		filePath := filepath.Join(repoRoot, "CHANGELOG.md")
+		content := readFileContent(t, filePath)
+		assert.Contains(t, content, "C053",
+			"CHANGELOG.md should document C053 cleanup work")
+	})
+}
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+// getRepoRoot returns the repository root directory by walking up from cwd.
+func getRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	require.NoError(t, err, "should get current directory")
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repository root (no go.mod found)")
+		}
+		dir = parent
+	}
+}
+
+// readFileContent reads a file and returns its content as a string.
+func readFileContent(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "should be able to read file: %s", path)
+	return string(content)
+}
+
+// extractFunctionBody extracts the body of a Go test function from file content.
+func extractFunctionBody(t *testing.T, content string, funcName string) string {
+	t.Helper()
+
+	pattern := regexp.MustCompile(`func ` + regexp.QuoteMeta(funcName) + `\(t \*testing\.T\) \{`)
+	loc := pattern.FindStringIndex(content)
+	require.NotNil(t, loc, "should find function %s", funcName)
+
+	// Track brace depth to find the closing brace
+	depth := 0
+	start := loc[0]
+	for i := loc[1] - 1; i < len(content); i++ {
+		switch content[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return content[start : i+1]
+			}
+		}
+	}
+
+	t.Fatalf("could not find closing brace for function %s", funcName)
+	return ""
+}
+
+// extractMethodBody extracts a method body by looking for a receiver method pattern.
+func extractMethodBody(t *testing.T, content string, methodName string) string {
+	t.Helper()
+
+	pattern := regexp.MustCompile(`func \(e \*InteractiveExecutor\) ` + regexp.QuoteMeta(methodName) + `\(`)
+	loc := pattern.FindStringIndex(content)
+	require.NotNil(t, loc, "should find method %s", methodName)
+
+	// Find the opening brace of the function body
+	braceStart := strings.Index(content[loc[0]:], "{")
+	require.NotEqual(t, -1, braceStart, "should find opening brace for %s", methodName)
+
+	// Track brace depth
+	depth := 0
+	absStart := loc[0] + braceStart
+	for i := absStart; i < len(content); i++ {
+		switch content[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return content[absStart : i+1]
+			}
+		}
+	}
+
+	t.Fatalf("could not find closing brace for method %s", methodName)
+	return ""
+}
+
+// countPatternInDir counts regex pattern matches across all .go files in a directory.
+func countPatternInDir(t *testing.T, repoRoot, relDir, pattern string) int {
+	t.Helper()
+
+	dir := filepath.Join(repoRoot, relDir)
+	re := regexp.MustCompile(pattern)
+	count := 0
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // skip inaccessible files
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return nil
+		}
+		defer file.Close()
+
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			if re.MatchString(scanner.Text()) {
+				count++
+			}
+		}
+		return nil
+	})
+
+	require.NoError(t, err, "should walk directory: %s", relDir)
+	return count
+}
+
+// countPatternOccurrences counts multiline regex pattern matches in content.
+func countPatternOccurrences(content, pattern string) int {
+	re := regexp.MustCompile(`(?s)` + pattern)
+	return len(re.FindAllString(content, -1))
+}

--- a/tests/integration/cli/migration_test.go
+++ b/tests/integration/cli/migration_test.go
@@ -76,11 +76,6 @@ func TestIntegrationTestMigration_BuildTagsPresent(t *testing.T) {
 	// Given: Integration test directory
 	targetDir := filepath.Join(repoRoot, "tests", "integration", "cli")
 
-	// Skip test if directory doesn't exist yet (before migration)
-	if _, err := os.Stat(targetDir); os.IsNotExist(err) {
-		t.Skip("Integration test directory not created yet")
-	}
-
 	require.DirExists(t, targetDir, "integration test directory should exist")
 
 	// When: Scanning all Go files in integration directory
@@ -118,11 +113,6 @@ func TestIntegrationTestMigration_PackageNaming(t *testing.T) {
 
 	// Given: Integration test directory
 	targetDir := filepath.Join(repoRoot, "tests", "integration", "cli")
-
-	// Skip test if directory doesn't exist yet
-	if _, err := os.Stat(targetDir); os.IsNotExist(err) {
-		t.Skip("Integration test directory not created yet")
-	}
 
 	require.DirExists(t, targetDir, "integration test directory should exist")
 
@@ -201,11 +191,6 @@ func TestIntegrationTestMigration_NoUnitTestsInIntegration(t *testing.T) {
 
 	// Given: Integration test directory
 	targetDir := filepath.Join(repoRoot, "tests", "integration", "cli")
-
-	// Skip test if directory doesn't exist yet
-	if _, err := os.Stat(targetDir); os.IsNotExist(err) {
-		t.Skip("Integration test directory not created yet")
-	}
 
 	require.DirExists(t, targetDir, "integration test directory should exist")
 
@@ -306,11 +291,6 @@ func TestIntegrationTestMigration_ImportsUpdated(t *testing.T) {
 	// Given: Integration test directory
 	targetDir := filepath.Join(repoRoot, "tests", "integration", "cli")
 
-	// Skip test if directory doesn't exist yet
-	if _, err := os.Stat(targetDir); os.IsNotExist(err) {
-		t.Skip("Integration test directory not created yet")
-	}
-
 	require.DirExists(t, targetDir, "integration test directory should exist")
 
 	// When: Scanning all test files for imports
@@ -357,11 +337,6 @@ func TestIntegrationTestMigration_NoThreadUnsafePatterns(t *testing.T) {
 
 	// Given: Integration test directory
 	targetDir := filepath.Join(repoRoot, "tests", "integration", "cli")
-
-	// Skip test if directory doesn't exist yet
-	if _, err := os.Stat(targetDir); os.IsNotExist(err) {
-		t.Skip("Integration test directory not created yet")
-	}
 
 	require.DirExists(t, targetDir, "integration test directory should exist")
 

--- a/tests/integration/conversation_test.go
+++ b/tests/integration/conversation_test.go
@@ -854,26 +854,6 @@ func TestFeature33_EdgeCase_EmptyConversationConfig(t *testing.T) {
 }
 
 // =============================================================================
-// Edge Case: Zero Max Turns
-// =============================================================================
-
-func TestFeature33_EdgeCase_ZeroMaxTurns(t *testing.T) {
-	// Skip in CI: Requires real AI provider (claude/gemini/codex) with billable API calls
-	skipInCI(t)
-
-	// Given: Conversation with max_turns=0 (invalid)
-	// This tests validation behavior
-
-	// Note: This would require a separate fixture with max_turns: 0
-	// For now, this test documents expected behavior:
-	// - max_turns: 0 should be rejected during validation
-	// - OR treated as unlimited/default value
-
-	// Test implementation depends on validation strategy chosen
-	t.Skip("Requires validation strategy decision for max_turns: 0")
-}
-
-// =============================================================================
 // Integration: Diagram Generation with Conversation Steps
 // =============================================================================
 
@@ -941,26 +921,6 @@ func TestFeature33_HelpCommand_ConversationWorkflows(t *testing.T) {
 	// - Conversation mode indication
 	// - Max turns configuration
 	// - Stop condition description
-}
-
-// =============================================================================
-// Performance: Large Conversation History
-// =============================================================================
-
-func TestFeature33_Performance_LargeConversationHistory(t *testing.T) {
-	// Skip in CI: Requires real AI provider with many billable API calls (performance stress test)
-	skipInCI(t)
-
-	// Given: Conversation with many turns (stress test)
-	// Note: This tests performance and memory handling
-
-	// This test would require:
-	// - Fixture with high max_turns (e.g., 50+)
-	// - Verification that state persistence handles large JSON
-	// - Memory usage remains reasonable
-
-	// Deferred until performance requirements defined
-	t.Skip("Performance test - requires max_turns stress test fixture")
 }
 
 // =============================================================================

--- a/tests/integration/loop_test.go
+++ b/tests/integration/loop_test.go
@@ -608,14 +608,6 @@ func TestLoopFixtures_Integration(t *testing.T) {
 	foreachPath := filepath.Join(fixturesPath, "loop-foreach.yaml")
 	whilePath := filepath.Join(fixturesPath, "loop-while.yaml")
 
-	// Skip if fixtures don't exist yet
-	if _, err := os.Stat(foreachPath); os.IsNotExist(err) {
-		t.Skip("loop fixtures not yet created")
-	}
-	if _, err := os.Stat(whilePath); os.IsNotExist(err) {
-		t.Skip("loop fixtures not yet created")
-	}
-
 	repo := repository.NewYAMLRepository(fixturesPath)
 	store := newMockStateStore()
 	exec := executor.NewShellExecutor()

--- a/tests/integration/memory_management_functional_test.go
+++ b/tests/integration/memory_management_functional_test.go
@@ -644,12 +644,3 @@ states:
 	require.True(t, exists)
 	assert.Equal(t, workflow.StatusCompleted, secondState.Status)
 }
-
-// TestMemoryManagement_Integration_ResumeWithPruning verifies that workflow
-// resumption works correctly with iteration pruning enabled.
-func TestMemoryManagement_Integration_ResumeWithPruning(t *testing.T) {
-	t.Skip("Resume functionality with pruning requires additional state serialization logic")
-	// TODO(#130): Implement when resume + pruning interaction is clarified
-	// Key question: Should pruned iterations be restored on resume?
-	// Current assumption: No - resume starts fresh with current retention window
-}


### PR DESCRIPTION
## Summary

- Remove 50+ problematic test skips: commented skips, defer-recover blocks, dead conditionals, untestable stubs, and feature placeholders
- Add atomic counter to `OutputStreamer` for thread-safe concurrent writes
- Fix retry pattern loop completion logic in `HandleMaxIterationFailure`
- Add nil-guard checks to `InteractiveExecutor` error handlers

## Test plan

- [x] All existing tests pass (`make test`)
- [x] New functional test suite validates removal of all problematic skip patterns
- [x] Race detector passes (`make test-race`)

Closes #188