### PR TITLE
refactor(c057): complete Tokens to TokensUsed migration in StepState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **C057**: Removed deprecated `Tokens` field from `StepState` — use `TokensUsed`
+  - Template interpolation: `{{states.step_name.Tokens}}` → `{{states.step_name.TokensUsed}}`
+  - Expression conditions: `states.step_name.Tokens > 0` → `states.step_name.TokensUsed > 0`
+  - **Migration**: Search workflow YAML files for `.Tokens` and replace with `.TokensUsed`
+  - **Risk**: Unreplaced references silently evaluate to `0` (expr-lang zero-value semantics)
+
 ### Changed
 
 - **C051**: Fixed DIP violation in application layer
@@ -461,8 +469,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Provider registry with configurable `model`, `max_tokens`, `temperature`, and `timeout`
   - `custom` provider for unsupported CLIs via command template with `{{prompt}}` placeholder
   - Prompt templates with full variable interpolation (`{{.inputs.*}}`, `{{.states.*}}`, `{{.env.*}}`)
-  - Automatic JSON response parsing stored in `{{.states.step_name.response}}`
-  - Token usage tracking accessible via `{{.states.step_name.tokens}}`
+  - Automatic JSON response parsing stored in `{{.states.step_name.Response}}`
+  - Token usage tracking accessible via `{{.states.step_name.TokensUsed}}`
   - Dry-run mode displays resolved prompts without execution
 - **F033**: Multi-turn Conversation Mode with Context Window Management
   - `mode: conversation` enables iterative agent interactions within a single step

--- a/docs/reference/interpolation.md
+++ b/docs/reference/interpolation.md
@@ -38,25 +38,62 @@ states:
 
 ### State Variables
 
-Access output and exit code from previous steps:
+Access output, exit code, and token usage from previous steps:
 
 ```yaml
-{{.states.step_name.Output}}
-{{.states.step_name.ExitCode}}
+{{.states.step_name.Output}}        # Command output
+{{.states.step_name.ExitCode}}      # Exit code (0 for success, non-zero for failure)
+{{.states.step_name.TokensUsed}}    # Tokens consumed by agent steps
 ```
 
-Example:
-```yaml
-read_file:
-  type: step
-  command: cat "{{.inputs.file}}"
-  on_success: analyze
+#### Output
 
+The standard output (stdout) from the executed step:
+
+```yaml
 analyze:
   type: step
   command: |
     claude -c "Analyze: {{.states.read_file.Output}}"
 ```
+
+#### ExitCode
+
+The exit code from the step's command execution. Use in transitions and expressions:
+
+```yaml
+transitions:
+  - when: "states.test_run.ExitCode == 0"
+    goto: success
+  - when: "states.test_run.ExitCode > 0"
+    goto: failure
+```
+
+#### TokensUsed
+
+Tokens consumed by agent steps (Claude, Gemini, Codex). Available for all agent step types:
+
+```yaml
+run_agent:
+  type: step
+  command: claude -c "Process this"
+  on_success: log_tokens
+
+log_tokens:
+  type: step
+  command: |
+    echo "Tokens used: {{.states.run_agent.TokensUsed}}"
+```
+
+Use in conditional expressions for token budgeting:
+
+```yaml
+transitions:
+  - when: "states.agent_step.TokensUsed > inputs.token_limit"
+    goto: token_exceeded
+```
+
+**Note**: Replaced deprecated `states.step_name.Tokens` field. If migrating from earlier versions, update workflow YAML expressions from `{{.states.step_name.Tokens}}` to `{{.states.step_name.TokensUsed}}`.
 
 ### Workflow Metadata
 

--- a/docs/user-guide/agent-steps.md
+++ b/docs/user-guide/agent-steps.md
@@ -160,7 +160,7 @@ review:
 **Available Variables:**
 - `{{.inputs.*}}` - Workflow input values
 - `{{.states.step_name.Output}}` - Previous step raw output
-- `{{.states.step_name.response}}` - Previous step parsed JSON
+- `{{.states.step_name.Response}}` - Previous step parsed JSON
 - `{{.env.VAR_NAME}}` - Environment variables
 - `{{.workflow.id}}` - Workflow execution ID
 - `{{.workflow.name}}` - Workflow name
@@ -171,11 +171,11 @@ See [Variable Interpolation Reference](../reference/interpolation.md) for comple
 
 Agent responses are automatically captured in the execution state:
 
-| Field | Type | Example |
-|-------|------|---------|
-| `{{.states.step_name.Output}}` | string | Raw response text |
-| `{{.states.step_name.response}}` | object | Parsed JSON (if valid) |
-| `{{.states.step_name.tokens}}` | object | Token usage metadata |
+| Field | Type | Description |
+|-------|------|-------------|
+| `{{.states.step_name.Output}}` | string | Raw response text from the agent |
+| `{{.states.step_name.Response}}` | object | Parsed JSON response (if valid) |
+| `{{.states.step_name.TokensUsed}}` | int | Tokens consumed by this step |
 | `{{.states.step_name.ExitCode}}` | int | 0 for success, non-zero for failure |
 
 ### Accessing Raw Output
@@ -196,7 +196,7 @@ If an agent returns valid JSON, it's automatically parsed:
 
 process_response:
   type: step
-  command: echo "Found {{.states.analyze.response.issues}} issues"
+  command: echo "Found {{.states.analyze.Response.issues}} issues"
   on_success: done
 ```
 
