### PR TITLE
fix(b004): exempt parallel branch children from transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Migration**: Search workflow YAML files for `.Tokens` and replace with `.TokensUsed`
   - **Risk**: Unreplaced references silently evaluate to `0` (expr-lang zero-value semantics)
 
+### Fixed
+
+- **B004**: Validator no longer forces dead-code transitions on parallel branch children
+  - Parallel branch children (`step.Branches`) can now omit `on_success`/`on_failure` and `Transitions`
+  - The execution engine discards these transitions, so requiring them was forcing dead code
+  - Existing workflows with transitions on parallel children continue to validate (backward compatible)
+
 ### Changed
 
 - **C051**: Fixed DIP violation in application layer

--- a/docs/reference/validation.md
+++ b/docs/reference/validation.md
@@ -253,9 +253,23 @@ awf run deploy \
 
 | Stage | What's Validated |
 |-------|------------------|
-| Load time | YAML syntax, state references, template references |
+| Load time | YAML syntax, state references, template references, transition requirements |
 | Runtime | Input values against validation rules |
 | `awf validate` | All load-time checks without execution |
+
+### Workflow Structure Rules
+
+Load-time validation enforces structural rules on workflow states:
+
+| Rule | Applies To | Description |
+|------|-----------|-------------|
+| Transition required | Command steps | `on_success`/`on_failure` or `transitions` must be defined |
+| Transition exempt | Parallel branch children | Steps listed in a parallel step's `parallel` field do not require transitions (the parallel executor controls flow) |
+| Transition exempt | Loop body steps | Steps listed in a loop's `body` field have relaxed transition target validation |
+| Branches required | Parallel steps | `parallel` field must list at least one branch step |
+| Valid strategy | Parallel steps | `strategy` must be `all_succeed`, `any_succeed`, `best_effort`, or empty |
+
+See [Workflow Syntax](../user-guide/workflow-syntax.md#parallel-state) for parallel step details.
 
 ## Best Practices
 

--- a/docs/user-guide/agent-steps.md
+++ b/docs/user-guide/agent-steps.md
@@ -331,17 +331,21 @@ Run multiple agents concurrently:
 ```yaml
 parallel_analysis:
   type: parallel
+  parallel:
+    - claude_review
+    - codex_suggest
   strategy: all_succeed
-  steps:
-    - name: claude_review
-      type: agent
-      provider: claude
-      prompt: "Analyze for security: {{.inputs.code}}"
-    - name: codex_suggest
-      type: agent
-      provider: codex
-      prompt: "Optimize performance: {{.inputs.code}}"
   on_success: aggregate
+
+claude_review:
+  type: agent
+  provider: claude
+  prompt: "Analyze for security: {{.inputs.code}}"
+
+codex_suggest:
+  type: agent
+  provider: codex
+  prompt: "Optimize performance: {{.inputs.code}}"
 
 aggregate:
   type: step

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -119,17 +119,26 @@ states:
 
   build_all:
     type: parallel
+    parallel:
+      - lint
+      - test
+      - build
     strategy: all_succeed
     max_concurrent: 3
-    steps:
-      - name: lint
-        command: golangci-lint run
-      - name: test
-        command: go test ./...
-      - name: build
-        command: go build ./cmd/...
     on_success: deploy
     on_failure: error
+
+  lint:
+    type: step
+    command: golangci-lint run
+
+  test:
+    type: step
+    command: go test ./...
+
+  build:
+    type: step
+    command: go build ./cmd/...
 
   deploy:
     type: step
@@ -453,27 +462,33 @@ states:
 
   parallel_analysis:
     type: parallel
+    parallel:
+      - security_review
+      - performance_review
+      - style_review
     strategy: all_succeed
-    steps:
-      - name: security_review
-        type: agent
-        provider: claude
-        prompt: |
-          Security review:
-          {{.inputs.code}}
-      - name: performance_review
-        type: agent
-        provider: codex
-        prompt: |
-          Performance analysis:
-          {{.inputs.code}}
-      - name: style_review
-        type: agent
-        provider: gemini
-        prompt: |
-          Code style review:
-          {{.inputs.code}}
     on_success: aggregate
+
+  security_review:
+    type: agent
+    provider: claude
+    prompt: |
+      Security review:
+      {{.inputs.code}}
+
+  performance_review:
+    type: agent
+    provider: codex
+    prompt: |
+      Performance analysis:
+      {{.inputs.code}}
+
+  style_review:
+    type: agent
+    provider: gemini
+    prompt: |
+      Code style review:
+      {{.inputs.code}}
 
   aggregate:
     type: step

--- a/docs/user-guide/workflow-syntax.md
+++ b/docs/user-guide/workflow-syntax.md
@@ -283,33 +283,44 @@ error:
 
 ## Parallel State
 
-Execute multiple steps concurrently.
+Execute multiple steps concurrently. Branch children are defined as separate states and referenced by name in the `parallel` field.
 
 ```yaml
 parallel_build:
   type: parallel
+  parallel:
+    - lint
+    - test
+    - build
   strategy: all_succeed
   max_concurrent: 3
-  steps:
-    - name: lint
-      command: golangci-lint run
-    - name: test
-      command: go test ./...
-    - name: build
-      command: go build ./cmd/...
   on_success: deploy
   on_failure: error
+
+lint:
+  type: step
+  command: golangci-lint run
+
+test:
+  type: step
+  command: go test ./...
+
+build:
+  type: step
+  command: go build ./cmd/...
 ```
+
+Branch children (`lint`, `test`, `build` above) do not need `on_success`/`on_failure` or `transitions` — the parallel executor controls flow after each branch completes. If provided, transitions are accepted but ignored at runtime.
 
 ### Parallel Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `steps` | array | - | List of steps to execute concurrently |
+| `parallel` | array | - | List of step names to execute concurrently |
 | `strategy` | string | `all_succeed` | Execution strategy |
 | `max_concurrent` | int | unlimited | Maximum concurrent steps |
-| `on_success` | string | - | Next state on success |
-| `on_failure` | string | - | Next state on failure |
+| `on_success` | string | - | Next state when all branches complete successfully |
+| `on_failure` | string | - | Next state on branch failure |
 
 ### Parallel Strategies
 
@@ -322,8 +333,8 @@ parallel_build:
 ### Accessing Parallel Results
 
 ```yaml
-# Access individual step outputs
-command: echo "{{.states.parallel_build.steps.lint.Output}}"
+# Branch children are top-level states — access their output directly
+command: echo "{{.states.lint.Output}}"
 ```
 
 ---

--- a/internal/domain/workflow/workflow.go
+++ b/internal/domain/workflow/workflow.go
@@ -114,6 +114,17 @@ func (w *Workflow) Validate(validator ExpressionCompiler) error {
 		}
 	}
 
+	// Build set of steps that are parallel branch children
+	// B004: Parallel branch children have transitions discarded by execution engine
+	parallelBranchSteps := make(map[string]bool)
+	for _, step := range w.Steps {
+		if step.Type == StepTypeParallel {
+			for _, branchName := range step.Branches {
+				parallelBranchSteps[branchName] = true
+			}
+		}
+	}
+
 	// Validate each step
 	for name, step := range w.Steps {
 		if err := step.Validate(validator); err != nil {
@@ -122,7 +133,8 @@ func (w *Workflow) Validate(validator ExpressionCompiler) error {
 
 		// Non-terminal steps must have some way to transition
 		// Either: OnSuccess/OnFailure (legacy) OR Transitions (conditional)
-		if step.Type == StepTypeCommand {
+		// B004: Parallel branch children are exempt (transitions discarded by executor)
+		if step.Type == StepTypeCommand && !parallelBranchSteps[name] {
 			hasLegacyTransitions := step.OnSuccess != "" || step.OnFailure != ""
 			hasConditionalTransitions := len(step.Transitions) > 0
 			if !hasLegacyTransitions && !hasConditionalTransitions {

--- a/internal/domain/workflow/workflow_test.go
+++ b/internal/domain/workflow/workflow_test.go
@@ -151,6 +151,206 @@ func TestWorkflowValidation(t *testing.T) {
 			wantErr: true,
 			errMsg:  "step 'middle': command step must have OnSuccess/OnFailure or Transitions",
 		},
+		// B004: Parallel branch children exemption tests
+		{
+			name: "B004: parallel branch child without transitions - valid",
+			wf: workflow.Workflow{
+				Name:    "test",
+				Initial: "parallel",
+				Steps: map[string]*workflow.Step{
+					"parallel": {
+						Name:      "parallel",
+						Type:      workflow.StepTypeParallel,
+						Branches:  []string{"task_a", "task_b"},
+						OnSuccess: "end",
+					},
+					"task_a": {Name: "task_a", Type: workflow.StepTypeCommand, Command: "echo A"},
+					"task_b": {Name: "task_b", Type: workflow.StepTypeCommand, Command: "echo B"},
+					"end":    {Name: "end", Type: workflow.StepTypeTerminal},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "B004: parallel branch child with transitions - still valid",
+			wf: workflow.Workflow{
+				Name:    "test",
+				Initial: "parallel",
+				Steps: map[string]*workflow.Step{
+					"parallel": {
+						Name:      "parallel",
+						Type:      workflow.StepTypeParallel,
+						Branches:  []string{"task_a", "task_b"},
+						OnSuccess: "end",
+					},
+					"task_a": {Name: "task_a", Type: workflow.StepTypeCommand, Command: "echo A", OnSuccess: "end"},
+					"task_b": {Name: "task_b", Type: workflow.StepTypeCommand, Command: "echo B", OnFailure: "end"},
+					"end":    {Name: "end", Type: workflow.StepTypeTerminal},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "B004: multiple parallel steps with branch children without transitions",
+			wf: workflow.Workflow{
+				Name:    "test",
+				Initial: "parallel1",
+				Steps: map[string]*workflow.Step{
+					"parallel1": {
+						Name:      "parallel1",
+						Type:      workflow.StepTypeParallel,
+						Branches:  []string{"task_a", "task_b"},
+						OnSuccess: "parallel2",
+					},
+					"task_a": {Name: "task_a", Type: workflow.StepTypeCommand, Command: "echo A"},
+					"task_b": {Name: "task_b", Type: workflow.StepTypeCommand, Command: "echo B"},
+					"parallel2": {
+						Name:      "parallel2",
+						Type:      workflow.StepTypeParallel,
+						Branches:  []string{"task_c", "task_d"},
+						OnSuccess: "end",
+					},
+					"task_c": {Name: "task_c", Type: workflow.StepTypeCommand, Command: "echo C"},
+					"task_d": {Name: "task_d", Type: workflow.StepTypeCommand, Command: "echo D"},
+					"end":    {Name: "end", Type: workflow.StepTypeTerminal},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "B004: parallel step with empty branches - invalid",
+			wf: workflow.Workflow{
+				Name:    "test",
+				Initial: "parallel",
+				Steps: map[string]*workflow.Step{
+					"parallel": {
+						Name:      "parallel",
+						Type:      workflow.StepTypeParallel,
+						Branches:  []string{},
+						OnSuccess: "end",
+					},
+					"end": {Name: "end", Type: workflow.StepTypeTerminal},
+				},
+			},
+			wantErr: true,
+			errMsg:  "step 'parallel': branches are required for parallel-type steps",
+		},
+		{
+			name: "B004: mix of parallel branch children and regular steps",
+			wf: workflow.Workflow{
+				Name:    "test",
+				Initial: "start",
+				Steps: map[string]*workflow.Step{
+					"start": {Name: "start", Type: workflow.StepTypeCommand, Command: "echo start", OnSuccess: "parallel"},
+					"parallel": {
+						Name:      "parallel",
+						Type:      workflow.StepTypeParallel,
+						Branches:  []string{"branch_a", "branch_b"},
+						OnSuccess: "regular",
+					},
+					"branch_a": {Name: "branch_a", Type: workflow.StepTypeCommand, Command: "echo A"},
+					"branch_b": {Name: "branch_b", Type: workflow.StepTypeCommand, Command: "echo B"},
+					"regular":  {Name: "regular", Type: workflow.StepTypeCommand, Command: "echo regular", OnSuccess: "end"},
+					"end":      {Name: "end", Type: workflow.StepTypeTerminal},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "B004: regular command step still requires transitions",
+			wf: workflow.Workflow{
+				Name:    "test",
+				Initial: "parallel",
+				Steps: map[string]*workflow.Step{
+					"parallel": {
+						Name:      "parallel",
+						Type:      workflow.StepTypeParallel,
+						Branches:  []string{"branch_a"},
+						OnSuccess: "regular",
+					},
+					"branch_a": {Name: "branch_a", Type: workflow.StepTypeCommand, Command: "echo A"},
+					"regular":  {Name: "regular", Type: workflow.StepTypeCommand, Command: "echo regular"}, // missing transitions
+					"end":      {Name: "end", Type: workflow.StepTypeTerminal},
+				},
+			},
+			wantErr: true,
+			errMsg:  "step 'regular': command step must have OnSuccess/OnFailure or Transitions",
+		},
+		{
+			name: "B004: parallel branch child using conditional transitions - valid",
+			wf: workflow.Workflow{
+				Name:    "test",
+				Initial: "parallel",
+				Steps: map[string]*workflow.Step{
+					"parallel": {
+						Name:      "parallel",
+						Type:      workflow.StepTypeParallel,
+						Branches:  []string{"conditional_task"},
+						OnSuccess: "end",
+					},
+					"conditional_task": {
+						Name:    "conditional_task",
+						Type:    workflow.StepTypeCommand,
+						Command: "test",
+						Transitions: workflow.Transitions{
+							{When: "output == 'success'", Goto: "end"},
+						},
+					},
+					"end": {Name: "end", Type: workflow.StepTypeTerminal},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "B004: three-level parallel branches without transitions",
+			wf: workflow.Workflow{
+				Name:    "test",
+				Initial: "p1",
+				Steps: map[string]*workflow.Step{
+					"p1": {
+						Name:      "p1",
+						Type:      workflow.StepTypeParallel,
+						Branches:  []string{"p2", "task_x"},
+						OnSuccess: "end",
+					},
+					"p2": {
+						Name:      "p2",
+						Type:      workflow.StepTypeParallel,
+						Branches:  []string{"task_a", "task_b"},
+						OnSuccess: "end",
+					},
+					"task_a": {Name: "task_a", Type: workflow.StepTypeCommand, Command: "echo A"},
+					"task_b": {Name: "task_b", Type: workflow.StepTypeCommand, Command: "echo B"},
+					"task_x": {Name: "task_x", Type: workflow.StepTypeCommand, Command: "echo X"},
+					"end":    {Name: "end", Type: workflow.StepTypeTerminal},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "B004: same step in multiple parallel branches - valid",
+			wf: workflow.Workflow{
+				Name:    "test",
+				Initial: "p1",
+				Steps: map[string]*workflow.Step{
+					"p1": {
+						Name:      "p1",
+						Type:      workflow.StepTypeParallel,
+						Branches:  []string{"shared_task"},
+						OnSuccess: "p2",
+					},
+					"p2": {
+						Name:      "p2",
+						Type:      workflow.StepTypeParallel,
+						Branches:  []string{"shared_task"},
+						OnSuccess: "end",
+					},
+					"shared_task": {Name: "shared_task", Type: workflow.StepTypeCommand, Command: "echo shared"},
+					"end":         {Name: "end", Type: workflow.StepTypeTerminal},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/tests/integration/parallel_test.go
+++ b/tests/integration/parallel_test.go
@@ -914,6 +914,370 @@ states:
 }
 
 // =============================================================================
+// B004 Bug Fix: Parallel Branch Validation (Integration Level)
+// Tests validate YAML → domain validation flow for parallel branch children
+// without required transitions (exemption from transition requirements)
+// =============================================================================
+
+// TestParallelValidation_BranchChildrenWithoutTransitions validates B004 fix:
+// parallel branch children should not require on_success/on_failure transitions.
+// This integration test validates the full YAML parsing → domain validation pipeline.
+func TestParallelValidation_BranchChildrenWithoutTransitions(t *testing.T) {
+	// Given: A parallel workflow where branch children have no transitions
+	workflowYAML := `name: b004-no-child-transitions
+version: "1.0.0"
+states:
+  initial: parallel_step
+  parallel_step:
+    type: parallel
+    parallel:
+      - task_a
+      - task_b
+    strategy: all_succeed
+    on_success: done
+    on_failure: error
+  task_a:
+    type: step
+    command: echo "Task A"
+  task_b:
+    type: step
+    command: echo "Task B"
+  done:
+    type: terminal
+    status: success
+  error:
+    type: terminal
+    status: failure`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tmpDir := t.TempDir()
+	wfPath := filepath.Join(tmpDir, "workflow.yaml")
+	require.NoError(t, os.WriteFile(wfPath, []byte(workflowYAML), 0o644))
+
+	repo := repository.NewYAMLRepository(tmpDir)
+	store := testutil.NewMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := testutil.NewMockLogger()
+
+	svc := testutil.NewExecutionServiceBuilder().
+		WithWorkflowRepository(repo).
+		WithStateStore(store).
+		WithExecutor(exec).
+		WithLogger(logger).
+		Build()
+
+	// When: The workflow is executed
+	execCtx, err := svc.Run(ctx, "workflow", nil)
+
+	// Then: No validation error, workflow completes successfully
+	require.NoError(t, err)
+	require.NotNil(t, execCtx)
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+	assert.Equal(t, "done", execCtx.CurrentStep)
+}
+
+// TestParallelValidation_AcceptanceCriteria validates all B004 acceptance criteria
+// using a table-driven approach to ensure complete coverage.
+func TestParallelValidation_AcceptanceCriteria(t *testing.T) {
+	tests := []struct {
+		name           string
+		workflowYAML   string
+		expectedStatus workflow.ExecutionStatus
+		expectedStep   string
+		wantErr        bool
+		description    string
+	}{
+		{
+			name: "AC1: parallel branch children without transitions (exemption)",
+			workflowYAML: `name: ac1-no-transitions
+version: "1.0.0"
+states:
+  initial: parallel_step
+  parallel_step:
+    type: parallel
+    parallel:
+      - task_a
+      - task_b
+    strategy: all_succeed
+    on_success: done
+    on_failure: error
+  task_a:
+    type: step
+    command: echo "Task A"
+  task_b:
+    type: step
+    command: echo "Task B"
+  done:
+    type: terminal
+    status: success
+  error:
+    type: terminal
+    status: failure`,
+			expectedStatus: workflow.StatusCompleted,
+			expectedStep:   "done",
+			wantErr:        false,
+			description:    "Parallel branch children should not require transitions",
+		},
+		{
+			name: "AC2: parallel branch children with optional transitions",
+			workflowYAML: `name: ac2-optional-transitions
+version: "1.0.0"
+states:
+  initial: parallel_step
+  parallel_step:
+    type: parallel
+    parallel:
+      - task_a
+      - task_b
+    strategy: all_succeed
+    on_success: done
+    on_failure: error
+  task_a:
+    type: step
+    command: echo "Task A"
+    on_success: done
+    on_failure: error
+  task_b:
+    type: step
+    command: echo "Task B"
+    on_success: done
+    on_failure: error
+  done:
+    type: terminal
+    status: success
+  error:
+    type: terminal
+    status: failure`,
+			expectedStatus: workflow.StatusCompleted,
+			expectedStep:   "done",
+			wantErr:        false,
+			description:    "Parallel branch children may still define transitions",
+		},
+		{
+			name: "AC2: mixed - some branches with transitions, some without",
+			workflowYAML: `name: ac2-mixed-transitions
+version: "1.0.0"
+states:
+  initial: parallel_step
+  parallel_step:
+    type: parallel
+    parallel:
+      - task_a
+      - task_b
+      - task_c
+    strategy: all_succeed
+    on_success: done
+    on_failure: error
+  task_a:
+    type: step
+    command: echo "Task A with transitions"
+    on_success: done
+    on_failure: error
+  task_b:
+    type: step
+    command: echo "Task B without transitions"
+  task_c:
+    type: step
+    command: echo "Task C with transitions"
+    on_success: done
+    on_failure: error
+  done:
+    type: terminal
+    status: success
+  error:
+    type: terminal
+    status: failure`,
+			expectedStatus: workflow.StatusCompleted,
+			expectedStep:   "done",
+			wantErr:        false,
+			description:    "Mixed: some branches with transitions, some without",
+		},
+		{
+			name: "AC4: regression - non-parallel command step requires transitions",
+			workflowYAML: `name: ac4-regression-non-parallel
+version: "1.0.0"
+states:
+  initial: regular_step
+  regular_step:
+    type: step
+    command: echo "Regular step"
+  done:
+    type: terminal
+    status: success`,
+			expectedStatus: workflow.StatusPending,
+			expectedStep:   "",
+			wantErr:        true,
+			description:    "Non-parallel command steps must still require transitions (regression test)",
+		},
+		{
+			name: "AC3: existing workflows with transitions continue to validate",
+			workflowYAML: `name: ac3-existing-workflow
+version: "1.0.0"
+states:
+  initial: parallel_step
+  parallel_step:
+    type: parallel
+    parallel:
+      - branch_a
+      - branch_b
+      - branch_c
+    strategy: all_succeed
+    on_success: done
+    on_failure: error
+  branch_a:
+    type: step
+    command: echo "Branch A"
+    on_success: done
+    on_failure: error
+  branch_b:
+    type: step
+    command: echo "Branch B"
+    on_success: done
+    on_failure: error
+  branch_c:
+    type: step
+    command: echo "Branch C"
+    on_success: done
+    on_failure: error
+  done:
+    type: terminal
+    status: success
+  error:
+    type: terminal
+    status: failure`,
+			expectedStatus: workflow.StatusCompleted,
+			expectedStep:   "done",
+			wantErr:        false,
+			description:    "Existing workflows with transitions should continue working",
+		},
+		{
+			name: "nested parallel: branch children without transitions",
+			workflowYAML: `name: nested-parallel-no-transitions
+version: "1.0.0"
+states:
+  initial: outer_parallel
+  outer_parallel:
+    type: parallel
+    parallel:
+      - inner_parallel
+      - task_x
+    strategy: all_succeed
+    on_success: done
+    on_failure: error
+  inner_parallel:
+    type: parallel
+    parallel:
+      - task_a
+      - task_b
+    strategy: all_succeed
+  task_a:
+    type: step
+    command: echo "Inner Task A"
+  task_b:
+    type: step
+    command: echo "Inner Task B"
+  task_x:
+    type: step
+    command: echo "Task X"
+  done:
+    type: terminal
+    status: success
+  error:
+    type: terminal
+    status: failure`,
+			expectedStatus: workflow.StatusCompleted,
+			expectedStep:   "done",
+			wantErr:        false,
+			description:    "Nested parallel: all branch children at all levels should not require transitions",
+		},
+		{
+			name: "multiple parallel steps in sequence",
+			workflowYAML: `name: sequential-parallel-steps
+version: "1.0.0"
+states:
+  initial: parallel_1
+  parallel_1:
+    type: parallel
+    parallel:
+      - task_a
+      - task_b
+    strategy: all_succeed
+    on_success: parallel_2
+    on_failure: error
+  task_a:
+    type: step
+    command: echo "Task A"
+  task_b:
+    type: step
+    command: echo "Task B"
+  parallel_2:
+    type: parallel
+    parallel:
+      - task_c
+      - task_d
+    strategy: all_succeed
+    on_success: done
+    on_failure: error
+  task_c:
+    type: step
+    command: echo "Task C"
+  task_d:
+    type: step
+    command: echo "Task D"
+  done:
+    type: terminal
+    status: success
+  error:
+    type: terminal
+    status: failure`,
+			expectedStatus: workflow.StatusCompleted,
+			expectedStep:   "done",
+			wantErr:        false,
+			description:    "Multiple parallel steps in sequence with transitionless branch children",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			tmpDir := t.TempDir()
+			wfPath := filepath.Join(tmpDir, "workflow.yaml")
+			require.NoError(t, os.WriteFile(wfPath, []byte(tt.workflowYAML), 0o644))
+
+			repo := repository.NewYAMLRepository(tmpDir)
+			store := testutil.NewMockStateStore()
+			exec := executor.NewShellExecutor()
+			logger := testutil.NewMockLogger()
+
+			svc := testutil.NewExecutionServiceBuilder().
+				WithWorkflowRepository(repo).
+				WithStateStore(store).
+				WithExecutor(exec).
+				WithLogger(logger).
+				Build()
+
+			// Act
+			execCtx, err := svc.Run(ctx, "workflow", nil)
+
+			// Assert
+			if tt.wantErr {
+				require.Error(t, err, tt.description)
+			} else {
+				require.NoError(t, err, tt.description)
+				require.NotNil(t, execCtx)
+				assert.Equal(t, tt.expectedStatus, execCtx.Status, tt.description)
+				assert.Equal(t, tt.expectedStep, execCtx.CurrentStep, tt.description)
+			}
+		})
+	}
+}
+
+// =============================================================================
 // Helper Functions
 // =============================================================================
 


### PR DESCRIPTION
## Summary

The workflow validator required all command-type steps to define `on_success`/`on_failure` transitions — including parallel branch children, where the execution engine discards transitions entirely. Users were forced to write dead-code transitions just to pass validation.

This PR exempts parallel branch children from the transition requirement by building a `parallelBranchSteps` set (mirroring the existing `loopBodySteps` pattern from F048) and skipping the check for steps in that set.

## Changes

**Core fix** (`internal/domain/workflow/workflow.go`):
- Build `parallelBranchSteps` exemption map from all `step.Branches` in parallel-type steps
- Guard the transition requirement check with a map lookup

**Tests** (573 new lines):
- 9 table-driven unit tests covering exemption, optional transitions, backward compat, and regressions
- 7 integration tests with full YAML pipeline validation against all acceptance criteria

**Documentation** (5 files):
- `docs/reference/validation.md` — document parallel branch transition exemption rules
- `docs/user-guide/agent-steps.md` — update parallel example to referenced states pattern
- `docs/user-guide/examples.md` — refactor parallel examples with top-level branch definitions
- `docs/user-guide/workflow-syntax.md` — document branch semantics and output access pattern
- `CHANGELOG.md` — add B004 entry in Fixed section

## Test plan

- [x] `make test-unit` — 9 new B004 validator test cases pass
- [x] `make test-integration` — 7 new parallel integration tests pass
- [x] `make test-race` — no race conditions
- [x] `make lint` — clean

Closes #200