### PR TITLE
feat(agent): add external prompt file loading with template interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Zero breaking changes: all existing consumers compile unchanged
 
 ### Added
+- **F063**: Prompt File Loading for Agent Steps
 
 - **F058**: Built-in HTTP Operation
   - New `http` operation provider with `http.request` operation for declarative REST API calls
@@ -213,6 +214,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Affects: Template interpolation, workflow validation, all state references
 
 ### Added
+- **F063**: Prompt File Loading for Agent Steps
 - **C056**: Add doc.go to 9 Key Infrastructure and Interface Packages
   - Created `doc.go` files for 9 undocumented packages: `agents`, `executor`, `expression`, `logger`, `plugin`, `repository`, `store`, `cli`, `cli/ui`
   - Three documentation tiers scaled by package complexity: concise (~20-30 lines), medium (~40-50 lines), comprehensive (~60-80 lines)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,10 @@ Use pkg pattern for cross-layer HTTP utilities (pkg/httputil) to avoid infrastru
 
 Implement infrastructure operation providers (e.g., HTTPOperationProvider) with direct domain type implementation to enable zero-change wiring into CompositeOperationProvider
 
+Implement prompt file loading in application layer (ExecutionService); domain layer defines PromptFile field only; infrastructure layer handles YAML mapping
+
+Populate AWF context variables (.awf.config_dir, .awf.cache_dir) in application layer during interpolation setup; use XDG directory standards for consistency
+
 ## Common Pitfalls
 
 Preserve existing infrastructure layers when adding domain registries; ADR-004 enforces infrastructure plugin registry coexistence for separate lifecycle concerns
@@ -237,11 +241,19 @@ Never duplicate HTTP client logic across notification backends; extract to pkg/h
 
 Limit HTTP response bodies at operation level (default 1MB via io.LimitReader) with truncated flag; preserve unlimited reads for notify backends by allowing maxBytes=0
 
+Always resolve relative prompt file paths against workflow.SourceDir, not current working directory; enables consistent behavior regardless of CLI invocation location
+
+Enforce 1MB size limit on loaded prompt files via io.LimitReader to prevent accidental memory issues and provide fast failure feedback for misconfigured paths
+
+Never allow both Prompt and PromptFile fields to be set simultaneously; AgentConfig.Validate must enforce XOR constraint with clear error messages
+
 ## Test Conventions
 
 Integration tests use compile-time interface checks (var _ PortInterface = (*Implementation)(nil)) to verify port implementation at build time
 
 Use HTTPDoer interface in pkg/httputil tests to mock HTTP behavior (timeouts, DNS errors, connection failures) without requiring adapters or *http.Client modifications
+
+Write unit tests for prompt file validation, interpolation, and YAML mapping before integration tests; use table-driven tests for path resolution scenarios
 
 ## Review Standards
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Go CLI tool for orchestrating AI agents (Claude, Gemini, Codex) through YAML-c
 
 - **State Machine Execution** - Define workflows as state machines with conditional transitions
 - **Agent Steps** - Invoke AI CLI agents (Claude, Codex, Gemini) with prompt templates and response parsing
+- **External Prompt Files** - Load agent prompts from `.md` files with full template interpolation and helper functions
 - **Conversation Mode** - Multi-turn conversations with automatic context window management and token counting
 - **Parallel Execution** - Run multiple steps concurrently with configurable strategies
 - **Loop Constructs** - For-each and while loops with full context access

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ Learn how to use AWF effectively:
 - [Commands](user-guide/commands.md) - All CLI commands and flags
 - [Interactive Input Collection](user-guide/interactive-inputs.md) - Automatic prompting for missing workflow inputs
 - [Agent Steps](user-guide/agent-steps.md) - Invoke AI agents (Claude, Codex, Gemini) in workflows