@@ -364,11 +364,11 @@ analyze:
 
 log_tokens:
   type: step
-  command: echo "Tokens used: {{.states.analyze.tokens.total}}"
+  command: echo "Tokens used: {{.states.analyze.TokensUsed}}"
   on_success: done
 ```
 
-Token availability depends on provider support. Check provider documentation for details.
+**Note**: All agent providers (Claude, Gemini, Codex) report token usage in the `TokensUsed` field.
 
 ## Best Practices
 

--- a/docs/user-guide/workflow-syntax.md
+++ b/docs/user-guide/workflow-syntax.md
@@ -191,8 +191,8 @@ Agent responses are captured in the step state:
 | Field | Type | Description |
 |-------|------|-------------|
 | `{{.states.step_name.Output}}` | string | Raw response text |
-| `{{.states.step_name.response}}` | object | Parsed JSON (if response is valid JSON) |
-| `{{.states.step_name.tokens}}` | object | Token usage (if provider supports it) |
+| `{{.states.step_name.Response}}` | object | Parsed JSON (if response is valid JSON) |
+| `{{.states.step_name.TokensUsed}}` | int | Tokens consumed by this agent step |
 
 ### Multi-Turn Conversations
 

--- a/internal/application/execution_service.go
+++ b/internal/application/execution_service.go
@@ -504,12 +504,12 @@ func (s *ExecutionService) buildInterpolationContext(
 	for name := range allStates {
 		state := allStates[name]
 		states[name] = interpolation.StepStateData{
-			Output:   state.Output,
-			Stderr:   state.Stderr,
-			ExitCode: state.ExitCode,
-			Status:   state.Status.String(),
-			Response: state.Response,
-			Tokens:   state.Tokens,
+			Output:     state.Output,
+			Stderr:     state.Stderr,
+			ExitCode:   state.ExitCode,
+			Status:     state.Status.String(),
+			Response:   state.Response,
+			TokensUsed: state.TokensUsed,
 		}
 	}
 
@@ -1790,10 +1790,10 @@ func (s *ExecutionService) executeAgentStep(
 	// Populate state from result
 	if result != nil {
 		state.Output = result.Output
-		// AC5: JSON auto-parsed to states.step_name.response
+		// AC5: JSON auto-parsed to states.step_name.Response
 		state.Response = result.Response
-		// AC6: Token usage in states.step_name.tokens
-		state.Tokens = result.Tokens
+		// AC6: Token usage in states.step_name.tokens_used
+		state.TokensUsed = result.Tokens
 	}
 
 	// Handle execution error (e.g., context cancelled, provider error)
@@ -1804,7 +1804,7 @@ func (s *ExecutionService) executeAgentStep(
 			state.Error = execErr.Error()
 			if result != nil {
 				state.Response = result.Response
-				state.Tokens = result.Tokens
+				state.TokensUsed = result.Tokens
 			}
 			execCtx.SetStepState(step.Name, state)
 			return "", fmt.Errorf("step %s: %w", step.Name, execErr)
@@ -1814,7 +1814,7 @@ func (s *ExecutionService) executeAgentStep(
 		state.Error = execErr.Error()
 		if result != nil {
 			state.Response = result.Response
-			state.Tokens = result.Tokens
+			state.TokensUsed = result.Tokens
 		}
 		execCtx.SetStepState(step.Name, state)
 

--- a/internal/domain/workflow/context.go
+++ b/internal/domain/workflow/context.go
@@ -32,8 +32,6 @@ type StepState struct {
 	StartedAt   time.Time
 	CompletedAt time.Time
 	Response    map[string]any // parsed JSON response from agent steps
-	Tokens      int            // token usage from agent steps (deprecated, use TokensUsed)
-
 	// F033: Conversation mode fields
 	Conversation       *ConversationState  // conversation history and state (nil for non-conversation steps)
 	TokensUsed         int                 // total tokens used in conversation mode

--- a/internal/domain/workflow/context_test.go
+++ b/internal/domain/workflow/context_test.go
@@ -802,7 +802,6 @@ func TestStepState_ConversationFields_CompleteConversationMode(t *testing.T) {
 			"status": "approved",
 			"issues": 0,
 		},
-		Tokens: 17000, // Legacy field (deprecated)
 		Conversation: &workflow.ConversationState{
 			Turns: []workflow.Turn{
 				{Role: workflow.TurnRoleSystem, Content: "You are a code reviewer", Tokens: 50},
@@ -1012,20 +1011,6 @@ func TestStepState_ConversationFields_StopReasons(t *testing.T) {
 			assert.Equal(t, reason, state.Conversation.StoppedBy)
 		})
 	}
-}
-
-func TestStepState_ConversationFields_BackwardCompatibility(t *testing.T) {
-	// Edge case: Legacy Tokens field should coexist with new TokensUsed
-	state := workflow.StepState{
-		Name:       "legacy-step",
-		Status:     workflow.StatusCompleted,
-		Tokens:     5000,  // Legacy field (deprecated)
-		TokensUsed: 10000, // New field (conversation mode)
-	}
-
-	// Both fields should be accessible
-	assert.Equal(t, 5000, state.Tokens, "Legacy Tokens field should still work")
-	assert.Equal(t, 10000, state.TokensUsed, "New TokensUsed field should work")
 }
 
 func TestStepState_ConversationFields_MixedStepsInContext(t *testing.T) {

--- a/internal/domain/workflow/reference.go
+++ b/internal/domain/workflow/reference.go
@@ -42,23 +42,24 @@ var ValidWorkflowProperties = map[string]bool{
 
 // ValidStateProperties lists known step state properties that can be referenced.
 var ValidStateProperties = map[string]bool{
-	"Output":   true,
-	"Stderr":   true,
-	"ExitCode": true,
-	"Status":   true,
-	"Response": true,
-	"Tokens":   true,
+	"Output":     true,
+	"Stderr":     true,
+	"ExitCode":   true,
+	"Status":     true,
+	"Response":   true,
+	"TokensUsed": true,
 }
 
 // lowercaseToUppercase maps lowercase property names to their correct uppercase equivalents.
 // Used to provide actionable error messages when users use incorrect casing.
 var lowercaseToUppercase = map[string]string{
-	"output":    "Output",
-	"stderr":    "Stderr",
-	"exit_code": "ExitCode",
-	"status":    "Status",
-	"response":  "Response",
-	"tokens":    "Tokens",
+	"output":     "Output",
+	"stderr":     "Stderr",
+	"exit_code":  "ExitCode",
+	"status":     "Status",
+	"response":   "Response",
+	"tokens":     "TokensUsed",
+	"tokensused": "TokensUsed",
 }
 
 // lowercaseToUppercaseError maps lowercase error property names to their correct uppercase equivalents.

--- a/pkg/expression/doc.go
+++ b/pkg/expression/doc.go
@@ -22,7 +22,7 @@
 //
 // BuildExprContext converts interpolation.Context to expr-compatible map:
 //   - inputs: Map of workflow input parameters (with type coercion)
-//   - states: Map of step results with PascalCase properties (Output, Stderr, ExitCode, Status, Response, Tokens)
+//   - states: Map of step results with PascalCase properties (Output, Stderr, ExitCode, Status, Response, TokensUsed)
 //   - workflow: Workflow metadata with PascalCase properties (ID, Name, CurrentState, Duration)
 //   - env: Environment variables
 //   - loop: Loop context (Index, Index1, Item, Length, First, Last, Parent)
@@ -247,7 +247,7 @@
 // # Property Name Casing (F050)
 //
 // PascalCase properties (uppercase first letter):
-//   - states.step.Output, states.step.Stderr, states.step.ExitCode, states.step.Status, states.step.Response, states.step.Tokens
+//   - states.step.Output, states.step.Stderr, states.step.ExitCode, states.step.Status, states.step.Response, states.step.TokensUsed
 //   - workflow.ID, workflow.Name, workflow.CurrentState, workflow.Duration
 //   - loop.Index, loop.Index1, loop.Item, loop.First, loop.Last, loop.Length, loop.Parent
 //   - error.Message, error.State, error.ExitCode, error.Type

--- a/pkg/expression/evaluator.go
+++ b/pkg/expression/evaluator.go
@@ -119,12 +119,12 @@ func BuildExprContext(ctx *interpolation.Context) map[string]any {
 		states := make(map[string]any, len(ctx.States))
 		for k, v := range ctx.States {
 			states[k] = map[string]any{
-				"Output":   v.Output,
-				"Stderr":   v.Stderr,
-				"ExitCode": v.ExitCode,
-				"Status":   v.Status,
-				"Response": v.Response,
-				"Tokens":   v.Tokens,
+				"Output":     v.Output,
+				"Stderr":     v.Stderr,
+				"ExitCode":   v.ExitCode,
+				"Status":     v.Status,
+				"Response":   v.Response,
+				"TokensUsed": v.TokensUsed,
 			}
 		}
 		result["states"] = states

--- a/pkg/expression/evaluator_test.go
+++ b/pkg/expression/evaluator_test.go
@@ -572,13 +572,13 @@ func TestExprEvaluator_Evaluate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "access state.Tokens field",
-			expr: `states.agent.Tokens > 50`,
+			name: "access state.TokensUsed field",
+			expr: `states.agent.TokensUsed > 50`,
 			ctx: &interpolation.Context{
 				States: map[string]interpolation.StepStateData{
 					"agent": {
-						Response: map[string]any{},
-						Tokens:   150,
+						Response:   map[string]any{},
+						TokensUsed: 150,
 					},
 				},
 			},
@@ -1047,7 +1047,7 @@ func TestExprEvaluator_NewStepFields(t *testing.T) {
 							"result": "ok",
 							"data":   "test",
 						},
-						Tokens: 100,
+						TokensUsed: 100,
 					},
 				},
 			},
@@ -1056,29 +1056,29 @@ func TestExprEvaluator_NewStepFields(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "access state.Tokens field",
+			name: "access state.TokensUsed field",
 			ctx: &interpolation.Context{
 				States: map[string]interpolation.StepStateData{
 					"agent": {
-						Response: map[string]any{},
-						Tokens:   150,
+						Response:   map[string]any{},
+						TokensUsed: 150,
 					},
 				},
 			},
-			expr:    "states.agent.Tokens == 150",
+			expr:    "states.agent.TokensUsed == 150",
 			want:    true,
 			wantErr: false,
 		},
 		{
-			name: "compare state.Tokens with threshold",
+			name: "compare state.TokensUsed with threshold",
 			ctx: &interpolation.Context{
 				States: map[string]interpolation.StepStateData{
 					"agent": {
-						Tokens: 150,
+						TokensUsed: 150,
 					},
 				},
 			},
-			expr:    "states.agent.Tokens > 50",
+			expr:    "states.agent.TokensUsed > 50",
 			want:    true,
 			wantErr: false,
 		},
@@ -1111,12 +1111,12 @@ func TestBuildExprContext_PascalCaseStateFields(t *testing.T) {
 			ctx: &interpolation.Context{
 				States: map[string]interpolation.StepStateData{
 					"step1": {
-						Output:   "test output",
-						Stderr:   "test error",
-						ExitCode: 1,
-						Status:   "completed",
-						Response: map[string]any{"key": "value"},
-						Tokens:   100,
+						Output:     "test output",
+						Stderr:     "test error",
+						ExitCode:   1,
+						Status:     "completed",
+						Response:   map[string]any{"key": "value"},
+						TokensUsed: 100,
 					},
 				},
 			},
@@ -1133,14 +1133,14 @@ func TestBuildExprContext_PascalCaseStateFields(t *testing.T) {
 				assert.Contains(t, step1, "ExitCode")
 				assert.Contains(t, step1, "Status")
 				assert.Contains(t, step1, "Response")
-				assert.Contains(t, step1, "Tokens")
+				assert.Contains(t, step1, "TokensUsed")
 
 				// Verify values
 				assert.Equal(t, "test output", step1["Output"])
 				assert.Equal(t, "test error", step1["Stderr"])
 				assert.Equal(t, 1, step1["ExitCode"])
 				assert.Equal(t, "completed", step1["Status"])
-				assert.Equal(t, 100, step1["Tokens"])
+				assert.Equal(t, 100, step1["TokensUsed"])
 			},
 		},
 		{

--- a/pkg/interpolation/doc.go
+++ b/pkg/interpolation/doc.go
@@ -31,7 +31,7 @@
 //
 // Context provides all variable namespaces for interpolation:
 //   - Context: Root context with all namespaces
-//   - StepStateData: Step execution results (output, stderr, exit_code, status, response, tokens)
+//   - StepStateData: Step execution results (output, stderr, exit_code, status, response, tokens_used)
 //   - WorkflowData: Workflow metadata (id, name, current_state, started_at, duration)
 //   - LoopData: Loop iteration state (item, index, first, last, length, parent)
 //   - ErrorData: Error information for error hooks (message, state, exit_code, type)
@@ -66,7 +66,7 @@
 //	{{states.step_name.ExitCode}}  # exit code
 //	{{states.step_name.Status}}    # execution status
 //	{{states.step_name.Response}}  # parsed JSON response (agent steps)
-//	{{states.step_name.Tokens}}    # token usage (agent steps)
+//	{{states.step_name.TokensUsed}}    # total tokens used (agent steps)
 //
 // ## Workflow Namespace
 //
@@ -205,7 +205,7 @@
 // # Property Name Casing (F050)
 //
 // PascalCase properties (uppercase first letter):
-//   - states.step.Output, states.step.Stderr, states.step.ExitCode, states.step.Status, states.step.Response, states.step.Tokens
+//   - states.step.Output, states.step.Stderr, states.step.ExitCode, states.step.Status, states.step.Response, states.step.TokensUsed
 //   - workflow.ID, workflow.Name, workflow.CurrentState, workflow.StartedAt, workflow.Duration
 //   - error.Message, error.State, error.ExitCode, error.Type
 //   - context.WorkingDir, context.User, context.Hostname

--- a/pkg/interpolation/reference.go
+++ b/pkg/interpolation/reference.go
@@ -44,12 +44,12 @@ var ValidWorkflowProperties = map[string]bool{
 
 // ValidStateProperties lists known step state properties that can be referenced.
 var ValidStateProperties = map[string]bool{
-	"Output":   true,
-	"Stderr":   true,
-	"ExitCode": true,
-	"Status":   true,
-	"Response": true,
-	"Tokens":   true,
+	"Output":     true,
+	"Stderr":     true,
+	"ExitCode":   true,
+	"Status":     true,
+	"Response":   true,
+	"TokensUsed": true,
 }
 
 // ValidErrorProperties lists known error properties in error hooks.

--- a/pkg/interpolation/reference_test.go
+++ b/pkg/interpolation/reference_test.go
@@ -846,12 +846,12 @@ func TestValidationMaps_PascalCase(t *testing.T) {
 			name:     "ValidStateProperties uses PascalCase and includes all fields",
 			validMap: interpolation.ValidStateProperties,
 			expectedKeys: []string{
-				"Output",   // already PascalCase
-				"Stderr",   // already PascalCase
-				"ExitCode", // already PascalCase
-				"Status",   // already PascalCase
-				"Response", // NEW: from agent steps (F039)
-				"Tokens",   // NEW: from agent steps (F039)
+				"Output",     // already PascalCase
+				"Stderr",     // already PascalCase
+				"ExitCode",   // already PascalCase
+				"Status",     // already PascalCase
+				"Response",   // NEW: from agent steps (F039)
+				"TokensUsed", // NEW: from agent steps (F039)
 			},
 			forbiddenKeys: []string{
 				"output",
@@ -948,8 +948,8 @@ func TestValidationMaps_Completeness(t *testing.T) {
 				"Stderr",
 				"ExitCode",
 				"Status",
-				"Response", // Added in F039 (agent steps)
-				"Tokens",   // Added in F039 (agent steps)
+				"Response",   // Added in F039 (agent steps)
+				"TokensUsed", // Added in F039 (agent steps)
 			},
 			mapDescription:    "ValidStateProperties",
 			contextMapping:    "states.<step>.* namespace in BuildExprContext()",
@@ -1109,12 +1109,12 @@ func TestValidationMaps_ConsistencyWithBuildExprContext(t *testing.T) {
 	t.Run("state namespace consistency", func(t *testing.T) {
 		// These keys MUST match what BuildExprContext sets in states map
 		expectedInBuildExprContext := map[string]bool{
-			"Output":   true, // v.Output
-			"Stderr":   true, // v.Stderr
-			"ExitCode": true, // v.ExitCode
-			"Status":   true, // v.Status
-			"Response": true, // v.Response (agent steps)
-			"Tokens":   true, // v.Tokens (agent steps)
+			"Output":     true, // v.Output
+			"Stderr":     true, // v.Stderr
+			"ExitCode":   true, // v.ExitCode
+			"Status":     true, // v.Status
+			"Response":   true, // v.Response (agent steps)
+			"TokensUsed": true, // v.TokensUsed (agent steps)
 		}
 
 		for key := range expectedInBuildExprContext {
@@ -1195,7 +1195,7 @@ func TestValidationMaps_BreakingChangeFromPre_(t *testing.T) {
 		assert.True(t, interpolation.ValidContextProperties["Hostname"], "PascalCase 'Hostname' is valid")
 	})
 
-	t.Run("state keys already PascalCase but Response/Tokens added", func(t *testing.T) {
+	t.Run("state keys already PascalCase but Response/TokensUsed added", func(t *testing.T) {
 		// State properties were already PascalCase (good!)
 		assert.True(t, interpolation.ValidStateProperties["Output"], "Output already PascalCase")
 		assert.True(t, interpolation.ValidStateProperties["Stderr"], "Stderr already PascalCase")
@@ -1204,10 +1204,10 @@ func TestValidationMaps_BreakingChangeFromPre_(t *testing.T) {
 
 		//  adds missing fields from F039 (agent steps)
 		assert.True(t, interpolation.ValidStateProperties["Response"], "Response field added in ")
-		assert.True(t, interpolation.ValidStateProperties["Tokens"], "Tokens field added in ")
+		assert.True(t, interpolation.ValidStateProperties["TokensUsed"], "TokensUsed field added in ")
 
 		// Lowercase versions should NOT exist
 		assert.False(t, interpolation.ValidStateProperties["response"], "lowercase 'response' not valid")
-		assert.False(t, interpolation.ValidStateProperties["tokens"], "lowercase 'tokens' not valid")
+		assert.False(t, interpolation.ValidStateProperties["tokensused"], "lowercase 'tokensused' not valid")
 	})
 }

--- a/pkg/interpolation/resolver.go
+++ b/pkg/interpolation/resolver.go
@@ -35,12 +35,12 @@ func (l *LoopData) Index1() int {
 
 // StepStateData holds step execution results for interpolation.
 type StepStateData struct {
-	Output   string
-	Stderr   string
-	ExitCode int
-	Status   string
-	Response map[string]any // parsed JSON response from agent steps
-	Tokens   int            // token usage from agent steps
+	Output     string
+	Stderr     string
+	ExitCode   int
+	Status     string
+	Response   map[string]any // parsed JSON response from agent steps
+	TokensUsed int            // total tokens used from agent steps
 }
 
 // WorkflowData holds workflow metadata for interpolation.

--- a/pkg/interpolation/resolver_test.go
+++ b/pkg/interpolation/resolver_test.go
@@ -2877,10 +2877,10 @@ func TestTemplateResolver_AutomaticSerialization_PointerTypes(t *testing.T) {
 // =============================================================================
 
 // =============================================================================
-// StepStateData.Tokens Tests (C018-T005)
+// StepStateData.TokensUsed Tests (C018-T005)
 // =============================================================================
 
-func TestTemplateResolver_StepStateDataTokens(t *testing.T) {
+func TestTemplateResolver_StepStateDataTokensUsed(t *testing.T) {
 	tests := []struct {
 		name     string
 		template string
@@ -2890,74 +2890,74 @@ func TestTemplateResolver_StepStateDataTokens(t *testing.T) {
 	}{
 		{
 			name:     "tokens integer access",
-			template: "tokens: {{.states.agent_step.Tokens}}",
+			template: "tokens: {{.states.agent_step.TokensUsed}}",
 			states: map[string]interpolation.StepStateData{
-				"agent_step": {Tokens: 1500},
+				"agent_step": {TokensUsed: 1500},
 			},
 			want: "tokens: 1500",
 		},
 		{
 			name:     "tokens zero value",
-			template: "count: {{.states.empty_step.Tokens}}",
+			template: "count: {{.states.empty_step.TokensUsed}}",
 			states: map[string]interpolation.StepStateData{
-				"empty_step": {Tokens: 0},
+				"empty_step": {TokensUsed: 0},
 			},
 			want: "count: 0",
 		},
 		{
 			name:     "tokens with other fields",
-			template: "{{.states.api_call.Output}} used {{.states.api_call.Tokens}} tokens",
+			template: "{{.states.api_call.Output}} used {{.states.api_call.TokensUsed}} tokens",
 			states: map[string]interpolation.StepStateData{
 				"api_call": {
-					Output: "Success",
-					Tokens: 2500,
+					Output:     "Success",
+					TokensUsed: 2500,
 				},
 			},
 			want: "Success used 2500 tokens",
 		},
 		{
 			name:     "tokens formatting in template",
-			template: "API call completed with {{.states.step1.Tokens}} tokens (exit {{.states.step1.ExitCode}})",
+			template: "API call completed with {{.states.step1.TokensUsed}} tokens (exit {{.states.step1.ExitCode}})",
 			states: map[string]interpolation.StepStateData{
 				"step1": {
-					Tokens:   3200,
-					ExitCode: 0,
-					Status:   "success",
+					TokensUsed: 3200,
+					ExitCode:   0,
+					Status:     "success",
 				},
 			},
 			want: "API call completed with 3200 tokens (exit 0)",
 		},
 		{
 			name:     "multiple steps with tokens",
-			template: "Total: {{.states.step1.Tokens}} + {{.states.step2.Tokens}}",
+			template: "Total: {{.states.step1.TokensUsed}} + {{.states.step2.TokensUsed}}",
 			states: map[string]interpolation.StepStateData{
-				"step1": {Tokens: 1000},
-				"step2": {Tokens: 1500},
+				"step1": {TokensUsed: 1000},
+				"step2": {TokensUsed: 1500},
 			},
 			want: "Total: 1000 + 1500",
 		},
 		{
 			name:     "tokens with response data",
-			template: "Response tokens: {{.states.agent.Tokens}}",
+			template: "Response tokens: {{.states.agent.TokensUsed}}",
 			states: map[string]interpolation.StepStateData{
 				"agent": {
-					Tokens:   4200,
-					Response: map[string]any{"result": "data"},
+					TokensUsed: 4200,
+					Response:   map[string]any{"result": "data"},
 				},
 			},
 			want: "Response tokens: 4200",
 		},
 		{
 			name:     "large token count",
-			template: "tokens={{.states.large.Tokens}}",
+			template: "tokens={{.states.large.TokensUsed}}",
 			states: map[string]interpolation.StepStateData{
-				"large": {Tokens: 999999},
+				"large": {TokensUsed: 999999},
 			},
 			want: "tokens=999999",
 		},
 		{
 			name:     "undefined state with tokens",
-			template: "{{.states.nonexistent.Tokens}}",
+			template: "{{.states.nonexistent.TokensUsed}}",
 			states:   map[string]interpolation.StepStateData{},
 			wantErr:  true,
 		},

--- a/tests/fixtures/workflows/expr-agent-fields.yaml
+++ b/tests/fixtures/workflows/expr-agent-fields.yaml
@@ -1,5 +1,5 @@
 # Feature: Test new agent step fields in expressions (VALID)
-# This workflow should PASS validation with Response and Tokens fields
+# Response and TokensUsed fields
 
 name: expr-agent-fields
 version: "1.0.0"
@@ -27,8 +27,8 @@ states:
 
   check_tokens:
     type: step
-    # VALID: Using Tokens field from agent step
-    when: 'states.agent_step.Tokens > 0'
+    # VALID: Using TokensUsed field from agent step
+    when: 'states.agent_step.TokensUsed > 0'
     command: echo "Used tokens"
     on_success: done
     on_failure: error


### PR DESCRIPTION
## Summary

- Complete the `Tokens` → `TokensUsed` migration across all execution paths, consumers, and documentation
- Remove the deprecated `StepState.Tokens` field entirely (breaking change)
- Fix `response` → `Response` casing inconsistency in documentation

## Breaking Change

Workflow YAML expressions referencing `{{.states.step_name.Tokens}}` must be updated to `{{.states.step_name.TokensUsed}}`.

```yaml
# Before
when: "states.analyze.Tokens > 1000"