+  - [External Prompt Files](user-guide/agent-steps.md#external-prompt-files) - Load prompts from Markdown files with template interpolation
 - [Conversation Mode](user-guide/conversation-steps.md) - Multi-turn conversations with context window management
 - [Configuration](user-guide/configuration.md) - Project configuration file
 - [Workflow Syntax](user-guide/workflow-syntax.md) - YAML workflow definition reference

--- a/docs/reference/interpolation.md
+++ b/docs/reference/interpolation.md
@@ -178,6 +178,104 @@ deploy:
     deploy.sh --env={{.env.DEPLOY_ENV}} --token={{.env.API_TOKEN}}
 ```
 
+### AWF Directory Context
+
+Access system directories configured per XDG standards:
+
+```yaml
+{{.awf.config_dir}}      # ~/.config/awf (or $XDG_CONFIG_HOME/awf)
+{{.awf.data_dir}}        # ~/.local/share/awf (or $XDG_DATA_HOME/awf)
+{{.awf.cache_dir}}       # ~/.cache/awf (or $XDG_CACHE_HOME/awf)
+{{.awf.prompts_dir}}     # Designated prompts directory within config_dir
+{{.awf.workflows_dir}}   # Designated workflows directory within config_dir
+{{.awf.plugins_dir}}     # Plugin installation directory
+```
+
+Example:
+```yaml
+analyze:
+  type: agent
+  provider: claude
+  prompt_file: "{{.awf.prompts_dir}}/code_review.md"
+  on_success: done
+```
+
+## Template Helper Functions
+
+When interpolating template expressions, the following helper functions are available:
+
+### `split`
+
+Split a string into an array by delimiter:
+
+```yaml
+{{split "apple,banana,orange" ","}}
+```
+
+Returns: `["apple" "banana" "orange"]`
+
+Use in templates with `range` to iterate:
+```markdown
+{{range split .states.select.Output ","}}
+- {{trimSpace .}}
+{{end}}
+```
+
+### `join`
+
+Join an array into a string with separator:
+
+```yaml
+{{join (split .states.agents.Output ",") " | "}}
+```
+
+Returns: `apple | banana | orange`
+
+### `readFile`
+
+Read and inline file contents (with 1MB size limit):
+
+```markdown
+## Specification
+
+{{readFile .states.spec_path.Output}}
+```
+
+The file path is relative to the workflow directory. Fails if:
+- File doesn't exist
+- File exceeds 1MB (prevents accidental large file loading)
+- Path is not readable
+
+### `trimSpace`
+
+Remove leading and trailing whitespace:
+
+```yaml
+Result: {{trimSpace .states.process.Output}}
+```
+
+Useful for cleaning multiline outputs or removing shell command trailing newlines.
+
+### Example: String Manipulation
+
+```markdown
+# Analysis Report
+
+## Available Agents
+{{range split .states.list_agents.Output ","}}
+- {{trimSpace .}}
+{{end}}
+
+## Combined Skills
+Skills: {{join .states.available_skills.Output ", "}}
+
+## Research Summary
+{{readFile .states.research_summary_path.Output}}
+
+## Status
+{{trimSpace .states.final_status.Output}}
+```
+
 ### Loop Context Variables
 
 Available inside `for_each` and `while` loops:

--- a/docs/user-guide/agent-steps.md
+++ b/docs/user-guide/agent-steps.md
@@ -167,6 +167,196 @@ review:
 
 See [Variable Interpolation Reference](../reference/interpolation.md) for complete details.
 
+## External Prompt Files
+
+Instead of inlining prompts in YAML, you can load prompts from external Markdown files using the `prompt_file` field:
+
+```yaml
+analyze:
+  type: agent
+  provider: claude
+  prompt_file: prompts/code_review.md
+  timeout: 120
+  on_success: done
+```
+
+**File:** `prompts/code_review.md`
+```markdown
+# Code Review Instructions
+
+Analyze the following file for:
+- Performance issues
+- Security vulnerabilities
+- Code style violations
+
+## File Path
+{{.inputs.file_path}}
+
+## File Content
+{{.inputs.file_content}}
+
+## Language
+{{.inputs.language}}
+```
+
+### Features
+
+- **Full Template Interpolation** — Same variable access as inline prompts
+- **Helper Functions** — String manipulation directly in templates
+- **Path Resolution** — Relative paths resolve to workflow directory
+- **XDG Directory Support** — Access system directories via `{{.awf.*}}`
+
+### Mutual Exclusivity
+
+You cannot specify both `prompt` and `prompt_file` on the same agent step:
+
+```yaml
+# ❌ Invalid: both prompt and prompt_file
+step:
+  type: agent
+  provider: claude
+  prompt: "Do this"
+  prompt_file: "prompts/template.md"  # ERROR: only one allowed
+
+# ✅ Valid: prompt only
+step:
+  type: agent
+  provider: claude
+  prompt: "Do this"
+
+# ✅ Valid: prompt_file only
+step:
+  type: agent
+  provider: claude
+  prompt_file: "prompts/template.md"
+```
+
+### Path Resolution
+
+Paths can be:
+
+1. **Relative to workflow directory:**
+   ```yaml
+   prompt_file: prompts/analyze.md           # Resolves to <workflow_dir>/prompts/analyze.md
+   ```
+
+2. **Absolute paths:**
+   ```yaml
+   prompt_file: /home/user/my-prompts/template.md
+   ```
+
+3. **Home directory expansion:**
+   ```yaml
+   prompt_file: ~/my-prompts/template.md      # Expands to user's home directory
+   ```
+
+4. **XDG-compliant system directories:**
+   ```yaml
+   prompt_file: "{{.awf.prompts_dir}}/analyze.md"  # ~/.config/awf/prompts/analyze.md (or per XDG_CONFIG_HOME)
+   prompt_file: "{{.awf.data_dir}}/templates/*.md"
+   ```
+
+### Template Helper Functions
+
+When interpolating prompt templates, four helper functions are available:
+
+#### `split`
+
+Split a string into an array:
+
+```markdown
+## Selected Agents
+
+{{range split .states.select_agents.Output ","}}
+- {{trimSpace .}}
+{{end}}
+```
+
+#### `join`
+
+Join an array into a string:
+
+```markdown
+Skills to use: {{join .states.available_skills.Output ", "}}
+```
+
+#### `readFile`
+
+Inline file contents (with 1MB size limit):
+
+```markdown
+## Specification
+
+{{readFile .states.get_spec.Output}}
+```
+
+#### `trimSpace`
+
+Remove leading/trailing whitespace:
+
+```markdown
+Result: {{trimSpace .states.process.Output}}
+```
+
+### Example: Multi-File Workflow
+
+**Workflow:** `code-review.yaml`
+```yaml
+name: code-review
+version: "1.0.0"
+
+inputs:
+  - name: file_path
+    type: string
+    required: true
+    validation:
+      file_exists: true
+  - name: focus_areas
+    type: string
+
+states:
+  initial: read_file
+
+  read_file:
+    type: step
+    command: cat "{{.inputs.file_path}}"
+    on_success: analyze
+
+  analyze:
+    type: agent
+    provider: claude
+    prompt_file: prompts/code_review.md
+    timeout: 120
+    on_success: done
+
+  done:
+    type: terminal
+```
+
+**Template:** `prompts/code_review.md`
+```markdown
+# Code Review
+
+File: `{{.inputs.file_path}}`
+
+Focus on:
+{{.inputs.focus_areas}}
+
+## Code to Review
+
+{{.states.read_file.Output}}
+
+Provide:
+1. Issues found
+2. Suggested fixes
+3. Overall assessment
+```
+
+Run:
+```bash
+awf run code-review --input file_path=main.py --input focus_areas="Performance and security"
+```
+
 ## Capturing Responses
 
 Agent responses are automatically captured in the execution state:

--- a/docs/user-guide/workflow-syntax.md
+++ b/docs/user-guide/workflow-syntax.md
@@ -155,6 +155,7 @@ refine_code:
 | `provider` | string | Yes | Agent provider: `claude`, `codex`, `gemini`, `opencode`, `custom` |
 | `mode` | string | No | Set to `conversation` for multi-turn mode |
 | `prompt` | string | Yes* | Prompt template (supports `{{.inputs.*}}` and `{{.states.*}}` interpolation) |
+| `prompt_file` | string | No* | Path to external prompt template file (mutually exclusive with `prompt`) |
 | `system_prompt` | string | No | System message (for conversation mode, preserved across turns) |
 | `initial_prompt` | string | No* | First user message (for conversation mode) |
 | `conversation` | object | No | Conversation configuration (required if mode=conversation) |
@@ -164,7 +165,7 @@ refine_code:
 | `on_failure` | string | No | Next state on failure |
 | `retry` | object | No | Retry configuration (same as step retry) |
 
-\* Use `prompt` for single-turn mode, `initial_prompt` for conversation mode.
+\* Use `prompt` or `prompt_file` for single-turn mode (mutually exclusive), `initial_prompt` for conversation mode. See [Agent Steps - External Prompt Files](agent-steps.md#external-prompt-files) for `prompt_file` details.
 
 ### Conversation Configuration
 

--- a/internal/application/dry_run_executor.go
+++ b/internal/application/dry_run_executor.go
@@ -17,6 +17,7 @@ type DryRunExecutor struct {
 	evaluator   ports.ExpressionEvaluator
 	templateSvc *TemplateService
 	logger      ports.Logger
+	awfPaths    map[string]string // F063: XDG directory paths injected from interfaces layer
 }
 
 func NewDryRunExecutor(
@@ -35,6 +36,11 @@ func NewDryRunExecutor(
 
 func (e *DryRunExecutor) SetTemplateService(svc *TemplateService) {
 	e.templateSvc = svc
+}
+
+// SetAWFPaths configures the AWF XDG directory paths for F063 template interpolation.
+func (e *DryRunExecutor) SetAWFPaths(paths map[string]string) {
+	e.awfPaths = paths
 }
 
 func (e *DryRunExecutor) Execute(ctx context.Context, workflowName string, inputs map[string]any) (*workflow.DryRunPlan, error) {
@@ -70,6 +76,14 @@ func (e *DryRunExecutor) buildPlan(ctx context.Context, wf *workflow.Workflow, i
 	}
 	interpCtx.Workflow.Name = wf.Name
 
+	// Populate AWF context with XDG directory paths (F063)
+	// Paths are injected via SetAWFPaths() to avoid infrastructure import in application layer
+	if e.awfPaths != nil {
+		interpCtx.AWF = e.awfPaths
+	} else {
+		interpCtx.AWF = map[string]string{}
+	}
+
 	plan := &workflow.DryRunPlan{
 		WorkflowName: wf.Name,
 		Description:  wf.Description,
@@ -100,7 +114,7 @@ func (e *DryRunExecutor) buildPlan(ctx context.Context, wf *workflow.Workflow, i
 			continue
 		}
 
-		dryRunStep, err := e.buildStepPlan(step, interpCtx)
+		dryRunStep, err := e.buildStepPlan(ctx, step, wf, interpCtx)
 		if err != nil {
 			return nil, fmt.Errorf("step '%s': %w", stepName, err)
 		}
@@ -145,7 +159,7 @@ func (e *DryRunExecutor) collectNextSteps(step *workflow.Step) []string {
 	return nextSteps
 }
 
-func (e *DryRunExecutor) buildStepPlan(step *workflow.Step, interpCtx *interpolation.Context) (*workflow.DryRunStep, error) {
+func (e *DryRunExecutor) buildStepPlan(ctx context.Context, step *workflow.Step, wf *workflow.Workflow, interpCtx *interpolation.Context) (*workflow.DryRunStep, error) {
 	dryRunStep := &workflow.DryRunStep{
 		Name:            step.Name,
 		Type:            step.Type,
@@ -197,7 +211,11 @@ func (e *DryRunExecutor) buildStepPlan(step *workflow.Step, interpCtx *interpola
 	}
 
 	if step.Agent != nil {
-		dryRunStep.Agent = e.buildAgentConfig(step.Agent, interpCtx)
+		var err error
+		dryRunStep.Agent, err = e.buildAgentConfig(ctx, step.Agent, wf, interpCtx)
+		if err != nil {
+			return nil, fmt.Errorf("build agent config: %w", err)
+		}
 	}
 
 	return dryRunStep, nil
@@ -334,15 +352,26 @@ func (e *DryRunExecutor) resolveCommand(cmd string, interpCtx *interpolation.Con
 	return resolved
 }
 
-func (e *DryRunExecutor) buildAgentConfig(agent *workflow.AgentConfig, interpCtx *interpolation.Context) *workflow.DryRunAgent {
+func (e *DryRunExecutor) buildAgentConfig(ctx context.Context, agent *workflow.AgentConfig, wf *workflow.Workflow, interpCtx *interpolation.Context) (*workflow.DryRunAgent, error) {
 	dryRunAgent := &workflow.DryRunAgent{
 		Provider: agent.Provider,
 		Timeout:  agent.Timeout,
 		Options:  make(map[string]any),
 	}
 
-	if agent.Prompt != "" {
-		dryRunAgent.ResolvedPrompt = e.resolveCommand(agent.Prompt, interpCtx)
+	// F063: Load and resolve prompt from file if prompt_file is specified
+	promptToResolve := agent.Prompt
+	if agent.PromptFile != "" {
+		loadedPrompt, err := loadPromptFile(ctx, agent.PromptFile, wf, interpCtx)
+		if err != nil {
+			return nil, fmt.Errorf("load prompt file: %w", err)
+		}
+		promptToResolve = loadedPrompt
+	}
+
+	// Resolve prompt via interpolation
+	if promptToResolve != "" {
+		dryRunAgent.ResolvedPrompt = e.resolveCommand(promptToResolve, interpCtx)
 	}
 
 	for key, value := range agent.Options {
@@ -353,5 +382,5 @@ func (e *DryRunExecutor) buildAgentConfig(agent *workflow.AgentConfig, interpCtx
 		dryRunAgent.CLICommand = e.resolveCommand(agent.Command, interpCtx)
 	}
 
-	return dryRunAgent
+	return dryRunAgent, nil
 }

--- a/internal/application/execution_service.go
+++ b/internal/application/execution_service.go
@@ -48,6 +48,7 @@ type ExecutionService struct {
 	agentRegistry     ports.AgentRegistry
 	conversationMgr   ConversationExecutor // F033: Multi-turn conversation orchestration (interface for testability)
 	outputLimiter     *OutputLimiter       // C019: Prevent OOM from unbounded output accumulation
+	awfPaths          map[string]string    // F063: XDG directory paths injected at construction (prompts_dir, config_dir, etc.)
 }
 
 // SetOutputWriters configures streaming output writers.
@@ -84,6 +85,12 @@ func (s *ExecutionService) SetEvaluator(evaluator ports.ExpressionEvaluator) {
 // Accepts ConversationExecutor interface to allow dependency injection and testing with mocks.
 func (s *ExecutionService) SetConversationManager(mgr ConversationExecutor) {
 	s.conversationMgr = mgr
+}
+
+// SetAWFPaths configures the AWF XDG directory paths for F063 template interpolation.
+// Keys: prompts_dir, config_dir, data_dir, workflows_dir, plugins_dir.
+func (s *ExecutionService) SetAWFPaths(paths map[string]string) {
+	s.awfPaths = paths
 }
 
 // NewExecutionService - historySvc can be nil to disable history recording.
@@ -275,7 +282,7 @@ func (s *ExecutionService) runWithCallStackAndWorkflow(
 		case workflow.StepTypeCallWorkflow:
 			nextStep, err = s.executeCallWorkflowStep(ctx, wf, step, execCtx)
 		case workflow.StepTypeAgent:
-			nextStep, err = s.executeAgentStep(ctx, step, execCtx)
+			nextStep, err = s.executeAgentStep(ctx, wf, step, execCtx)
 		default:
 			nextStep, err = s.executeStep(ctx, wf, step, execCtx)
 		}
@@ -526,6 +533,13 @@ func (s *ExecutionService) buildInterpolationContext(
 		env[k] = v // Override with workflow-specific env
 	}
 
+	// Populate AWF context with XDG directory paths (F063/T012)
+	// Paths are injected via SetAWFPaths() to avoid infrastructure import in application layer
+	awfContext := s.awfPaths
+	if awfContext == nil {
+		awfContext = map[string]string{}
+	}
+
 	intCtx := &interpolation.Context{
 		Inputs: execCtx.Inputs,
 		States: states,
@@ -542,6 +556,7 @@ func (s *ExecutionService) buildInterpolationContext(
 			Hostname:   hostname,
 		},
 		Error: nil, // Set in error hooks (F008)
+		AWF:   awfContext,
 	}
 
 	// Include loop context if we're inside a loop (with parent chain for nested loops)
@@ -791,7 +806,7 @@ func (s *ExecutionService) executeLoopStep(
 		case workflow.StepTypeCallWorkflow:
 			nextStep, err = s.executeCallWorkflowStep(ctx, wf, bodyStep, execCtx)
 		case workflow.StepTypeAgent:
-			nextStep, err = s.executeAgentStep(ctx, bodyStep, execCtx)
+			nextStep, err = s.executeAgentStep(ctx, wf, bodyStep, execCtx)
 		default:
 			nextStep, err = s.executeStep(ctx, wf, bodyStep, execCtx)
 		}
@@ -1311,7 +1326,7 @@ func (a *stepExecutorAdapter) ExecuteStep(
 	var err error
 	switch step.Type {
 	case workflow.StepTypeAgent:
-		_, err = a.execSvc.executeAgentStep(ctx, step, execCtx)
+		_, err = a.execSvc.executeAgentStep(ctx, wf, step, execCtx)
 	case workflow.StepTypeParallel:
 		_, err = a.execSvc.executeParallelStep(ctx, wf, step, execCtx)
 	case workflow.StepTypeForEach, workflow.StepTypeWhile:
@@ -1497,7 +1512,7 @@ func (s *ExecutionService) executeFromStep(
 		case workflow.StepTypeCallWorkflow:
 			nextStep, err = s.executeCallWorkflowStep(ctx, wf, step, execCtx)
 		case workflow.StepTypeAgent:
-			nextStep, err = s.executeAgentStep(ctx, step, execCtx)
+			nextStep, err = s.executeAgentStep(ctx, wf, step, execCtx)
 		default:
 			nextStep, err = s.executeStep(ctx, wf, step, execCtx)
 		}
@@ -1703,6 +1718,7 @@ var ErrNoAgentRegistry = errors.New("agent registry not configured")
 //nolint:gocognit // Complexity 39: agent step execution handles conversation/single modes, retries, context windows, token management. Inherent to agent orchestration.
 func (s *ExecutionService) executeAgentStep(
 	ctx context.Context,
+	wf *workflow.Workflow,
 	step *workflow.Step,
 	execCtx *workflow.ExecutionContext,
 ) (string, error) {
@@ -1753,8 +1769,18 @@ func (s *ExecutionService) executeAgentStep(
 		return s.executeConversationStep(stepCtx, step, execCtx)
 	}
 
+	// F063: Load prompt from file if prompt_file is specified
+	promptToResolve := step.Agent.Prompt
+	if step.Agent.PromptFile != "" {
+		loadedPrompt, err := loadPromptFile(stepCtx, step.Agent.PromptFile, wf, intCtx)
+		if err != nil {
+			return "", fmt.Errorf("step %s: load prompt file: %w", step.Name, err)
+		}
+		promptToResolve = loadedPrompt
+	}
+
 	// Resolve prompt via interpolation
-	resolvedPrompt, err := s.resolver.Resolve(step.Agent.Prompt, intCtx)
+	resolvedPrompt, err := s.resolver.Resolve(promptToResolve, intCtx)
 	if err != nil {
 		return "", fmt.Errorf("step %s: resolve prompt: %w", step.Name, err)
 	}

--- a/internal/application/execution_service_architecture_test.go
+++ b/internal/application/execution_service_architecture_test.go
@@ -29,7 +29,7 @@ func TestExecutionService_NoInfrastructureImport(t *testing.T) {
 		assert.NotContains(t, imp, "infrastructure/agents",
 			"execution_service.go must not import infrastructure/agents - violates DIP")
 		assert.NotContains(t, imp, "infrastructure/",
-			"execution_service.go should not import any infrastructure packages")
+			"execution_service.go must not import infrastructure packages - violates hexagonal architecture")
 	}
 }
 

--- a/internal/application/execution_service_awf_context_test.go
+++ b/internal/application/execution_service_awf_context_test.go
@@ -1,0 +1,439 @@
+package application_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/awf-project/awf/internal/domain/ports"
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/awf-project/awf/internal/infrastructure/xdg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Feature: F063 - Prompt File Loading for Agent Steps
+// Component: T012 - Populate .awf context in buildInterpolationContext()
+//
+// Tests verify that buildInterpolationContext() populates the AWF map with XDG directory paths.
+// These paths enable template interpolation like {{.awf.prompts_dir}}/template.md in workflows.
+
+func TestExecutionService_buildInterpolationContext_PopulatesAWFPaths(t *testing.T) {
+	promptsDir := xdg.AWFPromptsDir()
+
+	wf := &workflow.Workflow{
+		Name:    "test-awf-context",
+		Initial: "start",
+		Steps: map[string]*workflow.Step{
+			"start": {
+				Name:      "start",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo {{.awf.prompts_dir}}",
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test-awf-context", wf).
+		WithCommandResult("echo "+promptsDir, &ports.CommandResult{
+			Stdout:   promptsDir,
+			ExitCode: 0,
+		}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test-awf-context", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	state, ok := ctx.GetStepState("start")
+	require.True(t, ok)
+	assert.Contains(t, state.Output, promptsDir, "AWF prompts_dir should be interpolated")
+}
+
+func TestExecutionService_buildInterpolationContext_AWFConfigDir(t *testing.T) {
+	configDir := xdg.AWFConfigDir()
+
+	wf := &workflow.Workflow{
+		Name:    "test-config-dir",
+		Initial: "start",
+		Steps: map[string]*workflow.Step{
+			"start": {
+				Name:      "start",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo {{.awf.config_dir}}",
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test-config-dir", wf).
+		WithCommandResult("echo "+configDir, &ports.CommandResult{
+			Stdout:   configDir,
+			ExitCode: 0,
+		}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test-config-dir", nil)
+
+	require.NoError(t, err)
+	state, ok := ctx.GetStepState("start")
+	require.True(t, ok)
+	assert.Contains(t, state.Output, configDir, "AWF config_dir should be interpolated")
+}
+
+func TestExecutionService_buildInterpolationContext_AWFDataDir(t *testing.T) {
+	dataDir := xdg.AWFDataDir()
+
+	wf := &workflow.Workflow{
+		Name:    "test-data-dir",
+		Initial: "start",
+		Steps: map[string]*workflow.Step{
+			"start": {
+				Name:      "start",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo {{.awf.data_dir}}",
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test-data-dir", wf).
+		WithCommandResult("echo "+dataDir, &ports.CommandResult{
+			Stdout:   dataDir,
+			ExitCode: 0,
+		}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test-data-dir", nil)
+
+	require.NoError(t, err)
+	state, ok := ctx.GetStepState("start")
+	require.True(t, ok)
+	assert.Contains(t, state.Output, dataDir, "AWF data_dir should be interpolated")
+}
+
+func TestExecutionService_buildInterpolationContext_AWFWorkflowsDir(t *testing.T) {
+	workflowsDir := xdg.AWFWorkflowsDir()
+
+	wf := &workflow.Workflow{
+		Name:    "test-workflows-dir",
+		Initial: "start",
+		Steps: map[string]*workflow.Step{
+			"start": {
+				Name:      "start",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo {{.awf.workflows_dir}}",
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test-workflows-dir", wf).
+		WithCommandResult("echo "+workflowsDir, &ports.CommandResult{
+			Stdout:   workflowsDir,
+			ExitCode: 0,
+		}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test-workflows-dir", nil)
+
+	require.NoError(t, err)
+	state, ok := ctx.GetStepState("start")
+	require.True(t, ok)
+	assert.Contains(t, state.Output, workflowsDir, "AWF workflows_dir should be interpolated")
+}
+
+func TestExecutionService_buildInterpolationContext_AWFPluginsDir(t *testing.T) {
+	pluginsDir := xdg.AWFPluginsDir()
+
+	wf := &workflow.Workflow{
+		Name:    "test-plugins-dir",
+		Initial: "start",
+		Steps: map[string]*workflow.Step{
+			"start": {
+				Name:      "start",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo {{.awf.plugins_dir}}",
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test-plugins-dir", wf).
+		WithCommandResult("echo "+pluginsDir, &ports.CommandResult{
+			Stdout:   pluginsDir,
+			ExitCode: 0,
+		}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test-plugins-dir", nil)
+
+	require.NoError(t, err)
+	state, ok := ctx.GetStepState("start")
+	require.True(t, ok)
+	assert.Contains(t, state.Output, pluginsDir, "AWF plugins_dir should be interpolated")
+}
+
+func TestExecutionService_buildInterpolationContext_AllAWFPathsAvailable(t *testing.T) {
+	promptsDir := xdg.AWFPromptsDir()
+	configDir := xdg.AWFConfigDir()
+	dataDir := xdg.AWFDataDir()
+	workflowsDir := xdg.AWFWorkflowsDir()
+	pluginsDir := xdg.AWFPluginsDir()
+
+	wf := &workflow.Workflow{
+		Name:    "test-all-paths",
+		Initial: "start",
+		Steps: map[string]*workflow.Step{
+			"start": {
+				Name:      "start",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo {{.awf.prompts_dir}} {{.awf.config_dir}} {{.awf.data_dir}} {{.awf.workflows_dir}} {{.awf.plugins_dir}}",
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	expectedOutput := promptsDir + " " + configDir + " " + dataDir + " " + workflowsDir + " " + pluginsDir
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test-all-paths", wf).
+		WithCommandResult("echo "+expectedOutput, &ports.CommandResult{
+			Stdout:   expectedOutput,
+			ExitCode: 0,
+		}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test-all-paths", nil)
+
+	require.NoError(t, err)
+	state, ok := ctx.GetStepState("start")
+	require.True(t, ok)
+
+	assert.Contains(t, state.Output, promptsDir)
+	assert.Contains(t, state.Output, configDir)
+	assert.Contains(t, state.Output, dataDir)
+	assert.Contains(t, state.Output, workflowsDir)
+	assert.Contains(t, state.Output, pluginsDir)
+}
+
+func TestExecutionService_buildInterpolationContext_XDGOverride(t *testing.T) {
+	originalConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	originalDataHome := os.Getenv("XDG_DATA_HOME")
+	t.Cleanup(func() {
+		if originalConfigHome != "" {
+			os.Setenv("XDG_CONFIG_HOME", originalConfigHome)
+		} else {
+			os.Unsetenv("XDG_CONFIG_HOME")
+		}
+		if originalDataHome != "" {
+			os.Setenv("XDG_DATA_HOME", originalDataHome)
+		} else {
+			os.Unsetenv("XDG_DATA_HOME")
+		}
+	})
+
+	tmpDir := t.TempDir()
+	customConfigHome := filepath.Join(tmpDir, "custom-config")
+	customDataHome := filepath.Join(tmpDir, "custom-data")
+
+	os.Setenv("XDG_CONFIG_HOME", customConfigHome)
+	os.Setenv("XDG_DATA_HOME", customDataHome)
+
+	expectedConfigDir := filepath.Join(customConfigHome, "awf")
+
+	wf := &workflow.Workflow{
+		Name:    "test-xdg-override",
+		Initial: "start",
+		Steps: map[string]*workflow.Step{
+			"start": {
+				Name:      "start",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo {{.awf.config_dir}}",
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test-xdg-override", wf).
+		WithCommandResult("echo "+expectedConfigDir, &ports.CommandResult{
+			Stdout:   expectedConfigDir,
+			ExitCode: 0,
+		}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test-xdg-override", nil)
+
+	require.NoError(t, err)
+	state, ok := ctx.GetStepState("start")
+	require.True(t, ok)
+	assert.Contains(t, state.Output, expectedConfigDir, "AWF paths should respect XDG_CONFIG_HOME override")
+}
+
+func TestExecutionService_buildInterpolationContext_AWFContextInMultipleSteps(t *testing.T) {
+	promptsDir := xdg.AWFPromptsDir()
+	configDir := xdg.AWFConfigDir()
+
+	wf := &workflow.Workflow{
+		Name:    "test-multi-step-awf",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": {
+				Name:      "step1",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo {{.awf.prompts_dir}}",
+				OnSuccess: "step2",
+			},
+			"step2": {
+				Name:      "step2",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo {{.awf.config_dir}}",
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test-multi-step-awf", wf).
+		WithCommandResult("echo "+promptsDir, &ports.CommandResult{
+			Stdout:   promptsDir,
+			ExitCode: 0,
+		}).
+		WithCommandResult("echo "+configDir, &ports.CommandResult{
+			Stdout:   configDir,
+			ExitCode: 0,
+		}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test-multi-step-awf", nil)
+
+	require.NoError(t, err)
+
+	step1State, ok := ctx.GetStepState("step1")
+	require.True(t, ok)
+	assert.Contains(t, step1State.Output, promptsDir)
+
+	step2State, ok := ctx.GetStepState("step2")
+	require.True(t, ok)
+	assert.Contains(t, step2State.Output, configDir)
+}
+
+func TestExecutionService_buildInterpolationContext_AWFContextWithStateReference(t *testing.T) {
+	promptsDir := xdg.AWFPromptsDir()
+	expectedPath := filepath.Join(promptsDir, "template.md")
+
+	wf := &workflow.Workflow{
+		Name:    "test-awf-with-state",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": {
+				Name:      "step1",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo template.md",
+				OnSuccess: "step2",
+			},
+			"step2": {
+				Name:      "step2",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo {{.awf.prompts_dir}}/{{.states.step1.Output}}",
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test-awf-with-state", wf).
+		WithCommandResult("echo template.md", &ports.CommandResult{
+			Stdout:   "template.md",
+			ExitCode: 0,
+		}).
+		WithCommandResult("echo "+expectedPath, &ports.CommandResult{
+			Stdout:   expectedPath,
+			ExitCode: 0,
+		}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test-awf-with-state", nil)
+
+	require.NoError(t, err)
+
+	step2State, ok := ctx.GetStepState("step2")
+	require.True(t, ok)
+	assert.Contains(t, step2State.Output, expectedPath, "AWF path should combine with state output")
+}
+
+func TestExecutionService_buildInterpolationContext_EmptyAWFMapInitialized(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test-empty-awf",
+		Initial: "start",
+		Steps: map[string]*workflow.Step{
+			"start": {
+				Name:      "start",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo test",
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test-empty-awf", wf).
+		WithCommandResult("echo test", &ports.CommandResult{
+			Stdout:   "test",
+			ExitCode: 0,
+		}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test-empty-awf", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+}

--- a/internal/application/prompt_file.go
+++ b/internal/application/prompt_file.go
@@ -1,0 +1,103 @@
+package application
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/awf-project/awf/pkg/interpolation"
+)
+
+const maxPromptFileSize = 1024 * 1024 // 1MB
+
+// loadPromptFile loads and interpolates a prompt template file referenced by AgentConfig.PromptFile.
+// Returns the fully interpolated prompt content ready for agent execution.
+//
+// Path resolution order:
+//  1. Template interpolation of the path itself (e.g., {{.awf.prompts_dir}}/plan.md)
+//  2. Tilde expansion for home directory (~/)
+//  3. Relative path resolution against workflow source directory
+//
+// Applies 1MB size limit (NFR-001) to prevent accidental loading of large files.
+func loadPromptFile(
+	ctx context.Context,
+	promptFile string,
+	wf *workflow.Workflow,
+	intCtx *interpolation.Context,
+) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	// Step 1: Template interpolation of the path
+	resolver := interpolation.NewTemplateResolver()
+	interpolatedPath, err := resolver.Resolve(promptFile, intCtx)
+	if err != nil {
+		return "", fmt.Errorf("interpolate prompt_file path: %w", err)
+	}
+
+	// Step 2: Tilde expansion
+	expandedPath := interpolatedPath
+	if strings.HasPrefix(interpolatedPath, "~/") {
+		var homeDir string
+		homeDir, err = os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("expand tilde in prompt_file path: %w", err)
+		}
+		expandedPath = filepath.Join(homeDir, interpolatedPath[2:])
+	}
+
+	// Step 3: Relative path resolution
+	resolvedPath := expandedPath
+	if !filepath.IsAbs(expandedPath) {
+		resolvedPath = filepath.Join(wf.SourceDir, expandedPath)
+	}
+
+	// Fallback: if tilde-expanded path doesn't exist, try as relative path
+	if strings.HasPrefix(interpolatedPath, "~/") && expandedPath != interpolatedPath {
+		if _, statErr := os.Stat(resolvedPath); os.IsNotExist(statErr) {
+			fallbackPath := filepath.Join(wf.SourceDir, interpolatedPath[2:])
+			if _, statErr = os.Stat(fallbackPath); statErr == nil {
+				resolvedPath = fallbackPath
+			}
+		}
+	}
+
+	// Validate file
+	fileInfo, err := os.Stat(resolvedPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("prompt file not found: %s", resolvedPath)
+		}
+		if os.IsPermission(err) {
+			return "", fmt.Errorf("permission denied reading prompt file: %s", resolvedPath)
+		}
+		return "", fmt.Errorf("read prompt file: %w", err)
+	}
+
+	if fileInfo.IsDir() {
+		return "", fmt.Errorf("prompt_file path is a directory, not a file: %s", resolvedPath)
+	}
+
+	if fileInfo.Size() > maxPromptFileSize {
+		return "", fmt.Errorf("prompt file exceeds 1MB limit: %s (%d bytes)", resolvedPath, fileInfo.Size())
+	}
+
+	// Read file
+	file, err := os.Open(resolvedPath)
+	if err != nil {
+		return "", fmt.Errorf("open prompt file: %w", err)
+	}
+	defer file.Close()
+
+	content, err := io.ReadAll(io.LimitReader(file, maxPromptFileSize))
+	if err != nil {
+		return "", fmt.Errorf("read prompt file: %w", err)
+	}
+
+	return string(content), nil
+}

--- a/internal/application/prompt_file_test.go
+++ b/internal/application/prompt_file_test.go
@@ -1,0 +1,416 @@
+package application
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/awf-project/awf/pkg/interpolation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecutionService_loadPromptFile_HappyPath tests successful prompt file loading scenarios.
+func TestExecutionService_loadPromptFile_HappyPath(t *testing.T) {
+	tests := []struct {
+		name            string
+		fileContent     string
+		promptFilePath  string
+		setupFile       func(t *testing.T, dir string) string
+		awfContext      map[string]string
+		expectedContent string
+	}{
+		{
+			name:        "relative path to prompt file",
+			fileContent: "Analyze this code: {{.inputs.code}}",
+			setupFile: func(t *testing.T, dir string) string {
+				path := filepath.Join(dir, "prompts", "analyze.md")
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+				require.NoError(t, os.WriteFile(path, []byte("Analyze this code: {{.inputs.code}}"), 0o644))
+				return "prompts/analyze.md"
+			},
+			expectedContent: "Analyze this code: {{.inputs.code}}",
+		},
+		{
+			name:        "absolute path to prompt file",
+			fileContent: "Review this PR: {{.inputs.pr_url}}",
+			setupFile: func(t *testing.T, dir string) string {
+				path := filepath.Join(dir, "absolute.md")
+				require.NoError(t, os.WriteFile(path, []byte("Review this PR: {{.inputs.pr_url}}"), 0o644))
+				return path
+			},
+			expectedContent: "Review this PR: {{.inputs.pr_url}}",
+		},
+		{
+			name:        "nested directory structure",
+			fileContent: "Feature analysis prompt",
+			setupFile: func(t *testing.T, dir string) string {
+				path := filepath.Join(dir, "prompts", "feature-001", "agent", "step-02.md")
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+				require.NoError(t, os.WriteFile(path, []byte("Feature analysis prompt"), 0o644))
+				return "prompts/feature-001/agent/step-02.md"
+			},
+			expectedContent: "Feature analysis prompt",
+		},
+		{
+			name:        "prompt file with unicode content",
+			fileContent: "分析このコード: {{.inputs.code}}\n日本語プロンプト",
+			setupFile: func(t *testing.T, dir string) string {
+				path := filepath.Join(dir, "unicode.md")
+				require.NoError(t, os.WriteFile(path, []byte("分析このコード: {{.inputs.code}}\n日本語プロンプト"), 0o644))
+				return "unicode.md"
+			},
+			expectedContent: "分析このコード: {{.inputs.code}}\n日本語プロンプト",
+		},
+		{
+			name:        "template variable in path - awf.prompts_dir",
+			fileContent: "Prompt from AWF prompts directory",
+			setupFile: func(t *testing.T, dir string) string {
+				promptsDir := filepath.Join(dir, "awf-prompts")
+				path := filepath.Join(promptsDir, "plan", "research.md")
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+				require.NoError(t, os.WriteFile(path, []byte("Prompt from AWF prompts directory"), 0o644))
+				return "{{.awf.prompts_dir}}/plan/research.md"
+			},
+			awfContext: map[string]string{
+				"prompts_dir": func(t *testing.T, dir string) string {
+					return filepath.Join(dir, "awf-prompts")
+				}(t, ""),
+			},
+			expectedContent: "Prompt from AWF prompts directory",
+		},
+		{
+			name:        "large file under 1MB limit",
+			fileContent: strings.Repeat("a", 1024*500), // 500KB
+			setupFile: func(t *testing.T, dir string) string {
+				path := filepath.Join(dir, "large.md")
+				require.NoError(t, os.WriteFile(path, []byte(strings.Repeat("a", 1024*500)), 0o644))
+				return "large.md"
+			},
+			expectedContent: strings.Repeat("a", 1024*500),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			promptFilePath := tt.setupFile(t, tmpDir)
+			if tt.awfContext != nil && strings.Contains(promptFilePath, "{{.awf.prompts_dir}}") {
+				promptsDir := filepath.Join(tmpDir, "awf-prompts")
+				tt.awfContext["prompts_dir"] = promptsDir
+				promptFilePath = strings.Replace(promptFilePath, "{{.awf.prompts_dir}}", promptsDir, 1)
+			}
+
+			wf := &workflow.Workflow{
+				Name:      "test-workflow",
+				SourceDir: tmpDir,
+			}
+
+			intCtx := &interpolation.Context{
+				Inputs: map[string]any{
+					"code":   "test-code",
+					"pr_url": "https://github.com/org/repo/pull/1",
+				},
+				AWF: tt.awfContext,
+			}
+
+			result, err := loadPromptFile(context.Background(), promptFilePath, wf, intCtx)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedContent, result)
+		})
+	}
+}
+
+// TestExecutionService_loadPromptFile_TildeExpansion tests home directory expansion.
+func TestExecutionService_loadPromptFile_TildeExpansion(t *testing.T) {
+	tmpDir := t.TempDir()
+	promptPath := filepath.Join(tmpDir, "custom", "prompt.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(promptPath), 0o755))
+	require.NoError(t, os.WriteFile(promptPath, []byte("Custom prompt content"), 0o644))
+
+	wf := &workflow.Workflow{
+		Name:      "test-workflow",
+		SourceDir: tmpDir,
+	}
+
+	intCtx := &interpolation.Context{}
+
+	tildePromptFile := "~/custom/prompt.md"
+
+	result, err := loadPromptFile(context.Background(), tildePromptFile, wf, intCtx)
+
+	require.NoError(t, err)
+	assert.Contains(t, result, "Custom prompt content")
+}
+
+// TestExecutionService_loadPromptFile_TemplateInterpolationInPath tests path interpolation.
+func TestExecutionService_loadPromptFile_TemplateInterpolationInPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	promptPath := filepath.Join(configDir, "prompts", "test-feature.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(promptPath), 0o755))
+	require.NoError(t, os.WriteFile(promptPath, []byte("Feature-specific prompt"), 0o644))
+
+	wf := &workflow.Workflow{
+		Name:      "test-workflow",
+		SourceDir: tmpDir,
+	}
+
+	intCtx := &interpolation.Context{
+		Inputs: map[string]any{
+			"feature": "test-feature",
+		},
+		AWF: map[string]string{
+			"config_dir": configDir,
+		},
+	}
+
+	promptFile := "{{.awf.config_dir}}/prompts/{{.inputs.feature}}.md"
+
+	result, err := loadPromptFile(context.Background(), promptFile, wf, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Feature-specific prompt", result)
+}
+
+// TestExecutionService_loadPromptFile_SizeLimit tests 1MB limit enforcement.
+func TestExecutionService_loadPromptFile_SizeLimit(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	oversizedContent := strings.Repeat("a", 1024*1024+1) // 1MB + 1 byte
+	promptPath := filepath.Join(tmpDir, "oversized.md")
+	require.NoError(t, os.WriteFile(promptPath, []byte(oversizedContent), 0o644))
+
+	wf := &workflow.Workflow{
+		Name:      "test-workflow",
+		SourceDir: tmpDir,
+	}
+
+	intCtx := &interpolation.Context{}
+
+	_, err := loadPromptFile(context.Background(), "oversized.md", wf, intCtx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds 1MB limit")
+}
+
+// TestExecutionService_loadPromptFile_FileNotFound tests missing file error.
+func TestExecutionService_loadPromptFile_FileNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	wf := &workflow.Workflow{
+		Name:      "test-workflow",
+		SourceDir: tmpDir,
+	}
+
+	intCtx := &interpolation.Context{}
+
+	_, err := loadPromptFile(context.Background(), "nonexistent.md", wf, intCtx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent.md")
+}
+
+// TestExecutionService_loadPromptFile_DirectoryInsteadOfFile tests directory error.
+func TestExecutionService_loadPromptFile_DirectoryInsteadOfFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	dirPath := filepath.Join(tmpDir, "prompts")
+	require.NoError(t, os.MkdirAll(dirPath, 0o755))
+
+	wf := &workflow.Workflow{
+		Name:      "test-workflow",
+		SourceDir: tmpDir,
+	}
+
+	intCtx := &interpolation.Context{}
+
+	_, err := loadPromptFile(context.Background(), "prompts", wf, intCtx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is a directory")
+}
+
+// TestExecutionService_loadPromptFile_PermissionDenied tests unreadable file error.
+func TestExecutionService_loadPromptFile_PermissionDenied(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("Skipping permission test when running as root")
+	}
+
+	tmpDir := t.TempDir()
+	promptPath := filepath.Join(tmpDir, "unreadable.md")
+	require.NoError(t, os.WriteFile(promptPath, []byte("secret content"), 0o000))
+	defer os.Chmod(promptPath, 0o644) // cleanup
+
+	wf := &workflow.Workflow{
+		Name:      "test-workflow",
+		SourceDir: tmpDir,
+	}
+
+	intCtx := &interpolation.Context{}
+
+	_, err := loadPromptFile(context.Background(), "unreadable.md", wf, intCtx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permission denied")
+}
+
+// TestExecutionService_loadPromptFile_EmptyFile tests empty file handling.
+func TestExecutionService_loadPromptFile_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	promptPath := filepath.Join(tmpDir, "empty.md")
+	require.NoError(t, os.WriteFile(promptPath, []byte(""), 0o644))
+
+	wf := &workflow.Workflow{
+		Name:      "test-workflow",
+		SourceDir: tmpDir,
+	}
+
+	intCtx := &interpolation.Context{}
+
+	result, err := loadPromptFile(context.Background(), "empty.md", wf, intCtx)
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+// TestExecutionService_loadPromptFile_WhitespaceOnlyFile tests whitespace-only file.
+func TestExecutionService_loadPromptFile_WhitespaceOnlyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	promptPath := filepath.Join(tmpDir, "whitespace.md")
+	require.NoError(t, os.WriteFile(promptPath, []byte("   \n\t\n   "), 0o644))
+
+	wf := &workflow.Workflow{
+		Name:      "test-workflow",
+		SourceDir: tmpDir,
+	}
+
+	intCtx := &interpolation.Context{}
+
+	result, err := loadPromptFile(context.Background(), "whitespace.md", wf, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "   \n\t\n   ", result)
+}
+
+// TestExecutionService_loadPromptFile_PathWithSpaces tests file path containing spaces.
+func TestExecutionService_loadPromptFile_PathWithSpaces(t *testing.T) {
+	tmpDir := t.TempDir()
+	promptPath := filepath.Join(tmpDir, "my prompt file.md")
+	require.NoError(t, os.WriteFile(promptPath, []byte("Content with spaces in path"), 0o644))
+
+	wf := &workflow.Workflow{
+		Name:      "test-workflow",
+		SourceDir: tmpDir,
+	}
+
+	intCtx := &interpolation.Context{}
+
+	result, err := loadPromptFile(context.Background(), "my prompt file.md", wf, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Content with spaces in path", result)
+}
+
+// TestExecutionService_loadPromptFile_RelativePathResolution tests relative path handling.
+func TestExecutionService_loadPromptFile_RelativePathResolution(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	workflowDir := filepath.Join(tmpDir, "workflows")
+	promptsDir := filepath.Join(tmpDir, "prompts")
+	require.NoError(t, os.MkdirAll(workflowDir, 0o755))
+	require.NoError(t, os.MkdirAll(promptsDir, 0o755))
+
+	promptPath := filepath.Join(promptsDir, "analyze.md")
+	require.NoError(t, os.WriteFile(promptPath, []byte("Shared prompt"), 0o644))
+
+	wf := &workflow.Workflow{
+		Name:      "test-workflow",
+		SourceDir: workflowDir,
+	}
+
+	intCtx := &interpolation.Context{}
+
+	relativePromptFile := "../prompts/analyze.md"
+
+	result, err := loadPromptFile(context.Background(), relativePromptFile, wf, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Shared prompt", result)
+}
+
+// TestExecutionService_loadPromptFile_MultipleAWFVariables tests path with multiple template vars.
+func TestExecutionService_loadPromptFile_MultipleAWFVariables(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	dataDir := filepath.Join(tmpDir, "data")
+	promptPath := filepath.Join(configDir, dataDir, "prompt.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(promptPath), 0o755))
+	require.NoError(t, os.WriteFile(promptPath, []byte("Multi-var prompt"), 0o644))
+
+	wf := &workflow.Workflow{
+		Name:      "test-workflow",
+		SourceDir: tmpDir,
+	}
+
+	intCtx := &interpolation.Context{
+		AWF: map[string]string{
+			"config_dir": configDir,
+			"data_dir":   dataDir,
+		},
+	}
+
+	promptFile := "{{.awf.config_dir}}/{{.awf.data_dir}}/prompt.md"
+
+	result, err := loadPromptFile(context.Background(), promptFile, wf, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Multi-var prompt", result)
+}
+
+// TestExecutionService_loadPromptFile_BoundarySize tests file at exact 1MB limit.
+func TestExecutionService_loadPromptFile_BoundarySize(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	exactContent := strings.Repeat("a", 1024*1024) // Exactly 1MB
+	promptPath := filepath.Join(tmpDir, "exact-1mb.md")
+	require.NoError(t, os.WriteFile(promptPath, []byte(exactContent), 0o644))
+
+	wf := &workflow.Workflow{
+		Name:      "test-workflow",
+		SourceDir: tmpDir,
+	}
+
+	intCtx := &interpolation.Context{}
+
+	result, err := loadPromptFile(context.Background(), "exact-1mb.md", wf, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, exactContent, result)
+}
+
+// TestExecutionService_loadPromptFile_ContextCancellation tests context cancellation handling.
+func TestExecutionService_loadPromptFile_ContextCancellation(t *testing.T) {
+	tmpDir := t.TempDir()
+	promptPath := filepath.Join(tmpDir, "test.md")
+	require.NoError(t, os.WriteFile(promptPath, []byte("test content"), 0o644))
+
+	wf := &workflow.Workflow{
+		Name:      "test-workflow",
+		SourceDir: tmpDir,
+	}
+
+	intCtx := &interpolation.Context{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := loadPromptFile(ctx, "test.md", wf, intCtx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context canceled")
+}

--- a/internal/application/service.go
+++ b/internal/application/service.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
 	domerrors "github.com/awf-project/awf/internal/domain/errors"
 	"github.com/awf-project/awf/internal/domain/ports"
@@ -76,6 +79,81 @@ func (s *WorkflowService) ValidateWorkflow(ctx context.Context, name string) err
 		}
 		return fmt.Errorf("validate workflow %s: %w", name, err)
 	}
+
+	return s.validatePromptFiles(wf)
+}
+
+func (s *WorkflowService) validatePromptFiles(wf *workflow.Workflow) error {
+	for _, step := range wf.Steps {
+		if step.Type != workflow.StepTypeAgent || step.Agent == nil {
+			continue
+		}
+
+		if step.Agent.PromptFile == "" {
+			continue
+		}
+
+		// Skip validation for paths with template expressions — resolved at runtime
+		if strings.Contains(step.Agent.PromptFile, "{{") {
+			continue
+		}
+
+		path := step.Agent.PromptFile
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(wf.SourceDir, path)
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return domerrors.NewStructuredError(
+					domerrors.ErrorCodeUserInputMissingFile,
+					fmt.Sprintf("prompt_file not found: %s", step.Agent.PromptFile),
+					map[string]any{
+						"path": path,
+						"step": step.Name,
+					},
+					err,
+				)
+			}
+			return domerrors.NewStructuredError(
+				domerrors.ErrorCodeUserInputMissingFile,
+				fmt.Sprintf("prompt_file cannot be accessed: %s", step.Agent.PromptFile),
+				map[string]any{
+					"path": path,
+					"step": step.Name,
+				},
+				err,
+			)
+		}
+
+		if info.IsDir() {
+			return domerrors.NewStructuredError(
+				domerrors.ErrorCodeUserInputMissingFile,
+				fmt.Sprintf("prompt_file is a directory, not a file: %s", step.Agent.PromptFile),
+				map[string]any{
+					"path": path,
+					"step": step.Name,
+				},
+				nil,
+			)
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return domerrors.NewStructuredError(
+				domerrors.ErrorCodeUserInputMissingFile,
+				fmt.Sprintf("prompt_file cannot be read: %s", step.Agent.PromptFile),
+				map[string]any{
+					"path": path,
+					"step": step.Name,
+				},
+				err,
+			)
+		}
+		_ = f.Close()
+	}
+
 	return nil
 }
 

--- a/internal/application/service_prompt_file_test.go
+++ b/internal/application/service_prompt_file_test.go
@@ -1,0 +1,433 @@
+package application_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awf-project/awf/internal/application"
+	domerrors "github.com/awf-project/awf/internal/domain/errors"
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Helper to create a basic workflow with agent step and terminal state
+func newTestWorkflowWithPromptFile(name, sourceDir, promptFile string) *workflow.Workflow {
+	return &workflow.Workflow{
+		Name:      name,
+		Initial:   "agent_step",
+		SourceDir: sourceDir,
+		Steps: map[string]*workflow.Step{
+			"agent_step": {
+				Name: "agent_step",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:   "claude",
+					PromptFile: promptFile,
+				},
+				OnSuccess: "done",
+			},
+			"done": {
+				Name:   "done",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+}
+
+func TestValidateWorkflow_PromptFileValidation_HappyPath(t *testing.T) {
+	tempDir := t.TempDir()
+
+	promptFile := filepath.Join(tempDir, "prompt.md")
+	err := os.WriteFile(promptFile, []byte("# Test Prompt\n{{.inputs.name}}"), 0o600)
+	require.NoError(t, err)
+
+	repo := newMockRepository()
+	repo.workflows["test"] = newTestWorkflowWithPromptFile("test", tempDir, "prompt.md")
+
+	svc := application.NewWorkflowService(
+		repo,
+		newMockStateStore(),
+		newMockExecutor(),
+		&mockLogger{},
+		newMockExpressionValidator(),
+	)
+
+	err = svc.ValidateWorkflow(context.Background(), "test")
+	assert.NoError(t, err)
+}
+
+func TestValidateWorkflow_PromptFileValidation_MissingFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	repo := newMockRepository()
+	repo.workflows["test"] = newTestWorkflowWithPromptFile("test", tempDir, "nonexistent.md")
+
+	svc := application.NewWorkflowService(
+		repo,
+		newMockStateStore(),
+		newMockExecutor(),
+		&mockLogger{},
+		newMockExpressionValidator(),
+	)
+
+	err := svc.ValidateWorkflow(context.Background(), "test")
+	require.Error(t, err)
+
+	var structErr *domerrors.StructuredError
+	require.ErrorAs(t, err, &structErr)
+	assert.Equal(t, domerrors.ErrorCodeUserInputMissingFile, structErr.Code)
+	assert.Contains(t, structErr.Message, "prompt_file")
+	assert.Contains(t, structErr.Message, "nonexistent.md")
+}
+
+func TestValidateWorkflow_PromptFileValidation_UnreadableFile(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("Skipping permission test when running as root")
+	}
+
+	tempDir := t.TempDir()
+
+	promptFile := filepath.Join(tempDir, "unreadable.md")
+	err := os.WriteFile(promptFile, []byte("# Test"), 0o000)
+	require.NoError(t, err)
+	defer os.Chmod(promptFile, 0o600)
+
+	repo := newMockRepository()
+	repo.workflows["test"] = newTestWorkflowWithPromptFile("test", tempDir, "unreadable.md")
+
+	svc := application.NewWorkflowService(
+		repo,
+		newMockStateStore(),
+		newMockExecutor(),
+		&mockLogger{},
+		newMockExpressionValidator(),
+	)
+
+	err = svc.ValidateWorkflow(context.Background(), "test")
+	require.Error(t, err)
+
+	var structErr *domerrors.StructuredError
+	require.ErrorAs(t, err, &structErr)
+	assert.Equal(t, domerrors.ErrorCodeUserInputMissingFile, structErr.Code)
+}
+
+func TestValidateWorkflow_PromptFileValidation_AbsolutePath(t *testing.T) {
+	tempDir := t.TempDir()
+
+	promptFile := filepath.Join(tempDir, "absolute.md")
+	err := os.WriteFile(promptFile, []byte("# Absolute Path Test"), 0o600)
+	require.NoError(t, err)
+
+	repo := newMockRepository()
+	repo.workflows["test"] = newTestWorkflowWithPromptFile("test", "/some/other/dir", promptFile)
+
+	svc := application.NewWorkflowService(
+		repo,
+		newMockStateStore(),
+		newMockExecutor(),
+		&mockLogger{},
+		newMockExpressionValidator(),
+	)
+
+	err = svc.ValidateWorkflow(context.Background(), "test")
+	assert.NoError(t, err)
+}
+
+func TestValidateWorkflow_PromptFileValidation_MultipleAgentSteps(t *testing.T) {
+	tempDir := t.TempDir()
+
+	prompt1 := filepath.Join(tempDir, "prompt1.md")
+	prompt2 := filepath.Join(tempDir, "prompt2.md")
+	err := os.WriteFile(prompt1, []byte("# Prompt 1"), 0o600)
+	require.NoError(t, err)
+	err = os.WriteFile(prompt2, []byte("# Prompt 2"), 0o600)
+	require.NoError(t, err)
+
+	repo := newMockRepository()
+	repo.workflows["test"] = &workflow.Workflow{
+		Name:      "test",
+		Initial:   "step1",
+		SourceDir: tempDir,
+		Steps: map[string]*workflow.Step{
+			"step1": {
+				Name: "step1",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:   "claude",
+					PromptFile: "prompt1.md",
+				},
+				OnSuccess: "step2",
+			},
+			"step2": {
+				Name: "step2",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:   "gemini",
+					PromptFile: "prompt2.md",
+				},
+				OnSuccess: "done",
+			},
+			"done": {
+				Name:   "done",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	svc := application.NewWorkflowService(
+		repo,
+		newMockStateStore(),
+		newMockExecutor(),
+		&mockLogger{},
+		newMockExpressionValidator(),
+	)
+
+	err = svc.ValidateWorkflow(context.Background(), "test")
+	assert.NoError(t, err)
+}
+
+func TestValidateWorkflow_PromptFileValidation_NoAgentSteps(t *testing.T) {
+	repo := newMockRepository()
+	repo.workflows["test"] = &workflow.Workflow{
+		Name:      "test",
+		Initial:   "shell_step",
+		SourceDir: "/tmp",
+		Steps: map[string]*workflow.Step{
+			"shell_step": {
+				Name:      "shell_step",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo 'hello'",
+				OnSuccess: "done",
+			},
+			"done": {
+				Name:   "done",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	svc := application.NewWorkflowService(
+		repo,
+		newMockStateStore(),
+		newMockExecutor(),
+		&mockLogger{},
+		newMockExpressionValidator(),
+	)
+
+	err := svc.ValidateWorkflow(context.Background(), "test")
+	assert.NoError(t, err)
+}
+
+func TestValidateWorkflow_PromptFileValidation_EmptyPromptFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	repo := newMockRepository()
+	repo.workflows["test"] = &workflow.Workflow{
+		Name:      "test",
+		Initial:   "agent_step",
+		SourceDir: tempDir,
+		Steps: map[string]*workflow.Step{
+			"agent_step": {
+				Name: "agent_step",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:   "claude",
+					Prompt:     "inline prompt",
+					PromptFile: "",
+				},
+				OnSuccess: "done",
+			},
+			"done": {
+				Name:   "done",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	svc := application.NewWorkflowService(
+		repo,
+		newMockStateStore(),
+		newMockExecutor(),
+		&mockLogger{},
+		newMockExpressionValidator(),
+	)
+
+	err := svc.ValidateWorkflow(context.Background(), "test")
+	assert.NoError(t, err)
+}
+
+func TestValidateWorkflow_PromptFileValidation_DirectoryInsteadOfFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	subDir := filepath.Join(tempDir, "subdir")
+	err := os.Mkdir(subDir, 0o755)
+	require.NoError(t, err)
+
+	repo := newMockRepository()
+	repo.workflows["test"] = newTestWorkflowWithPromptFile("test", tempDir, "subdir")
+
+	svc := application.NewWorkflowService(
+		repo,
+		newMockStateStore(),
+		newMockExecutor(),
+		&mockLogger{},
+		newMockExpressionValidator(),
+	)
+
+	err = svc.ValidateWorkflow(context.Background(), "test")
+	require.Error(t, err)
+
+	var structErr *domerrors.StructuredError
+	require.ErrorAs(t, err, &structErr)
+	assert.Equal(t, domerrors.ErrorCodeUserInputMissingFile, structErr.Code)
+}
+
+func TestValidateWorkflow_PromptFileValidation_NestedPath(t *testing.T) {
+	tempDir := t.TempDir()
+
+	nestedDir := filepath.Join(tempDir, "prompts", "analyze")
+	err := os.MkdirAll(nestedDir, 0o755)
+	require.NoError(t, err)
+
+	promptFile := filepath.Join(nestedDir, "research.md")
+	err = os.WriteFile(promptFile, []byte("# Research Prompt"), 0o600)
+	require.NoError(t, err)
+
+	repo := newMockRepository()
+	repo.workflows["test"] = newTestWorkflowWithPromptFile("test", tempDir, "prompts/analyze/research.md")
+
+	svc := application.NewWorkflowService(
+		repo,
+		newMockStateStore(),
+		newMockExecutor(),
+		&mockLogger{},
+		newMockExpressionValidator(),
+	)
+
+	err = svc.ValidateWorkflow(context.Background(), "test")
+	assert.NoError(t, err)
+}
+
+func TestValidateWorkflow_PromptFileValidation_ErrorIncludesDetails(t *testing.T) {
+	tempDir := t.TempDir()
+
+	similarFile := filepath.Join(tempDir, "prompt_template.md")
+	err := os.WriteFile(similarFile, []byte("# Similar"), 0o600)
+	require.NoError(t, err)
+
+	repo := newMockRepository()
+	repo.workflows["test"] = newTestWorkflowWithPromptFile("test", tempDir, "prompt_tempalte.md")
+
+	svc := application.NewWorkflowService(
+		repo,
+		newMockStateStore(),
+		newMockExecutor(),
+		&mockLogger{},
+		newMockExpressionValidator(),
+	)
+
+	err = svc.ValidateWorkflow(context.Background(), "test")
+	require.Error(t, err)
+
+	var structErr *domerrors.StructuredError
+	require.ErrorAs(t, err, &structErr)
+
+	assert.NotNil(t, structErr.Details)
+	pathDetail, hasPath := structErr.Details["path"]
+	assert.True(t, hasPath, "error details should include path field for FileNotFoundHintGenerator")
+	assert.NotEmpty(t, pathDetail)
+}
+
+func TestValidateWorkflow_PromptFileValidation_TemplateExpressionSkipped(t *testing.T) {
+	// Paths containing template expressions (e.g. {{.awf.prompts_dir}}) cannot be
+	// validated statically — they are resolved at runtime via interpolation.
+	repo := newMockRepository()
+	repo.workflows["test"] = newTestWorkflowWithPromptFile(
+		"test", "/nonexistent/source", "{{.awf.prompts_dir}}/commit/commit-message.md",
+	)
+
+	svc := application.NewWorkflowService(
+		repo,
+		newMockStateStore(),
+		newMockExecutor(),
+		&mockLogger{},
+		newMockExpressionValidator(),
+	)
+
+	err := svc.ValidateWorkflow(context.Background(), "test")
+	assert.NoError(t, err, "paths with template expressions should be skipped during static validation")
+}
+
+func TestValidateWorkflow_PromptFileValidation_MultipleFilesFirstFailureReported(t *testing.T) {
+	tempDir := t.TempDir()
+
+	prompt2 := filepath.Join(tempDir, "prompt2.md")
+	err := os.WriteFile(prompt2, []byte("# Valid"), 0o600)
+	require.NoError(t, err)
+
+	repo := newMockRepository()
+	repo.workflows["test"] = &workflow.Workflow{
+		Name:      "test",
+		Initial:   "step1",
+		SourceDir: tempDir,
+		Steps: map[string]*workflow.Step{
+			"step1": {
+				Name: "step1",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:   "claude",
+					PromptFile: "missing1.md",
+				},
+				OnSuccess: "step2",
+			},
+			"step2": {
+				Name: "step2",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:   "gemini",
+					PromptFile: "prompt2.md",
+				},
+				OnSuccess: "step3",
+			},
+			"step3": {
+				Name: "step3",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:   "claude",
+					PromptFile: "missing3.md",
+				},
+				OnSuccess: "done",
+			},
+			"done": {
+				Name:   "done",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	svc := application.NewWorkflowService(
+		repo,
+		newMockStateStore(),
+		newMockExecutor(),
+		&mockLogger{},
+		newMockExpressionValidator(),
+	)
+
+	err = svc.ValidateWorkflow(context.Background(), "test")
+	require.Error(t, err)
+
+	errMsg := err.Error()
+	assert.True(t,
+		strings.Contains(errMsg, "missing1.md") || strings.Contains(errMsg, "missing3.md"),
+		"error should mention at least one missing file",
+	)
+}

--- a/internal/application/testutil_test.go
+++ b/internal/application/testutil_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/awf-project/awf/internal/application"
 	"github.com/awf-project/awf/internal/domain/ports"
 	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/awf-project/awf/internal/infrastructure/xdg"
 	"github.com/awf-project/awf/internal/testutil/builders"
 	testmocks "github.com/awf-project/awf/internal/testutil/mocks"
 )
@@ -278,6 +279,16 @@ func (h *ServiceTestHarness) WithExecutor(executor ports.CommandExecutor) *Servi
 func (h *ServiceTestHarness) Build() (*application.ExecutionService, *TestMocks) {
 	// Build the ExecutionService using the configured builder
 	service := h.builder.Build()
+
+	// F063/T012: Inject AWF XDG directory paths for template interpolation
+	// This populates the .awf namespace in interpolation contexts
+	service.SetAWFPaths(map[string]string{
+		"prompts_dir":   xdg.AWFPromptsDir(),
+		"config_dir":    xdg.AWFConfigDir(),
+		"data_dir":      xdg.AWFDataDir(),
+		"workflows_dir": xdg.AWFWorkflowsDir(),
+		"plugins_dir":   xdg.AWFPluginsDir(),
+	})
 
 	// Create TestMocks tuple with references to all mocks
 	mocks := &TestMocks{

--- a/internal/domain/workflow/agent_config.go
+++ b/internal/domain/workflow/agent_config.go
@@ -13,6 +13,7 @@ const DefaultAgentTimeout = 300
 type AgentConfig struct {
 	Provider      string              `yaml:"provider"`       // agent provider: claude, codex, gemini, opencode, custom
 	Prompt        string              `yaml:"prompt"`         // prompt template with {{inputs.*}} and {{states.*}} (single mode) or initial prompt (conversation mode)
+	PromptFile    string              `yaml:"prompt_file"`    // path to external prompt template file (mutually exclusive with Prompt)
 	Options       map[string]any      `yaml:"options"`        // provider-specific options (model, temperature, max_tokens, etc.)
 	Timeout       int                 `yaml:"timeout"`        // seconds, 0 = use DefaultAgentTimeout
 	Command       string              `yaml:"command"`        // custom command template (for custom provider)
@@ -42,8 +43,17 @@ func (c *AgentConfig) Validate(validator ExpressionCompiler) error {
 		return errors.New("mode must be 'single' or 'conversation'")
 	}
 
+	// Validate mutual exclusivity of Prompt and PromptFile
+	if c.Prompt != "" && c.PromptFile != "" {
+		return errors.New("prompt and prompt_file are mutually exclusive")
+	}
+
 	// Mode-specific validation
 	if c.Mode == "conversation" {
+		// prompt_file not supported in conversation mode (deferred per spec)
+		if c.PromptFile != "" {
+			return errors.New("prompt_file is not supported in conversation mode")
+		}
 		// In conversation mode, require either InitialPrompt or Prompt
 		if c.InitialPrompt == "" && c.Prompt == "" {
 			return errors.New("initial_prompt or prompt is required in conversation mode")
@@ -54,9 +64,9 @@ func (c *AgentConfig) Validate(validator ExpressionCompiler) error {
 				return err
 			}
 		}
-	} else if c.Prompt == "" {
-		// In single mode, require Prompt
-		return errors.New("prompt is required")
+	} else if c.Prompt == "" && c.PromptFile == "" {
+		// In single mode, require either Prompt or PromptFile
+		return errors.New("prompt or prompt_file is required")
 	}
 
 	// Validate timeout (must be non-negative)

--- a/internal/domain/workflow/agent_config_prompt_file_test.go
+++ b/internal/domain/workflow/agent_config_prompt_file_test.go
@@ -1,0 +1,349 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Feature: F063 - Prompt File Loading for Agent Steps
+// Component: T001 - Add PromptFile field and Validate() mutual exclusivity
+// Tests: PromptFile field validation and mutual exclusivity with Prompt
+
+func TestAgentConfig_PromptFile_SingleMode_Valid(t *testing.T) {
+	tests := []struct {
+		name       string
+		promptFile string
+	}{
+		{
+			name:       "relative path",
+			promptFile: "prompts/analyze.md",
+		},
+		{
+			name:       "absolute path",
+			promptFile: "/etc/awf/prompts/plan.md",
+		},
+		{
+			name:       "tilde path",
+			promptFile: "~/prompts/custom.md",
+		},
+		{
+			name:       "template variable path",
+			promptFile: "{{.awf.prompts_dir}}/plan/research.md",
+		},
+		{
+			name:       "nested relative path",
+			promptFile: "../../shared/prompts/analyze.md",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := AgentConfig{
+				Provider:   "claude",
+				PromptFile: tt.promptFile,
+			}
+			err := config.Validate(nil)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestAgentConfig_PromptFile_MutualExclusivity_BothSet(t *testing.T) {
+	config := AgentConfig{
+		Provider:   "claude",
+		Prompt:     "Analyze this code",
+		PromptFile: "prompts/analyze.md",
+	}
+	err := config.Validate(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestAgentConfig_PromptFile_SingleMode_NeitherSet(t *testing.T) {
+	config := AgentConfig{
+		Provider: "claude",
+		Mode:     "single",
+	}
+	err := config.Validate(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prompt or prompt_file is required")
+}
+
+func TestAgentConfig_PromptFile_SingleMode_OnlyPromptFile(t *testing.T) {
+	config := AgentConfig{
+		Provider:   "claude",
+		PromptFile: "prompts/test.md",
+		Mode:       "single",
+	}
+	err := config.Validate(nil)
+	assert.NoError(t, err)
+}
+
+func TestAgentConfig_PromptFile_SingleMode_OnlyPrompt(t *testing.T) {
+	config := AgentConfig{
+		Provider: "claude",
+		Prompt:   "Test prompt",
+		Mode:     "single",
+	}
+	err := config.Validate(nil)
+	assert.NoError(t, err)
+}
+
+func TestAgentConfig_PromptFile_ConversationMode_NotSupported(t *testing.T) {
+	config := AgentConfig{
+		Provider:   "claude",
+		PromptFile: "prompts/conversation.md",
+		Mode:       "conversation",
+	}
+	err := config.Validate(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported in conversation mode")
+}
+
+func TestAgentConfig_PromptFile_ConversationMode_PromptAllowed(t *testing.T) {
+	config := AgentConfig{
+		Provider: "claude",
+		Prompt:   "Initial conversation prompt",
+		Mode:     "conversation",
+	}
+	err := config.Validate(nil)
+	assert.NoError(t, err)
+}
+
+func TestAgentConfig_PromptFile_ConversationMode_InitialPromptAllowed(t *testing.T) {
+	config := AgentConfig{
+		Provider:      "claude",
+		InitialPrompt: "Start conversation",
+		Mode:          "conversation",
+	}
+	err := config.Validate(nil)
+	assert.NoError(t, err)
+}
+
+func TestAgentConfig_PromptFile_EdgeCases_EmptyString(t *testing.T) {
+	config := AgentConfig{
+		Provider:   "claude",
+		PromptFile: "",
+		Prompt:     "Valid prompt",
+	}
+	err := config.Validate(nil)
+	assert.NoError(t, err)
+}
+
+func TestAgentConfig_PromptFile_EdgeCases_WhitespaceOnly(t *testing.T) {
+	config := AgentConfig{
+		Provider:   "claude",
+		PromptFile: "   ",
+		Prompt:     "",
+	}
+	err := config.Validate(nil)
+	assert.NoError(t, err)
+}
+
+func TestAgentConfig_PromptFile_ComplexPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		promptFile string
+		wantErr    bool
+		errMsg     string
+	}{
+		{
+			name:       "path with spaces",
+			promptFile: "prompts/my prompt file.md",
+			wantErr:    false,
+		},
+		{
+			name:       "path with special chars",
+			promptFile: "prompts/@special-#prompt$.md",
+			wantErr:    false,
+		},
+		{
+			name:       "path with unicode",
+			promptFile: "prompts/日本語.md",
+			wantErr:    false,
+		},
+		{
+			name:       "mixed template and literal",
+			promptFile: "{{.env.HOME}}/prompts/analyze.md",
+			wantErr:    false,
+		},
+		{
+			name:       "multiple template variables",
+			promptFile: "{{.awf.config_dir}}/{{.inputs.workflow_name}}/prompt.md",
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := AgentConfig{
+				Provider:   "claude",
+				PromptFile: tt.promptFile,
+			}
+			err := config.Validate(nil)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAgentConfig_PromptFile_WithOtherFields(t *testing.T) {
+	config := AgentConfig{
+		Provider:   "claude",
+		PromptFile: "prompts/analyze.md",
+		Options: map[string]any{
+			"model":      "claude-sonnet-4-20250514",
+			"max_tokens": 4096,
+		},
+		Timeout: 120,
+	}
+	err := config.Validate(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "prompts/analyze.md", config.PromptFile)
+	assert.Equal(t, "claude", config.Provider)
+	assert.Equal(t, 120, config.Timeout)
+}
+
+func TestAgentConfig_PromptFile_MutualExclusivity_NonEmptyPrompt(t *testing.T) {
+	tests := []struct {
+		name       string
+		prompt     string
+		promptFile string
+		wantErr    bool
+	}{
+		{
+			name:       "both non-empty",
+			prompt:     "Inline prompt",
+			promptFile: "prompts/file.md",
+			wantErr:    true,
+		},
+		{
+			name:       "both with templates",
+			prompt:     "Code: {{inputs.code}}",
+			promptFile: "{{.awf.prompts_dir}}/analyze.md",
+			wantErr:    true,
+		},
+		{
+			name:       "empty prompt, non-empty file",
+			prompt:     "",
+			promptFile: "prompts/file.md",
+			wantErr:    false,
+		},
+		{
+			name:       "non-empty prompt, empty file",
+			prompt:     "Inline prompt",
+			promptFile: "",
+			wantErr:    false,
+		},
+		{
+			name:       "whitespace prompt, non-empty file",
+			prompt:     "   ",
+			promptFile: "prompts/file.md",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := AgentConfig{
+				Provider:   "claude",
+				Prompt:     tt.prompt,
+				PromptFile: tt.promptFile,
+			}
+			err := config.Validate(nil)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "mutually exclusive")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAgentConfig_PromptFile_GetEffectivePrompt_DoesNotReturnFile(t *testing.T) {
+	config := AgentConfig{
+		Provider:   "claude",
+		PromptFile: "prompts/analyze.md",
+	}
+	effectivePrompt := config.GetEffectivePrompt()
+	assert.Empty(t, effectivePrompt)
+}
+
+func TestAgentConfig_PromptFile_ConversationMode_Combinations(t *testing.T) {
+	tests := []struct {
+		name          string
+		prompt        string
+		promptFile    string
+		initialPrompt string
+		wantErr       bool
+		errMsg        string
+	}{
+		{
+			name:       "promptFile only",
+			promptFile: "prompts/conv.md",
+			wantErr:    true,
+			errMsg:     "not supported in conversation mode",
+		},
+		{
+			name:          "promptFile with initialPrompt",
+			promptFile:    "prompts/conv.md",
+			initialPrompt: "Start",
+			wantErr:       true,
+			errMsg:        "not supported in conversation mode",
+		},
+		{
+			name:       "promptFile with prompt",
+			promptFile: "prompts/conv.md",
+			prompt:     "Initial",
+			wantErr:    true,
+			errMsg:     "mutually exclusive",
+		},
+		{
+			name:          "promptFile with both prompt and initialPrompt",
+			promptFile:    "prompts/conv.md",
+			prompt:        "Initial",
+			initialPrompt: "Start",
+			wantErr:       true,
+		},
+		{
+			name:          "initialPrompt only (valid)",
+			initialPrompt: "Start conversation",
+			wantErr:       false,
+		},
+		{
+			name:    "prompt only (valid)",
+			prompt:  "Initial message",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := AgentConfig{
+				Provider:      "claude",
+				Mode:          "conversation",
+				Prompt:        tt.prompt,
+				PromptFile:    tt.promptFile,
+				InitialPrompt: tt.initialPrompt,
+			}
+			err := config.Validate(nil)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/domain/workflow/workflow.go
+++ b/internal/domain/workflow/workflow.go
@@ -27,6 +27,7 @@ type Workflow struct {
 	Initial     string           // initial state name
 	Steps       map[string]*Step // state name -> step
 	Hooks       WorkflowHooks    // workflow-level hooks
+	SourceDir   string           // workflow file directory for path resolution (runtime metadata)
 }
 
 // GetStep retrieves a step by name.

--- a/internal/domain/workflow/workflow_source_dir_test.go
+++ b/internal/domain/workflow/workflow_source_dir_test.go
@@ -1,0 +1,183 @@
+package workflow_test
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorkflow_SourceDir_FieldExists(t *testing.T) {
+	wf := workflow.Workflow{
+		Name:      "test-workflow",
+		Initial:   "start",
+		SourceDir: "/home/user/.config/awf/workflows",
+		Steps: map[string]*workflow.Step{
+			"start": {Name: "start", Type: workflow.StepTypeTerminal},
+		},
+	}
+
+	assert.Equal(t, "/home/user/.config/awf/workflows", wf.SourceDir)
+}
+
+func TestWorkflow_SourceDir_EmptyByDefault(t *testing.T) {
+	wf := workflow.Workflow{
+		Name:    "test-workflow",
+		Initial: "start",
+		Steps: map[string]*workflow.Step{
+			"start": {Name: "start", Type: workflow.StepTypeTerminal},
+		},
+	}
+
+	assert.Empty(t, wf.SourceDir)
+}
+
+func TestWorkflow_SourceDir_CanStoreRelativePath(t *testing.T) {
+	wf := workflow.Workflow{
+		Name:      "test-workflow",
+		Initial:   "start",
+		SourceDir: ".awf/workflows",
+		Steps: map[string]*workflow.Step{
+			"start": {Name: "start", Type: workflow.StepTypeTerminal},
+		},
+	}
+
+	assert.Equal(t, ".awf/workflows", wf.SourceDir)
+}
+
+func TestWorkflow_SourceDir_CanStoreAbsolutePath(t *testing.T) {
+	wf := workflow.Workflow{
+		Name:      "test-workflow",
+		Initial:   "start",
+		SourceDir: "/opt/workflows/production",
+		Steps: map[string]*workflow.Step{
+			"start": {Name: "start", Type: workflow.StepTypeTerminal},
+		},
+	}
+
+	assert.Equal(t, "/opt/workflows/production", wf.SourceDir)
+}
+
+func TestWorkflow_SourceDir_HandlesPathsWithSpaces(t *testing.T) {
+	wf := workflow.Workflow{
+		Name:      "test-workflow",
+		Initial:   "start",
+		SourceDir: "/home/user/my workflows/project 123",
+		Steps: map[string]*workflow.Step{
+			"start": {Name: "start", Type: workflow.StepTypeTerminal},
+		},
+	}
+
+	assert.Equal(t, "/home/user/my workflows/project 123", wf.SourceDir)
+}
+
+func TestWorkflow_SourceDir_PathExtraction(t *testing.T) {
+	tests := []struct {
+		name              string
+		filePath          string
+		expectedSourceDir string
+	}{
+		{
+			name:              "absolute path",
+			filePath:          "/home/user/.config/awf/workflows/plan.yaml",
+			expectedSourceDir: "/home/user/.config/awf/workflows",
+		},
+		{
+			name:              "relative path",
+			filePath:          ".awf/workflows/analyze.yaml",
+			expectedSourceDir: ".awf/workflows",
+		},
+		{
+			name:              "nested path",
+			filePath:          "/opt/company/workflows/prod/deploy.yaml",
+			expectedSourceDir: "/opt/company/workflows/prod",
+		},
+		{
+			name:              "path with spaces",
+			filePath:          "/home/user/my workflows/test.yaml",
+			expectedSourceDir: "/home/user/my workflows",
+		},
+		{
+			name:              "current directory",
+			filePath:          "workflow.yaml",
+			expectedSourceDir: ".",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualDir := filepath.Dir(tt.filePath)
+			assert.Equal(t, tt.expectedSourceDir, actualDir,
+				"filepath.Dir() should extract directory from %s", tt.filePath)
+		})
+	}
+}
+
+func TestWorkflow_SourceDir_UsedForRelativePathResolution(t *testing.T) {
+	wf := workflow.Workflow{
+		Name:      "test-workflow",
+		Initial:   "start",
+		SourceDir: "/home/user/.config/awf/workflows",
+		Steps: map[string]*workflow.Step{
+			"start": {Name: "start", Type: workflow.StepTypeTerminal},
+		},
+	}
+
+	relativePath := "prompts/analyze.md"
+	expectedAbsolutePath := filepath.Join(wf.SourceDir, relativePath)
+
+	assert.Equal(t, "/home/user/.config/awf/workflows/prompts/analyze.md", expectedAbsolutePath)
+}
+
+func TestWorkflow_SourceDir_PathJoinBehavior(t *testing.T) {
+	tests := []struct {
+		name         string
+		sourceDir    string
+		relativePath string
+		expectedPath string
+	}{
+		{
+			name:         "trailing slash in SourceDir",
+			sourceDir:    "/home/user/workflows/",
+			relativePath: "prompts/file.md",
+			expectedPath: "/home/user/workflows/prompts/file.md",
+		},
+		{
+			name:         "no trailing slash",
+			sourceDir:    "/home/user/workflows",
+			relativePath: "prompts/file.md",
+			expectedPath: "/home/user/workflows/prompts/file.md",
+		},
+		{
+			name:         "dot-dot navigation",
+			sourceDir:    "/home/user/workflows",
+			relativePath: "../shared/prompt.md",
+			expectedPath: "/home/user/shared/prompt.md",
+		},
+		{
+			name:         "dot current directory",
+			sourceDir:    "/home/user/workflows",
+			relativePath: "./prompts/file.md",
+			expectedPath: "/home/user/workflows/prompts/file.md",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualPath := filepath.Join(tt.sourceDir, tt.relativePath)
+			assert.Equal(t, tt.expectedPath, actualPath)
+		})
+	}
+}
+
+func TestWorkflow_SourceDir_NoYAMLTag(t *testing.T) {
+	wfType := reflect.TypeOf(workflow.Workflow{})
+	field, found := wfType.FieldByName("SourceDir")
+
+	assert.True(t, found, "SourceDir field should exist on Workflow struct")
+
+	yamlTag := field.Tag.Get("yaml")
+	assert.Empty(t, yamlTag, "SourceDir should not have a yaml struct tag (runtime metadata only)")
+}

--- a/internal/infrastructure/repository/yaml_mapper.go
+++ b/internal/infrastructure/repository/yaml_mapper.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -12,6 +13,11 @@ import (
 
 // mapToDomain converts a yamlWorkflow to a domain Workflow.
 func mapToDomain(filePath string, y *yamlWorkflow) (*workflow.Workflow, error) {
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		absPath = filePath
+	}
+
 	wf := &workflow.Workflow{
 		Name:        y.Name,
 		Description: y.Description,
@@ -23,6 +29,7 @@ func mapToDomain(filePath string, y *yamlWorkflow) (*workflow.Workflow, error) {
 		Inputs:      mapInputs(y.Inputs),
 		Steps:       make(map[string]*workflow.Step),
 		Hooks:       mapWorkflowHooks(y.Hooks),
+		SourceDir:   filepath.Dir(absPath),
 	}
 
 	// Map steps
@@ -415,6 +422,7 @@ func mapAgentConfigFlat(y *yamlStep) *workflow.AgentConfig {
 	return &workflow.AgentConfig{
 		Provider:      y.Provider,
 		Prompt:        y.Prompt,
+		PromptFile:    y.PromptFile,
 		Options:       y.Options,
 		Mode:          y.Mode,
 		SystemPrompt:  y.SystemPrompt,

--- a/internal/infrastructure/repository/yaml_mapper_prompt_file_test.go
+++ b/internal/infrastructure/repository/yaml_mapper_prompt_file_test.go
@@ -1,0 +1,442 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Feature: F063 - Prompt File Loading for Agent Steps
+
+// mapAgentConfigFlat Tests - PromptFile Happy Path
+
+func TestMapAgentConfigFlat_PromptFile_HappyPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		yamlStep yamlStep
+		want     *workflow.AgentConfig
+	}{
+		{
+			name: "relative path to prompt file",
+			yamlStep: yamlStep{
+				Provider:   "claude",
+				PromptFile: "prompts/analyze.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:   "claude",
+				PromptFile: "prompts/analyze.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "tilde expansion in prompt file path",
+			yamlStep: yamlStep{
+				Provider:   "claude",
+				PromptFile: "~/custom/prompt.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:   "claude",
+				PromptFile: "~/custom/prompt.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "awf template variable in prompt file path",
+			yamlStep: yamlStep{
+				Provider:   "claude",
+				PromptFile: "{{.awf.prompts_dir}}/plan/research.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:   "claude",
+				PromptFile: "{{.awf.prompts_dir}}/plan/research.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "absolute path to prompt file",
+			yamlStep: yamlStep{
+				Provider:   "gemini",
+				PromptFile: "/var/lib/awf/prompts/system.md",
+				Options: map[string]any{
+					"model": "gemini-pro",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:   "gemini",
+				PromptFile: "/var/lib/awf/prompts/system.md",
+				Options: map[string]any{
+					"model": "gemini-pro",
+				},
+			},
+		},
+		{
+			name: "prompt file with nested directory structure",
+			yamlStep: yamlStep{
+				Provider:   "claude",
+				PromptFile: "prompts/feature-001/agent/step-02.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:   "claude",
+				PromptFile: "prompts/feature-001/agent/step-02.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "prompt file with template interpolation in path",
+			yamlStep: yamlStep{
+				Provider:   "claude",
+				PromptFile: "{{.awf.config_dir}}/prompts/{{.inputs.feature}}.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:   "claude",
+				PromptFile: "{{.awf.config_dir}}/prompts/{{.inputs.feature}}.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapAgentConfigFlat(&tt.yamlStep)
+
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want.Provider, got.Provider)
+			assert.Equal(t, tt.want.PromptFile, got.PromptFile)
+			assert.Equal(t, tt.want.Prompt, got.Prompt)
+			assert.Equal(t, tt.want.Options, got.Options)
+		})
+	}
+}
+
+// mapAgentConfigFlat Tests - PromptFile Edge Cases
+
+func TestMapAgentConfigFlat_PromptFile_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		yamlStep yamlStep
+		want     *workflow.AgentConfig
+	}{
+		{
+			name: "empty prompt file field",
+			yamlStep: yamlStep{
+				Provider:   "claude",
+				Prompt:     "Inline prompt text",
+				PromptFile: "",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:   "claude",
+				Prompt:     "Inline prompt text",
+				PromptFile: "",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "prompt file with only filename no extension",
+			yamlStep: yamlStep{
+				Provider:   "claude",
+				PromptFile: "prompt",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:   "claude",
+				PromptFile: "prompt",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "prompt file with special characters in path",
+			yamlStep: yamlStep{
+				Provider:   "claude",
+				PromptFile: "prompts/my-prompt_v2.0.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:   "claude",
+				PromptFile: "prompts/my-prompt_v2.0.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "prompt file with spaces in path",
+			yamlStep: yamlStep{
+				Provider:   "claude",
+				PromptFile: "prompts/my prompt file.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:   "claude",
+				PromptFile: "prompts/my prompt file.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "prompt file with unicode characters in path",
+			yamlStep: yamlStep{
+				Provider:   "claude",
+				PromptFile: "prompts/インストール手順.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:   "claude",
+				PromptFile: "prompts/インストール手順.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "prompt file with multiple path separators",
+			yamlStep: yamlStep{
+				Provider:   "claude",
+				PromptFile: "prompts//subdir///file.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:   "claude",
+				PromptFile: "prompts//subdir///file.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapAgentConfigFlat(&tt.yamlStep)
+
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want.Provider, got.Provider)
+			assert.Equal(t, tt.want.PromptFile, got.PromptFile)
+			assert.Equal(t, tt.want.Prompt, got.Prompt)
+			assert.Equal(t, tt.want.Options, got.Options)
+		})
+	}
+}
+
+// mapAgentConfigFlat Tests - PromptFile Mutual Exclusivity
+
+func TestMapAgentConfigFlat_PromptFile_MutualExclusivity(t *testing.T) {
+	tests := []struct {
+		name     string
+		yamlStep yamlStep
+		want     *workflow.AgentConfig
+	}{
+		{
+			name: "both prompt and prompt file set",
+			yamlStep: yamlStep{
+				Provider:   "claude",
+				Prompt:     "Inline prompt text",
+				PromptFile: "prompts/analyze.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:   "claude",
+				Prompt:     "Inline prompt text",
+				PromptFile: "prompts/analyze.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "only prompt set",
+			yamlStep: yamlStep{
+				Provider: "claude",
+				Prompt:   "Inline prompt text",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider: "claude",
+				Prompt:   "Inline prompt text",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "only prompt file set",
+			yamlStep: yamlStep{
+				Provider:   "claude",
+				PromptFile: "prompts/analyze.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:   "claude",
+				PromptFile: "prompts/analyze.md",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "neither prompt nor prompt file set",
+			yamlStep: yamlStep{
+				Provider: "claude",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider: "claude",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapAgentConfigFlat(&tt.yamlStep)
+
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want.Provider, got.Provider)
+			assert.Equal(t, tt.want.Prompt, got.Prompt)
+			assert.Equal(t, tt.want.PromptFile, got.PromptFile)
+			assert.Equal(t, tt.want.Options, got.Options)
+		})
+	}
+}
+
+// mapAgentConfigFlat Tests - PromptFile with Conversation Mode
+
+func TestMapAgentConfigFlat_PromptFile_WithConversationMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		yamlStep yamlStep
+		want     *workflow.AgentConfig
+	}{
+		{
+			name: "conversation mode with prompt file",
+			yamlStep: yamlStep{
+				Provider:      "claude",
+				PromptFile:    "prompts/conversation.md",
+				Mode:          "conversation",
+				SystemPrompt:  "You are a helpful assistant",
+				InitialPrompt: "Hello, I need help with {{.inputs.task}}",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:      "claude",
+				PromptFile:    "prompts/conversation.md",
+				Mode:          "conversation",
+				SystemPrompt:  "You are a helpful assistant",
+				InitialPrompt: "Hello, I need help with {{.inputs.task}}",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "single mode with prompt file",
+			yamlStep: yamlStep{
+				Provider:   "claude",
+				PromptFile: "prompts/single.md",
+				Mode:       "single",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:   "claude",
+				PromptFile: "prompts/single.md",
+				Mode:       "single",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "conversation mode with both initial prompt and prompt file",
+			yamlStep: yamlStep{
+				Provider:      "claude",
+				PromptFile:    "prompts/base.md",
+				InitialPrompt: "Override prompt",
+				Mode:          "conversation",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:      "claude",
+				PromptFile:    "prompts/base.md",
+				InitialPrompt: "Override prompt",
+				Mode:          "conversation",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapAgentConfigFlat(&tt.yamlStep)
+
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want.Provider, got.Provider)
+			assert.Equal(t, tt.want.PromptFile, got.PromptFile)
+			assert.Equal(t, tt.want.Mode, got.Mode)
+			assert.Equal(t, tt.want.SystemPrompt, got.SystemPrompt)
+			assert.Equal(t, tt.want.InitialPrompt, got.InitialPrompt)
+			assert.Equal(t, tt.want.Options, got.Options)
+		})
+	}
+}

--- a/internal/infrastructure/repository/yaml_repository_source_dir_test.go
+++ b/internal/infrastructure/repository/yaml_repository_source_dir_test.go
@@ -1,0 +1,139 @@
+package repository
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestYAMLRepository_Load_PopulatesSourceDir_AbsolutePath(t *testing.T) {
+	repo := NewYAMLRepository(fixturesPath)
+
+	wf, err := repo.Load(context.Background(), "valid-simple")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	absFixturePath, err := filepath.Abs(fixturesPath)
+	if err != nil {
+		t.Fatalf("filepath.Abs() error = %v", err)
+	}
+
+	if wf.SourceDir != absFixturePath {
+		t.Errorf("SourceDir = %q, want %q", wf.SourceDir, absFixturePath)
+	}
+}
+
+func TestYAMLRepository_Load_PopulatesSourceDir_WithYamlExtension(t *testing.T) {
+	repo := NewYAMLRepository(fixturesPath)
+
+	wf, err := repo.Load(context.Background(), "valid-full.yaml")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	absFixturePath, err := filepath.Abs(fixturesPath)
+	if err != nil {
+		t.Fatalf("filepath.Abs() error = %v", err)
+	}
+
+	if wf.SourceDir != absFixturePath {
+		t.Errorf("SourceDir = %q, want %q", wf.SourceDir, absFixturePath)
+	}
+}
+
+func TestYAMLRepository_Load_PopulatesSourceDir_MultipleWorkflows(t *testing.T) {
+	tests := []struct {
+		name         string
+		workflowName string
+	}{
+		{"valid-simple", "valid-simple"},
+		{"valid-full", "valid-full"},
+		{"valid-with-dir", "valid-with-dir"},
+		{"loop-foreach", "loop-foreach"},
+	}
+
+	repo := NewYAMLRepository(fixturesPath)
+	absFixturePath, err := filepath.Abs(fixturesPath)
+	if err != nil {
+		t.Fatalf("filepath.Abs() error = %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf, err := repo.Load(context.Background(), tt.workflowName)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+
+			if wf.SourceDir != absFixturePath {
+				t.Errorf("SourceDir = %q, want %q", wf.SourceDir, absFixturePath)
+			}
+		})
+	}
+}
+
+func TestYAMLRepository_Load_SourceDir_UsableForRelativePathResolution(t *testing.T) {
+	repo := NewYAMLRepository(fixturesPath)
+
+	wf, err := repo.Load(context.Background(), "valid-simple")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if wf.SourceDir == "" {
+		t.Fatal("SourceDir should not be empty after Load()")
+	}
+
+	relativePromptPath := "prompts/analyze.md"
+	resolvedPath := filepath.Join(wf.SourceDir, relativePromptPath)
+
+	absFixturePath, err := filepath.Abs(fixturesPath)
+	if err != nil {
+		t.Fatalf("filepath.Abs() error = %v", err)
+	}
+	expectedPath := filepath.Join(absFixturePath, relativePromptPath)
+
+	if resolvedPath != expectedPath {
+		t.Errorf("resolved path = %q, want %q", resolvedPath, expectedPath)
+	}
+}
+
+func TestYAMLRepository_Load_SourceDir_ExtractedFromFilePath(t *testing.T) {
+	tests := []struct {
+		name           string
+		basePath       string
+		workflowName   string
+		expectedResult string
+	}{
+		{
+			name:           "simple base path",
+			basePath:       "/workflows",
+			workflowName:   "test",
+			expectedResult: "/workflows",
+		},
+		{
+			name:           "nested base path",
+			basePath:       "/home/user/.config/awf/workflows",
+			workflowName:   "analyze",
+			expectedResult: "/home/user/.config/awf/workflows",
+		},
+		{
+			name:           "relative base path",
+			basePath:       "configs/workflows",
+			workflowName:   "deploy",
+			expectedResult: "configs/workflows",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := filepath.Join(tt.basePath, tt.workflowName+".yaml")
+			actualSourceDir := filepath.Dir(filePath)
+
+			if actualSourceDir != tt.expectedResult {
+				t.Errorf("filepath.Dir(%q) = %q, want %q", filePath, actualSourceDir, tt.expectedResult)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/repository/yaml_types.go
+++ b/internal/infrastructure/repository/yaml_types.go
@@ -64,9 +64,10 @@ type yamlStep struct {
 
 	// Agent configuration (for AI agent steps - F039)
 	// Flat structure: provider, prompt, options directly on step
-	Provider string         `yaml:"provider"` // agent provider: claude, codex, gemini, opencode, custom
-	Prompt   string         `yaml:"prompt"`   // prompt template with {{inputs.*}} and {{states.*}}
-	Options  map[string]any `yaml:"options"`  // provider-specific options (model, temperature, max_tokens, etc.)
+	Provider   string         `yaml:"provider"`    // agent provider: claude, codex, gemini, opencode, custom
+	Prompt     string         `yaml:"prompt"`      // prompt template with {{inputs.*}} and {{states.*}}
+	PromptFile string         `yaml:"prompt_file"` // path to external prompt template file
+	Options    map[string]any `yaml:"options"`     // provider-specific options (model, temperature, max_tokens, etc.)
 
 	// Agent conversation mode (F033) - extends agent configuration
 	Mode          string                  `yaml:"mode"`           // execution mode: "single" (default) or "conversation"

--- a/internal/interfaces/cli/resume.go
+++ b/internal/interfaces/cli/resume.go
@@ -212,6 +212,7 @@ func runResume(cmd *cobra.Command, cfg *Config, workflowID string, inputFlags []
 		return fmt.Errorf("failed to register agent providers: %w", err)
 	}
 	execSvc.SetAgentRegistry(agentRegistry)
+	execSvc.SetAWFPaths(buildAWFPaths())
 
 	if stdoutWriter != nil {
 		execSvc.SetOutputWriters(stdoutWriter, stderrWriter)

--- a/internal/interfaces/cli/run.go
+++ b/internal/interfaces/cli/run.go
@@ -262,6 +262,7 @@ func runWorkflow(cmd *cobra.Command, cfg *Config, workflowName string, inputFlag
 		return fmt.Errorf("failed to register agent providers: %w", err)
 	}
 	execSvc.SetAgentRegistry(agentRegistry)
+	execSvc.SetAWFPaths(buildAWFPaths())
 
 	// Setup operation providers (F054 GitHub + F056 Notify + F058 HTTP)
 	githubClient := github.NewClient(logger)
@@ -436,6 +437,7 @@ func runDryRun(cmd *cobra.Command, cfg *Config, workflowName string, inputFlags 
 	exprValidator := infra_expression.NewExprValidator()
 	wfSvc := application.NewWorkflowService(repo, stateStore, shellExecutor, logger, exprValidator)
 	dryRunExec := application.NewDryRunExecutor(wfSvc, resolver, exprEvaluator, logger)
+	dryRunExec.SetAWFPaths(buildAWFPaths())
 
 	// Setup template service for workflow template expansion
 	templatePaths := []string{
@@ -924,6 +926,7 @@ func runSingleStep(
 		return fmt.Errorf("failed to register agent providers: %w", err)
 	}
 	execSvc.SetAgentRegistry(agentRegistry)
+	execSvc.SetAWFPaths(buildAWFPaths())
 
 	// Setup operation providers (F054 GitHub + F056 Notify + F058 HTTP)
 	githubClient := github.NewClient(logger)
@@ -1205,4 +1208,15 @@ func registerNotifyBackends(provider *notify.NotifyOperationProvider, cfg *confi
 	}
 
 	return nil
+}
+
+// buildAWFPaths returns the AWF XDG directory paths for template interpolation (F063).
+func buildAWFPaths() map[string]string {
+	return map[string]string{
+		"prompts_dir":   xdg.AWFPromptsDir(),
+		"config_dir":    xdg.AWFConfigDir(),
+		"data_dir":      xdg.AWFDataDir(),
+		"workflows_dir": xdg.AWFWorkflowsDir(),
+		"plugins_dir":   xdg.AWFPluginsDir(),
+	}
 }

--- a/pkg/interpolation/resolver.go
+++ b/pkg/interpolation/resolver.go
@@ -16,6 +16,7 @@ type Context struct {
 	Context  ContextData
 	Error    *ErrorData
 	Loop     *LoopData // loop iteration data
+	AWF      map[string]string
 }
 
 // LoopData holds loop iteration context for interpolation.
@@ -77,5 +78,6 @@ func NewContext() *Context {
 		Inputs: make(map[string]any),
 		States: make(map[string]StepStateData),
 		Env:    make(map[string]string),
+		AWF:    make(map[string]string),
 	}
 }

--- a/pkg/interpolation/resolver_awf_test.go
+++ b/pkg/interpolation/resolver_awf_test.go
@@ -1,0 +1,161 @@
+package interpolation_test
+
+import (
+	"testing"
+
+	"github.com/awf-project/awf/pkg/interpolation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplateResolver_AWF(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		awf      map[string]string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "single AWF variable",
+			template: "prompts: {{.awf.prompts_dir}}",
+			awf:      map[string]string{"prompts_dir": "/home/user/.config/awf/prompts"},
+			want:     "prompts: /home/user/.config/awf/prompts",
+		},
+		{
+			name:     "multiple AWF variables",
+			template: "config={{.awf.config_dir}} data={{.awf.data_dir}}",
+			awf: map[string]string{
+				"config_dir": "/home/user/.config/awf",
+				"data_dir":   "/home/user/.local/share/awf",
+			},
+			want: "config=/home/user/.config/awf data=/home/user/.local/share/awf",
+		},
+		{
+			name:     "AWF variable in path",
+			template: "{{.awf.prompts_dir}}/plan/research.md",
+			awf:      map[string]string{"prompts_dir": "/etc/awf/prompts"},
+			want:     "/etc/awf/prompts/plan/research.md",
+		},
+		{
+			name:     "all standard AWF directories",
+			template: "{{.awf.prompts_dir}},{{.awf.config_dir}},{{.awf.workflows_dir}},{{.awf.data_dir}},{{.awf.plugins_dir}}",
+			awf: map[string]string{
+				"prompts_dir":   "/home/user/.config/awf/prompts",
+				"config_dir":    "/home/user/.config/awf",
+				"workflows_dir": "/home/user/.config/awf/workflows",
+				"data_dir":      "/home/user/.local/share/awf",
+				"plugins_dir":   "/home/user/.local/share/awf/plugins",
+			},
+			want: "/home/user/.config/awf/prompts,/home/user/.config/awf,/home/user/.config/awf/workflows,/home/user/.local/share/awf,/home/user/.local/share/awf/plugins",
+		},
+		{
+			name:     "empty AWF map",
+			template: "{{.awf.prompts_dir}}",
+			awf:      map[string]string{},
+			wantErr:  true,
+		},
+		{
+			name:     "undefined AWF key",
+			template: "{{.awf.unknown_dir}}",
+			awf:      map[string]string{"prompts_dir": "/home/user/.config/awf/prompts"},
+			wantErr:  true,
+		},
+		{
+			name:     "AWF with special characters in path",
+			template: "path={{.awf.config_dir}}",
+			awf:      map[string]string{"config_dir": "/home/user name/My Documents/.config/awf"},
+			want:     "path=/home/user name/My Documents/.config/awf",
+		},
+		{
+			name:     "AWF with tilde expansion result",
+			template: "{{.awf.prompts_dir}}/custom.md",
+			awf:      map[string]string{"prompts_dir": "/home/user/.config/awf/prompts"},
+			want:     "/home/user/.config/awf/prompts/custom.md",
+		},
+		{
+			name:     "AWF empty string value",
+			template: "dir=[{{.awf.empty_dir}}]",
+			awf:      map[string]string{"empty_dir": ""},
+			want:     "dir=[]",
+		},
+	}
+
+	resolver := interpolation.NewTemplateResolver()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			ctx.AWF = tt.awf
+
+			got, err := resolver.Resolve(tt.template, ctx)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNewContext_AWFInitialization(t *testing.T) {
+	ctx := interpolation.NewContext()
+
+	require.NotNil(t, ctx.AWF, "AWF map should be initialized")
+	assert.Empty(t, ctx.AWF, "AWF map should be empty initially")
+	assert.IsType(t, map[string]string{}, ctx.AWF, "AWF should be map[string]string type")
+}
+
+func TestContext_AWFWithOtherVariables(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		setup    func(*interpolation.Context)
+		want     string
+	}{
+		{
+			name:     "AWF with inputs",
+			template: "{{.awf.prompts_dir}}/{{.inputs.filename}}",
+			setup: func(ctx *interpolation.Context) {
+				ctx.AWF["prompts_dir"] = "/home/user/.config/awf/prompts"
+				ctx.Inputs["filename"] = "analyze.md"
+			},
+			want: "/home/user/.config/awf/prompts/analyze.md",
+		},
+		{
+			name:     "AWF with env variables",
+			template: "{{.awf.config_dir}}/{{.env.ENV_NAME}}.yaml",
+			setup: func(ctx *interpolation.Context) {
+				ctx.AWF["config_dir"] = "/etc/awf"
+				ctx.Env["ENV_NAME"] = "production"
+			},
+			want: "/etc/awf/production.yaml",
+		},
+		{
+			name:     "AWF with state output",
+			template: "{{.awf.data_dir}}/{{.states.save.Output}}",
+			setup: func(ctx *interpolation.Context) {
+				ctx.AWF["data_dir"] = "/var/lib/awf"
+				ctx.States["save"] = interpolation.StepStateData{Output: "result.json"}
+			},
+			want: "/var/lib/awf/result.json",
+		},
+	}
+
+	resolver := interpolation.NewTemplateResolver()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			tt.setup(ctx)
+
+			got, err := resolver.Resolve(tt.template, ctx)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/interpolation/template_helpers.go
+++ b/pkg/interpolation/template_helpers.go
@@ -1,0 +1,68 @@
+package interpolation
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+//nolint:unused // used in readFileTemplateFunc
+const maxFileReadSize = 1 << 20 // 1MB
+
+// splitTemplateFunc splits a string by delimiter into a slice.
+// Each element is trimmed of leading/trailing whitespace.
+//
+//nolint:unused // registered in TemplateResolver FuncMap
+func splitTemplateFunc(s, delimiter string) []string {
+	parts := strings.Split(s, delimiter)
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
+}
+
+// joinTemplateFunc joins a slice of strings with a separator.
+//
+//nolint:unused // registered in TemplateResolver FuncMap
+func joinTemplateFunc(items []string, separator string) string {
+	return strings.Join(items, separator)
+}
+
+// readFileTemplateFunc reads a file's contents, limited to 1MB.
+//
+//nolint:unused // registered in TemplateResolver FuncMap
+func readFileTemplateFunc(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file %q: %w", path, err)
+	}
+
+	if info.IsDir() {
+		return "", fmt.Errorf("failed to read file %q: path is a directory", path)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file %q: %w", path, err)
+	}
+	defer file.Close()
+
+	content, err := io.ReadAll(io.LimitReader(file, maxFileReadSize+1))
+	if err != nil {
+		return "", fmt.Errorf("failed to read file %q: %w", path, err)
+	}
+
+	if len(content) > maxFileReadSize {
+		return "", fmt.Errorf("file %q exceeds 1MB size limit", path)
+	}
+
+	return string(content), nil
+}
+
+// trimSpaceTemplateFunc removes leading and trailing whitespace.
+//
+//nolint:unused // registered in TemplateResolver FuncMap
+func trimSpaceTemplateFunc(s string) string {
+	return strings.TrimSpace(s)
+}

--- a/pkg/interpolation/template_helpers_test.go
+++ b/pkg/interpolation/template_helpers_test.go
@@ -1,0 +1,415 @@
+package interpolation_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awf-project/awf/pkg/interpolation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplateHelpers_Split(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		inputs   map[string]any
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "split comma-separated values",
+			template: `{{range split .inputs.list ","}}{{.}} {{end}}`,
+			inputs:   map[string]any{"list": "one,two,three"},
+			want:     "one two three ",
+		},
+		{
+			name:     "split with custom delimiter",
+			template: `{{range split .inputs.path "/"}}[{{.}}]{{end}}`,
+			inputs:   map[string]any{"path": "usr/local/bin"},
+			want:     "[usr][local][bin]",
+		},
+		{
+			name:     "split empty string returns single empty element",
+			template: `{{split .inputs.empty ","}}`,
+			inputs:   map[string]any{"empty": ""},
+			want:     "[]",
+		},
+		{
+			name:     "split with no delimiter match returns original",
+			template: `{{split .inputs.text "|"}}`,
+			inputs:   map[string]any{"text": "no delimiter here"},
+			want:     "[no delimiter here]",
+		},
+		{
+			name:     "split single element",
+			template: `{{split .inputs.single ","}}`,
+			inputs:   map[string]any{"single": "alone"},
+			want:     "[alone]",
+		},
+		{
+			name:     "split with spaces",
+			template: `{{range split .inputs.words " "}}{{.}},{{end}}`,
+			inputs:   map[string]any{"words": "alpha beta gamma"},
+			want:     "alpha,beta,gamma,",
+		},
+		{
+			name:     "split consecutive delimiters creates empty elements",
+			template: `{{split .inputs.text ","}}`,
+			inputs:   map[string]any{"text": "a,,b"},
+			want:     "[a  b]",
+		},
+	}
+
+	resolver := interpolation.NewTemplateResolver()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			for k, v := range tt.inputs {
+				ctx.Inputs[k] = v
+			}
+
+			got, err := resolver.Resolve(tt.template, ctx)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTemplateHelpers_Join(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		setup    func(*interpolation.Context)
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "join slice with comma separator",
+			template: `{{join (split .inputs.list ",") ", "}}`,
+			setup: func(ctx *interpolation.Context) {
+				ctx.Inputs["list"] = "one,two,three"
+			},
+			want: "one, two, three",
+		},
+		{
+			name:     "join with pipe separator",
+			template: `{{join (split .inputs.items " ") "|"}}`,
+			setup: func(ctx *interpolation.Context) {
+				ctx.Inputs["items"] = "a b c"
+			},
+			want: "a|b|c",
+		},
+		{
+			name:     "join empty slice",
+			template: `{{join (split .inputs.empty ",") ","}}`,
+			setup: func(ctx *interpolation.Context) {
+				ctx.Inputs["empty"] = ""
+			},
+			want: "",
+		},
+		{
+			name:     "join single element",
+			template: `{{join (split .inputs.single ",") ","}}`,
+			setup: func(ctx *interpolation.Context) {
+				ctx.Inputs["single"] = "alone"
+			},
+			want: "alone",
+		},
+		{
+			name:     "join with newline separator",
+			template: `{{join (split .inputs.text ",") "\n"}}`,
+			setup: func(ctx *interpolation.Context) {
+				ctx.Inputs["text"] = "line1,line2,line3"
+			},
+			want: "line1\nline2\nline3",
+		},
+	}
+
+	resolver := interpolation.NewTemplateResolver()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			tt.setup(ctx)
+
+			got, err := resolver.Resolve(tt.template, ctx)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTemplateHelpers_TrimSpace(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		inputs   map[string]any
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "trim leading and trailing spaces",
+			template: `{{trimSpace .inputs.text}}`,
+			inputs:   map[string]any{"text": "  hello  "},
+			want:     "hello",
+		},
+		{
+			name:     "trim tabs and newlines",
+			template: `{{trimSpace .inputs.text}}`,
+			inputs:   map[string]any{"text": "\t\nhello\n\t"},
+			want:     "hello",
+		},
+		{
+			name:     "trim mixed whitespace",
+			template: `{{trimSpace .inputs.text}}`,
+			inputs:   map[string]any{"text": " \t\n world \n\t "},
+			want:     "world",
+		},
+		{
+			name:     "trim empty string",
+			template: `[{{trimSpace .inputs.empty}}]`,
+			inputs:   map[string]any{"empty": ""},
+			want:     "[]",
+		},
+		{
+			name:     "trim whitespace-only string",
+			template: `[{{trimSpace .inputs.spaces}}]`,
+			inputs:   map[string]any{"spaces": "   \t\n   "},
+			want:     "[]",
+		},
+		{
+			name:     "trim preserves internal whitespace",
+			template: `{{trimSpace .inputs.text}}`,
+			inputs:   map[string]any{"text": "  hello  world  "},
+			want:     "hello  world",
+		},
+		{
+			name:     "trim no whitespace",
+			template: `{{trimSpace .inputs.text}}`,
+			inputs:   map[string]any{"text": "clean"},
+			want:     "clean",
+		},
+		{
+			name:     "trim from state output",
+			template: `{{trimSpace .states.step.Output}}`,
+			inputs:   map[string]any{},
+			want:     "trimmed output",
+		},
+	}
+
+	resolver := interpolation.NewTemplateResolver()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			for k, v := range tt.inputs {
+				ctx.Inputs[k] = v
+			}
+
+			if tt.name == "trim from state output" {
+				ctx.States["step"] = interpolation.StepStateData{
+					Output: "  trimmed output  \n",
+				}
+			}
+
+			got, err := resolver.Resolve(tt.template, ctx)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTemplateHelpers_ReadFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	smallFile := filepath.Join(tmpDir, "small.txt")
+	require.NoError(t, os.WriteFile(smallFile, []byte("content from file"), 0o600))
+
+	multilineFile := filepath.Join(tmpDir, "multiline.txt")
+	require.NoError(t, os.WriteFile(multilineFile, []byte("line1\nline2\nline3"), 0o600))
+
+	largeContent := strings.Repeat("x", 1024*1024+1)
+	largeFile := filepath.Join(tmpDir, "large.txt")
+	require.NoError(t, os.WriteFile(largeFile, []byte(largeContent), 0o600))
+
+	emptyFile := filepath.Join(tmpDir, "empty.txt")
+	require.NoError(t, os.WriteFile(emptyFile, []byte(""), 0o600))
+
+	tests := []struct {
+		name     string
+		template string
+		inputs   map[string]any
+		want     string
+		wantErr  bool
+		errMsg   string
+	}{
+		{
+			name:     "read small file",
+			template: `{{readFile .inputs.path}}`,
+			inputs:   map[string]any{"path": smallFile},
+			want:     "content from file",
+		},
+		{
+			name:     "read multiline file",
+			template: `{{readFile .inputs.path}}`,
+			inputs:   map[string]any{"path": multilineFile},
+			want:     "line1\nline2\nline3",
+		},
+		{
+			name:     "read empty file",
+			template: `[{{readFile .inputs.path}}]`,
+			inputs:   map[string]any{"path": emptyFile},
+			want:     "[]",
+		},
+		{
+			name:     "read file exceeding 1MB limit",
+			template: `{{readFile .inputs.path}}`,
+			inputs:   map[string]any{"path": largeFile},
+			wantErr:  true,
+			errMsg:   "1MB",
+		},
+		{
+			name:     "read nonexistent file",
+			template: `{{readFile .inputs.path}}`,
+			inputs:   map[string]any{"path": filepath.Join(tmpDir, "nonexistent.txt")},
+			wantErr:  true,
+			errMsg:   "no such file",
+		},
+		{
+			name:     "read directory fails",
+			template: `{{readFile .inputs.path}}`,
+			inputs:   map[string]any{"path": tmpDir},
+			wantErr:  true,
+			errMsg:   "directory",
+		},
+		{
+			name:     "read file path from state",
+			template: `{{readFile .states.save_path.Output}}`,
+			inputs:   map[string]any{},
+			want:     "content from file",
+		},
+	}
+
+	resolver := interpolation.NewTemplateResolver()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			for k, v := range tt.inputs {
+				ctx.Inputs[k] = v
+			}
+
+			if tt.name == "read file path from state" {
+				ctx.States["save_path"] = interpolation.StepStateData{
+					Output: smallFile,
+				}
+			}
+
+			got, err := resolver.Resolve(tt.template, ctx)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTemplateHelpers_ReadFile_ExactlyOneMB(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	exactlyOneMB := strings.Repeat("a", 1024*1024)
+	file := filepath.Join(tmpDir, "1mb.txt")
+	require.NoError(t, os.WriteFile(file, []byte(exactlyOneMB), 0o600))
+
+	resolver := interpolation.NewTemplateResolver()
+	ctx := interpolation.NewContext()
+	ctx.Inputs["path"] = file
+
+	got, err := resolver.Resolve(`{{readFile .inputs.path}}`, ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, exactlyOneMB, got)
+}
+
+func TestTemplateHelpers_CombinedUsage(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	specFile := filepath.Join(tmpDir, "spec.txt")
+	require.NoError(t, os.WriteFile(specFile, []byte("  Feature A, Feature B, Feature C  "), 0o600))
+
+	tests := []struct {
+		name     string
+		template string
+		inputs   map[string]any
+		want     string
+	}{
+		{
+			name:     "split then join with different separator",
+			template: `{{join (split .inputs.csv ",") " | "}}`,
+			inputs:   map[string]any{"csv": "a,b,c"},
+			want:     "a | b | c",
+		},
+		{
+			name:     "readFile then trimSpace",
+			template: `{{trimSpace (readFile .inputs.path)}}`,
+			inputs:   map[string]any{"path": specFile},
+			want:     "Feature A, Feature B, Feature C",
+		},
+		{
+			name:     "readFile, trimSpace, split, join",
+			template: `{{join (split (trimSpace (readFile .inputs.path)) ",") "\n- "}}`,
+			inputs:   map[string]any{"path": specFile},
+			want:     "Feature A\n- Feature B\n- Feature C",
+		},
+		{
+			name:     "trim each element after split",
+			template: `{{range split .inputs.list ","}}{{trimSpace .}},{{end}}`,
+			inputs:   map[string]any{"list": " a , b , c "},
+			want:     "a,b,c,",
+		},
+	}
+
+	resolver := interpolation.NewTemplateResolver()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			for k, v := range tt.inputs {
+				ctx.Inputs[k] = v
+			}
+
+			got, err := resolver.Resolve(tt.template, ctx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/interpolation/template_resolver.go
+++ b/pkg/interpolation/template_resolver.go
@@ -28,15 +28,20 @@ func (r *TemplateResolver) Resolve(tmplStr string, ctx *Context) (string, error)
 	tmpl := template.New("cmd").
 		Option("missingkey=error").
 		Funcs(template.FuncMap{
-			"escape":   escapeTemplateFunc,
-			"json":     jsonTemplateFunc,
-			"inputs":   r.makeInputsAccessor(ctx),
-			"states":   r.makeStatesAccessor(ctx),
-			"workflow": r.makeWorkflowAccessor(ctx),
-			"env":      r.makeEnvAccessor(ctx),
-			"loop":     r.makeLoopAccessor(ctx),
-			"context":  r.makeContextAccessor(ctx),
-			"error":    r.makeErrorAccessor(ctx),
+			"escape":    escapeTemplateFunc,
+			"json":      jsonTemplateFunc,
+			"split":     splitTemplateFunc,
+			"join":      joinTemplateFunc,
+			"readFile":  readFileTemplateFunc,
+			"trimSpace": trimSpaceTemplateFunc,
+			"inputs":    r.makeInputsAccessor(ctx),
+			"states":    r.makeStatesAccessor(ctx),
+			"workflow":  r.makeWorkflowAccessor(ctx),
+			"env":       r.makeEnvAccessor(ctx),
+			"loop":      r.makeLoopAccessor(ctx),
+			"context":   r.makeContextAccessor(ctx),
+			"error":     r.makeErrorAccessor(ctx),
+			"awf":       r.makeAWFAccessor(ctx),
 		})
 
 	tmpl, err := tmpl.Parse(tmplStr)
@@ -59,6 +64,7 @@ func (r *TemplateResolver) buildTemplateData(ctx *Context) map[string]any {
 		"workflow": ctx.Workflow,
 		"env":      ctx.Env,
 		"context":  ctx.Context,
+		"awf":      ctx.AWF,
 	}
 	if ctx.Error != nil {
 		data["error"] = ctx.Error
@@ -234,5 +240,12 @@ func (r *TemplateResolver) makeWorkflowAccessor(ctx *Context) func() WorkflowDat
 func (r *TemplateResolver) makeEnvAccessor(ctx *Context) func() map[string]string {
 	return func() map[string]string {
 		return ctx.Env
+	}
+}
+
+// makeAWFAccessor returns a function that provides AWF directory paths.
+func (r *TemplateResolver) makeAWFAccessor(ctx *Context) func() map[string]string {
+	return func() map[string]string {
+		return ctx.AWF
 	}
 }

--- a/tests/integration/cli/run_prompt_file_test.go
+++ b/tests/integration/cli/run_prompt_file_test.go
@@ -1,0 +1,477 @@
+//go:build integration
+
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/awf-project/awf/internal/interfaces/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunCommand_PromptFile_Basic tests loading external prompt template
+// AC: Agent step with prompt_file loads and interpolates external .md template
+func TestRunCommand_PromptFile_Basic(t *testing.T) {
+	tmpDir := setupInitTestDir(t)
+
+	promptContent := `Analyze the following name: {{.inputs.name}}`
+	promptPath := filepath.Join(tmpDir, ".awf", "workflows", "prompts", "analyze.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(promptPath), 0o755))
+	require.NoError(t, os.WriteFile(promptPath, []byte(promptContent), 0o644))
+
+	workflowContent := `name: prompt-file-basic
+version: "1.0.0"
+inputs:
+  - name: name
+    type: string
+    required: true
+states:
+  initial: analyze
+  analyze:
+    type: agent
+    provider: claude
+    prompt_file: prompts/analyze.md
+    on_success: done
+  done:
+    type: terminal
+`
+	createTestWorkflow(t, tmpDir, "prompt-file-basic.yaml", workflowContent)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"run", "prompt-file-basic", "--dry-run", "--input=name=TestValue"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "Analyze the following name: TestValue", "prompt should be interpolated with input value")
+}
+
+// TestRunCommand_PromptFile_RelativePath tests relative path resolution
+// AC: Relative paths in prompt_file resolve against workflow directory
+func TestRunCommand_PromptFile_RelativePath(t *testing.T) {
+	tmpDir := setupInitTestDir(t)
+
+	promptsDir := filepath.Join(tmpDir, ".awf", "workflows", "prompts")
+	require.NoError(t, os.MkdirAll(promptsDir, 0o755))
+
+	promptContent := `Execute the task with context.`
+	promptPath := filepath.Join(promptsDir, "task.md")
+	require.NoError(t, os.WriteFile(promptPath, []byte(promptContent), 0o644))
+
+	workflowContent := `name: relative-path
+version: "1.0.0"
+states:
+  initial: task
+  task:
+    type: agent
+    provider: claude
+    prompt_file: prompts/task.md
+    on_success: done
+  done:
+    type: terminal
+`
+	createTestWorkflow(t, tmpDir, "relative-path.yaml", workflowContent)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"run", "relative-path", "--dry-run"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "Execute the task with context", "should load prompt from relative path")
+}
+
+// TestRunCommand_PromptFile_AWFDirectory tests AWF directory template variable
+// AC: prompt_file supports {{.awf.prompts_dir}} for XDG-compliant directory
+func TestRunCommand_PromptFile_AWFDirectory(t *testing.T) {
+	tmpDir := setupInitTestDir(t)
+
+	// Override XDG_CONFIG_HOME to use tmpDir for testing
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	awfPromptsDir := filepath.Join(tmpDir, "awf", "prompts")
+	require.NoError(t, os.MkdirAll(awfPromptsDir, 0o755))
+
+	promptContent := `Research the topic thoroughly.`
+	promptPath := filepath.Join(awfPromptsDir, "research.md")
+	require.NoError(t, os.WriteFile(promptPath, []byte(promptContent), 0o644))
+
+	workflowContent := `name: awf-dir
+version: "1.0.0"
+states:
+  initial: research
+  research:
+    type: agent
+    provider: claude
+    prompt_file: "{{.awf.prompts_dir}}/research.md"
+    on_success: done
+  done:
+    type: terminal
+`
+	createTestWorkflow(t, tmpDir, "awf-dir.yaml", workflowContent)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"run", "awf-dir", "--dry-run"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "Research the topic thoroughly", "should resolve AWF directory template variable")
+}
+
+// TestRunCommand_PromptFile_TildeExpansion tests home directory expansion
+// AC: prompt_file supports ~ expansion to user's home directory
+func TestRunCommand_PromptFile_TildeExpansion(t *testing.T) {
+	tmpDir := setupInitTestDir(t)
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	promptsDir := filepath.Join(homeDir, ".awf-test-prompts")
+	require.NoError(t, os.MkdirAll(promptsDir, 0o755))
+	t.Cleanup(func() {
+		os.RemoveAll(promptsDir)
+	})
+
+	promptContent := `Custom prompt from home directory.`
+	promptPath := filepath.Join(promptsDir, "custom.md")
+	require.NoError(t, os.WriteFile(promptPath, []byte(promptContent), 0o644))
+
+	workflowContent := `name: tilde-expansion
+version: "1.0.0"
+states:
+  initial: custom
+  custom:
+    type: agent
+    provider: claude
+    prompt_file: ~/.awf-test-prompts/custom.md
+    on_success: done
+  done:
+    type: terminal
+`
+	createTestWorkflow(t, tmpDir, "tilde-expansion.yaml", workflowContent)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"run", "tilde-expansion", "--dry-run"})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "Custom prompt from home directory", "should expand tilde to home directory")
+}
+
+// TestRunCommand_PromptFile_TemplateHelpers tests template helper functions
+// AC: Template helpers (split, join, readFile, trimSpace) work in prompt files
+func TestRunCommand_PromptFile_TemplateHelpers(t *testing.T) {
+	tmpDir := setupInitTestDir(t)
+
+	dataFile := filepath.Join(tmpDir, ".awf", "data", "spec.txt")
+	require.NoError(t, os.MkdirAll(filepath.Dir(dataFile), 0o755))
+	require.NoError(t, os.WriteFile(dataFile, []byte("  Specification Content  \n"), 0o644))
+
+	promptContent := `Process the agents: {{join (split .inputs.agents ",") " and "}}
+Spec: {{trimSpace (readFile .inputs.spec_path)}}`
+
+	promptPath := filepath.Join(tmpDir, ".awf", "workflows", "prompts", "helpers.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(promptPath), 0o755))
+	require.NoError(t, os.WriteFile(promptPath, []byte(promptContent), 0o644))
+
+	workflowContent := `name: template-helpers
+version: "1.0.0"
+inputs:
+  - name: agents
+    type: string
+    required: true
+  - name: spec_path
+    type: string
+    required: true
+states:
+  initial: process
+  process:
+    type: agent
+    provider: claude
+    prompt_file: prompts/helpers.md
+    on_success: done
+  done:
+    type: terminal
+`
+	createTestWorkflow(t, tmpDir, "template-helpers.yaml", workflowContent)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	specPath := filepath.Join(tmpDir, ".awf", "data", "spec.txt")
+	cmd.SetArgs([]string{
+		"run", "template-helpers",
+		"--dry-run",
+		"--input=agents=claude,gemini,codex",
+		"--input=spec_path=" + specPath,
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "claude and gemini and codex", "split and join should work")
+	assert.Contains(t, output, "Specification Content", "readFile and trimSpace should work")
+}
+
+// TestValidateCommand_PromptFile_Missing tests validation for missing files
+// AC: awf validate returns USER.INPUT.INVALID for nonexistent prompt_file
+func TestValidateCommand_PromptFile_Missing(t *testing.T) {
+	tmpDir := setupInitTestDir(t)
+
+	workflowContent := `name: missing-file
+version: "1.0.0"
+states:
+  initial: analyze
+  analyze:
+    type: agent
+    provider: claude
+    prompt_file: nonexistent.md
+    on_success: done
+  done:
+    type: terminal
+`
+	createTestWorkflow(t, tmpDir, "missing-file.yaml", workflowContent)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"validate", "missing-file"})
+
+	err := cmd.Execute()
+	require.Error(t, err, "validation should fail for missing prompt_file")
+	assert.Contains(t, err.Error(), "prompt_file not found", "error should mention prompt_file not found")
+}
+
+// TestValidateCommand_PromptFile_Valid tests validation passing for existing file
+// AC: awf validate passes when prompt_file points to valid file
+func TestValidateCommand_PromptFile_Valid(t *testing.T) {
+	tmpDir := setupInitTestDir(t)
+
+	promptPath := filepath.Join(tmpDir, ".awf", "workflows", "prompts", "valid.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(promptPath), 0o755))
+	require.NoError(t, os.WriteFile(promptPath, []byte("Valid prompt"), 0o644))
+
+	workflowContent := `name: valid-file
+version: "1.0.0"
+states:
+  initial: analyze
+  analyze:
+    type: agent
+    provider: claude
+    prompt_file: prompts/valid.md
+    on_success: done
+  done:
+    type: terminal
+`
+	createTestWorkflow(t, tmpDir, "valid-file.yaml", workflowContent)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"validate", "valid-file"})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "validation should pass for existing prompt_file")
+}
+
+// TestValidateCommand_PromptFile_MutualExclusivity tests prompt/prompt_file mutual exclusivity
+// AC: Both prompt and prompt_file set returns validation error
+func TestValidateCommand_PromptFile_MutualExclusivity(t *testing.T) {
+	tmpDir := setupInitTestDir(t)
+
+	promptPath := filepath.Join(tmpDir, ".awf", "prompts", "test.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(promptPath), 0o755))
+	require.NoError(t, os.WriteFile(promptPath, []byte("Template"), 0o644))
+
+	workflowContent := `name: mutual-exclusive
+version: "1.0.0"
+states:
+  initial: analyze
+  analyze:
+    type: agent
+    provider: claude
+    prompt: "Inline prompt"
+    prompt_file: prompts/test.md
+    on_success: done
+  done:
+    type: terminal
+`
+	createTestWorkflow(t, tmpDir, "mutual-exclusive.yaml", workflowContent)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"validate", "mutual-exclusive"})
+
+	err := cmd.Execute()
+	require.Error(t, err, "validation should fail when both prompt and prompt_file are set")
+	assert.Contains(t, err.Error(), "mutually exclusive", "error should mention mutual exclusivity")
+}
+
+// TestValidateCommand_PromptFile_RequireOnePromptSource tests validation requiring at least one prompt source
+// AC: Neither prompt nor prompt_file returns validation error
+func TestValidateCommand_PromptFile_RequireOnePromptSource(t *testing.T) {
+	tmpDir := setupInitTestDir(t)
+
+	workflowContent := `name: no-prompt
+version: "1.0.0"
+states:
+  initial: analyze
+  analyze:
+    type: agent
+    provider: claude
+    on_success: done
+  done:
+    type: terminal
+`
+	createTestWorkflow(t, tmpDir, "no-prompt.yaml", workflowContent)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"validate", "no-prompt"})
+
+	err := cmd.Execute()
+	require.Error(t, err, "validation should fail when neither prompt nor prompt_file is set")
+	assert.Contains(t, err.Error(), "required", "error should mention field is required")
+}
+
+// TestValidateCommand_PromptFile_Directory tests validation rejecting directories
+// AC: prompt_file pointing to directory returns validation error
+func TestValidateCommand_PromptFile_Directory(t *testing.T) {
+	tmpDir := setupInitTestDir(t)
+
+	dirPath := filepath.Join(tmpDir, ".awf", "workflows", "prompts", "not-a-file")
+	require.NoError(t, os.MkdirAll(dirPath, 0o755))
+
+	workflowContent := `name: directory-instead-of-file
+version: "1.0.0"
+states:
+  initial: analyze
+  analyze:
+    type: agent
+    provider: claude
+    prompt_file: prompts/not-a-file
+    on_success: done
+  done:
+    type: terminal
+`
+	createTestWorkflow(t, tmpDir, "directory-instead-of-file.yaml", workflowContent)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"validate", "directory-instead-of-file"})
+
+	err := cmd.Execute()
+	require.Error(t, err, "validation should fail when prompt_file points to directory")
+	assert.Contains(t, err.Error(), "directory", "error should mention directory issue")
+}
+
+// TestRunCommand_PromptFile_FileSizeLimit tests 1MB file size limit
+// NFR-001: File reading must fail for files exceeding 1MB
+func TestRunCommand_PromptFile_FileSizeLimit(t *testing.T) {
+	tmpDir := setupInitTestDir(t)
+
+	largeContent := make([]byte, 2*1024*1024) // 2MB
+	for i := range largeContent {
+		largeContent[i] = 'A'
+	}
+
+	promptPath := filepath.Join(tmpDir, ".awf", "workflows", "prompts", "large.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(promptPath), 0o755))
+	require.NoError(t, os.WriteFile(promptPath, largeContent, 0o644))
+
+	workflowContent := `name: large-file
+version: "1.0.0"
+states:
+  initial: analyze
+  analyze:
+    type: agent
+    provider: claude
+    prompt_file: prompts/large.md
+    on_success: done
+  done:
+    type: terminal
+`
+	createTestWorkflow(t, tmpDir, "large-file.yaml", workflowContent)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"run", "large-file", "--dry-run"})
+
+	err := cmd.Execute()
+	require.Error(t, err, "execution should fail for files exceeding 1MB")
+	assert.Contains(t, err.Error(), "exceeds", "error should mention size limit")
+}
+
+// TestRunCommand_PromptFile_StateInterpolation tests interpolation with state outputs
+// AC: prompt_file content supports {{.states.step.output}} interpolation
+func TestRunCommand_PromptFile_StateInterpolation(t *testing.T) {
+	tmpDir := setupInitTestDir(t)
+
+	promptContent := `Based on previous step: {{.states.prepare.output}}`
+	promptPath := filepath.Join(tmpDir, ".awf", "workflows", "prompts", "with-state.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(promptPath), 0o755))
+	require.NoError(t, os.WriteFile(promptPath, []byte(promptContent), 0o644))
+
+	workflowContent := `name: state-interpolation
+version: "1.0.0"
+states:
+  initial: prepare
+  prepare:
+    type: step
+    command: echo "prepared data"
+    on_success: analyze
+  analyze:
+    type: agent
+    provider: claude
+    prompt_file: prompts/with-state.md
+    on_success: done
+  done:
+    type: terminal
+`
+	createTestWorkflow(t, tmpDir, "state-interpolation.yaml", workflowContent)
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"run", "state-interpolation", "--dry-run"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "Based on previous step:", "prompt should reference state output")
+}


### PR DESCRIPTION
## Summary

- 794a20d feat(agent): add external prompt file loading with template interpolation

## Changes

```
 CHANGELOG.md                                       |   2 +
 CLAUDE.md                                          |  12 +
 README.md                                          |   1 +
 docs/README.md                                     |   1 +
 docs/reference/interpolation.md                    |  98 +++++
 docs/user-guide/agent-steps.md                     | 190 ++++++++
 docs/user-guide/workflow-syntax.md                 |   3 +-
 internal/application/dry_run_executor.go           |  43 +-
 internal/application/execution_service.go          |  36 +-
 .../execution_service_architecture_test.go         |   2 +-
 .../execution_service_awf_context_test.go          | 439 +++++++++++++++++++
 internal/application/prompt_file.go                | 103 +++++
 internal/application/prompt_file_test.go           | 416 ++++++++++++++++++
 internal/application/service.go                    |  78 ++++
 internal/application/service_prompt_file_test.go   | 433 +++++++++++++++++++
 internal/application/testutil_test.go              |  11 +
 internal/domain/workflow/agent_config.go           |  16 +-
 .../workflow/agent_config_prompt_file_test.go      | 349 +++++++++++++++
 internal/domain/workflow/workflow.go               |   1 +
 .../domain/workflow/workflow_source_dir_test.go    | 183 ++++++++
 internal/infrastructure/repository/yaml_mapper.go  |   8 +
 .../repository/yaml_mapper_prompt_file_test.go     | 442 +++++++++++++++++++
 .../repository/yaml_repository_source_dir_test.go  | 139 ++++++
 internal/infrastructure/repository/yaml_types.go   |   7 +-
 internal/interfaces/cli/resume.go                  |   1 +
 internal/interfaces/cli/run.go                     |  14 +
 pkg/interpolation/resolver.go                      |   2 +
 pkg/interpolation/resolver_awf_test.go             | 161 +++++++
 pkg/interpolation/template_helpers.go              |  68 +++
 pkg/interpolation/template_helpers_test.go         | 415 ++++++++++++++++++
 pkg/interpolation/template_resolver.go             |  31 +-
 tests/integration/cli/run_prompt_file_test.go      | 477 +++++++++++++++++++++
 32 files changed, 4153 insertions(+), 29 deletions(-)
```

Closes #216


---
Generated with awf commit workflow