# After
when: "states.analyze.TokensUsed > 1000"
```

## Changes

**Domain** (`internal/domain/workflow/`)
- Remove deprecated `Tokens` field from `StepState` struct
- Update `ValidStateProperties` map: `"Tokens"` → `"TokensUsed"`
- Update `lowercaseToUppercase` map with `"tokens"` and `"tokensused"` entries

**Application** (`internal/application/`)
- Update 3 single-mode agent write sites to populate `state.TokensUsed`
- Update interpolation context builder to read `state.TokensUsed`

**Public packages** (`pkg/`)
- Rename `StepStateData.Tokens` → `TokensUsed` in `pkg/interpolation/resolver.go`
- Update `ValidStateProperties` in `pkg/interpolation/reference.go`
- Update `BuildExprContext` map key in `pkg/expression/evaluator.go`
- Update `doc.go` files in both packages

**Documentation**
- Fix `response` → `Response` casing in `workflow-syntax.md`, `agent-steps.md`, `CHANGELOG.md`
- Fix `tokens` → `TokensUsed` in `CHANGELOG.md`
- Expand `interpolation.md` with TokensUsed examples and migration note

**Tests**
- Update all affected test files across domain, interpolation, and expression packages
- Remove backward-compatibility test for deleted `Tokens` field
- Update YAML fixture `expr-agent-fields.yaml`

## Test plan

- [x] `go build ./...` passes
- [x] `make test` passes (all tests green)
- [x] `make lint` passes (0 issues)
- [x] No remaining references to bare `"Tokens"` in production code
- [x] No C057 temporary artifacts left in tree

Closes #199