### PR TITLE
feat(workflow): add output_format field for agent steps

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -22,6 +22,7 @@ commonComponents:
   - pkg-stringutil
   - pkg-validation
   - pkg-httputil
+  - pkg-output
 
 vendors:
   go-stdlib:
@@ -150,6 +151,9 @@ components:
 
   pkg-httputil:
     in: ../pkg/httputil
+
+  pkg-output:
+    in: ../pkg/output
 
   pkg-validation:
     in: ../pkg/validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Zero breaking changes: all existing consumers compile unchanged
 
 ### Added
+- **F065**: Output Format for Agent Steps
+  - New `output_format` field on agent steps: `json` (fence stripping + JSON validation) or `text` (fence stripping only)
+  - Automatic markdown code fence stripping from agent output (outermost `` ```lang...``` `` removed)
+  - Parsed JSON accessible via `{{.states.step.JSON.field}}` dot notation in templates
+  - Invalid JSON with `output_format: json` fails the step with descriptive error (first 200 chars of malformed output)
+  - Domain validation rejects unknown `output_format` values at `awf validate` time
+  - New `pkg/output` package for reusable output processing utilities
+  - Dry-run mode displays configured output format
+  - Full backward compatibility: steps without `output_format` behave unchanged
 - **F064**: Script File Loading for Step States
   - New `script_file` field on step states to reference external shell scripts instead of inline `command`
   - Mutual exclusivity validation: `command` and `script_file` cannot both be set on the same step
@@ -291,6 +300,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Affects: Template interpolation, workflow validation, all state references
 
 ### Added
+- **F065**: Output Format for Agent Steps
 - **F063**: Prompt File Loading for Agent Steps
 - **C056**: Add doc.go to 9 Key Infrastructure and Interface Packages
   - Created `doc.go` files for 9 undocumented packages: `agents`, `executor`, `expression`, `logger`, `plugin`, `repository`, `store`, `cli`, `cli/ui`

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Go CLI tool for orchestrating AI agents (Claude, Gemini, Codex) through YAML-c
 
 - **State Machine Execution** - Define workflows as state machines with conditional transitions
 - **Agent Steps** - Invoke AI CLI agents (Claude, Codex, Gemini) with prompt templates and response parsing
+- **Output Formatting for Agent Steps** - Automatically strip markdown code fences and validate JSON output
 - **External Prompt Files** - Load agent prompts from `.md` files with full template interpolation and helper functions
 - **External Script Files** - Load shell commands from `.sh` files with template interpolation and path resolution
 - **Conversation Mode** - Multi-turn conversations with automatic context window management and token counting

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ Learn how to use AWF effectively:
 - [Commands](user-guide/commands.md) - All CLI commands and flags
 - [Interactive Input Collection](user-guide/interactive-inputs.md) - Automatic prompting for missing workflow inputs
 - [Agent Steps](user-guide/agent-steps.md) - Invoke AI agents (Claude, Codex, Gemini) in workflows
+  - [Output Formatting](user-guide/agent-steps.md#output-formatting) - Automatic code fence stripping and JSON validation (`output_format: json|text`)
   - [External Prompt Files](user-guide/agent-steps.md#external-prompt-files) - Load prompts from Markdown files with template interpolation
 - [Conversation Mode](user-guide/conversation-steps.md) - Multi-turn conversations with context window management
 - [Configuration](user-guide/configuration.md) - Project configuration file

--- a/docs/reference/interpolation.md
+++ b/docs/reference/interpolation.md
@@ -41,10 +41,11 @@ states:
 Access output, exit code, and token usage from previous steps:
 
 ```yaml
-{{.states.step_name.Output}}            # Command output (raw text or JSON)
+{{.states.step_name.Output}}            # Command output (raw text, or cleaned if output_format set)
 {{.states.step_name.ExitCode}}          # Exit code (0 for success, non-zero for failure)
 {{.states.step_name.TokensUsed}}        # Tokens consumed by agent steps
-{{.states.step_name.Response.field}}    # Parsed field from operation/agent structured output
+{{.states.step_name.Response.field}}    # Parsed field from operation/agent structured output (heuristic)
+{{.states.step_name.JSON.field}}        # Parsed field from output_format: json (explicit)
 ```
 
 #### Output
@@ -143,6 +144,59 @@ states:
 ```
 
 See [Workflow Syntax - Operation State](../user-guide/workflow-syntax.md#operation-state) for the full list of available operations and their output fields.
+
+#### JSON (Explicit Output Formatting)
+
+When an agent step uses `output_format: json`, the parsed JSON is accessible via `JSON`:
+
+```yaml
+{{.states.step_name.JSON.field}}         # Access a JSON object field
+{{.states.step_name.JSON}}               # Full parsed JSON object
+```
+
+**Key differences from `Response`:**
+- `JSON` is only populated when `output_format: json` is explicitly set on the agent step
+- `Response` is populated automatically for all agent outputs if valid JSON is detected (heuristic)
+- `JSON` represents explicitly formatted output; `Response` is automatic best-effort parsing
+
+Example with `output_format: json`:
+
+```yaml
+states:
+  initial: analyze
+
+  analyze:
+    type: agent
+    provider: claude
+    prompt: "Return JSON analysis with 'issues' and 'severity' fields"
+    output_format: json
+    on_success: process
+    on_failure: error
+
+  process:
+    type: step
+    command: |
+      echo "Severity: {{.states.analyze.JSON.severity}}"
+      echo "Issues: {{.states.analyze.JSON.issues}}"
+    on_success: done
+
+  done:
+    type: terminal
+  error:
+    type: terminal
+    status: failure
+```
+
+If agent returns:
+```json
+{"issues": ["buffer overflow", "memory leak"], "severity": "high"}
+```
+
+Then:
+- `{{.states.analyze.JSON.severity}}` = `"high"`
+- `{{.states.analyze.JSON.issues}}` = `["buffer overflow", "memory leak"]`
+
+See [Agent Steps - Output Formatting](../user-guide/agent-steps.md#output-formatting) for detailed examples and best practices.
 
 ### Workflow Metadata
 

--- a/docs/user-guide/agent-steps.md
+++ b/docs/user-guide/agent-steps.md
@@ -160,7 +160,8 @@ review:
 **Available Variables:**
 - `{{.inputs.*}}` - Workflow input values
 - `{{.states.step_name.Output}}` - Previous step raw output
-- `{{.states.step_name.Response}}` - Previous step parsed JSON
+- `{{.states.step_name.Response}}` - Previous step parsed JSON (heuristic)
+- `{{.states.step_name.JSON}}` - Parsed JSON from `output_format: json` (explicit)
 - `{{.env.VAR_NAME}}` - Environment variables
 - `{{.workflow.id}}` - Workflow execution ID
 - `{{.workflow.name}}` - Workflow name
@@ -363,8 +364,9 @@ Agent responses are automatically captured in the execution state:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `{{.states.step_name.Output}}` | string | Raw response text from the agent |
-| `{{.states.step_name.Response}}` | object | Parsed JSON response (if valid) |
+| `{{.states.step_name.Output}}` | string | Raw response text (or cleaned text if `output_format` is set) |
+| `{{.states.step_name.Response}}` | object | Parsed JSON response (automatic heuristic) |
+| `{{.states.step_name.JSON}}` | object | Parsed JSON from `output_format: json` (explicit, see [Output Formatting](#output-formatting)) |
 | `{{.states.step_name.TokensUsed}}` | int | Tokens consumed by this step |
 | `{{.states.step_name.ExitCode}}` | int | 0 for success, non-zero for failure |
 
@@ -389,6 +391,137 @@ process_response:
   command: echo "Found {{.states.analyze.Response.issues}} issues"
   on_success: done
 ```
+
+## Output Formatting
+
+When an agent wraps its output in markdown code fences (common with many LLMs), use `output_format` to automatically strip the fences and optionally validate the content:
+
+```yaml
+analyze:
+  type: agent
+  provider: claude
+  prompt: "Return JSON analysis"
+  output_format: json
+  on_success: process
+```
+
+### Available Formats
+
+#### `json` Format
+
+Strips markdown code fences and validates the output as valid JSON. Parsed JSON is accessible via `{{.states.step_name.JSON}}`:
+
+```yaml
+analyze:
+  type: agent
+  provider: claude
+  prompt: |
+    Analyze the code and return results as JSON:
+    {
+      "issues": [<list of issues>],
+      "severity": "high|medium|low"
+    }
+  output_format: json
+  on_success: process_results
+
+process_results:
+  type: step
+  command: echo "Severity: {{.states.analyze.JSON.severity}}"
+  on_success: done
+```
+
+**Behavior:**
+- Strips outermost markdown code fences (e.g., ````json ... ``` ``)
+- Validates stripped content as valid JSON
+- Stores parsed JSON in `{{.states.step_name.JSON}}`
+- If validation fails, step fails with a descriptive error
+- Works with both objects and arrays
+
+**Example agent output:**
+```
+The analysis shows the following:
+```json
+{"issues": ["buffer overflow", "memory leak"], "severity": "high"}
+```
+```
+
+**After processing:**
+- `{{.states.analyze.Output}}` = `{"issues": ["buffer overflow", "memory leak"], "severity": "high"}`
+- `{{.states.analyze.JSON.issues}}` = `["buffer overflow", "memory leak"]`
+- `{{.states.analyze.JSON.severity}}` = `"high"`
+
+#### `text` Format
+
+Strips markdown code fences without JSON validation. Useful for code or plain text output:
+
+```yaml
+generate_code:
+  type: agent
+  provider: claude
+  prompt: "Generate a Python function to..."
+  output_format: text
+  on_success: save_code
+
+save_code:
+  type: step
+  command: echo "{{.states.generate_code.Output}}" > generated.py
+  on_success: done
+```
+
+**Behavior:**
+- Strips outermost markdown code fences (e.g., ````python ... ``` ``)
+- Returns clean text in `{{.states.step_name.Output}}`
+- Does not populate `{{.states.step_name.JSON}}`
+
+**Example agent output:**
+```
+Here's the function:
+```python
+def fibonacci(n):
+    if n <= 1:
+        return n
+    return fibonacci(n-1) + fibonacci(n-2)
+```
+```
+
+**After processing:**
+- `{{.states.generate_code.Output}}` = `def fibonacci(n):\n    if n <= 1:\n        return n\n    return fibonacci(n-1) + fibonacci(n-2)`
+
+#### No Format (Default)
+
+Omit `output_format` for backward compatibility. Raw agent output is stored unchanged:
+
+```yaml
+analyze:
+  type: agent
+  provider: claude
+  prompt: "Analyze this code"
+  on_success: next
+```
+
+### Error Handling
+
+When `output_format: json` is specified but the output is invalid JSON:
+
+```yaml
+analyze:
+  type: agent
+  provider: claude
+  prompt: "Return valid JSON"
+  output_format: json
+  timeout: 60
+  on_failure: handle_json_error
+
+handle_json_error:
+  type: step
+  command: echo "JSON parsing failed"
+  on_success: done
+```
+
+**Error message includes:**
+- Clear indication of JSON validation failure
+- First 200 characters of the malformed output (for debugging)
+- Suggestions on how to fix the issue
 
 ## Multi-Turn Conversations
 

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -86,10 +86,10 @@ states:
       Review this code and suggest improvements:
 
       {{.states.read_file.Output}}
+    output_format: json
     options:
       model: claude-sonnet-4-20250514
       max_tokens: 4096
-      output_format: json
     timeout: 120
     on_success: done
     on_failure: error

--- a/docs/user-guide/workflow-syntax.md
+++ b/docs/user-guide/workflow-syntax.md
@@ -265,6 +265,7 @@ refine_code:
 | `prompt_file` | string | No* | Path to external prompt template file (mutually exclusive with `prompt`) |
 | `system_prompt` | string | No | System message (for conversation mode, preserved across turns) |
 | `initial_prompt` | string | No* | First user message (for conversation mode) |
+| `output_format` | string | No | Post-processing format: `json` (strip fences + validate JSON) or `text` (strip fences only) |
 | `conversation` | object | No | Conversation configuration (required if mode=conversation) |
 | `options` | map | No | Provider-specific options (model, temperature, max_tokens, etc.) |
 | `timeout` | int | No | Execution timeout in seconds (0 = no timeout) |

--- a/internal/application/dry_run_executor.go
+++ b/internal/application/dry_run_executor.go
@@ -364,9 +364,10 @@ func (e *DryRunExecutor) resolveCommand(cmd string, interpCtx *interpolation.Con
 
 func (e *DryRunExecutor) buildAgentConfig(ctx context.Context, agent *workflow.AgentConfig, wf *workflow.Workflow, interpCtx *interpolation.Context) (*workflow.DryRunAgent, error) {
 	dryRunAgent := &workflow.DryRunAgent{
-		Provider: agent.Provider,
-		Timeout:  agent.Timeout,
-		Options:  make(map[string]any),
+		Provider:     agent.Provider,
+		Timeout:      agent.Timeout,
+		OutputFormat: agent.OutputFormat,
+		Options:      make(map[string]any),
 	}
 
 	promptToResolve := agent.Prompt

--- a/internal/application/dry_run_executor_output_format_test.go
+++ b/internal/application/dry_run_executor_output_format_test.go
@@ -1,0 +1,320 @@
+package application_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/awf-project/awf/internal/application"
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/awf-project/awf/internal/testutil/mocks"
+	"github.com/awf-project/awf/pkg/interpolation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDryRunExecutor_AgentStep_OutputFormatJSON verifies that agent steps
+// with output_format: json are correctly captured in the dry run plan.
+func TestDryRunExecutor_AgentStep_OutputFormatJSON(t *testing.T) {
+	repo := newMockRepository()
+	repo.workflows["agent_json"] = &workflow.Workflow{
+		Name:    "agent_json",
+		Initial: "generate",
+		Steps: map[string]*workflow.Step{
+			"generate": {
+				Name: "generate",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "claude",
+					Prompt:       "Generate a JSON response",
+					OutputFormat: workflow.OutputFormatJSON,
+				},
+				OnSuccess: "done",
+			},
+			"done": {Name: "done", Type: workflow.StepTypeTerminal},
+		},
+	}
+
+	wfSvc := application.NewWorkflowService(repo, newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := mocks.NewMockExpressionEvaluator()
+	executor := application.NewDryRunExecutor(wfSvc, resolver, evaluator, &mockLogger{})
+
+	plan, err := executor.Execute(context.Background(), "agent_json", nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	var agentStep *workflow.DryRunStep
+	for i := range plan.Steps {
+		if plan.Steps[i].Name == "generate" {
+			agentStep = &plan.Steps[i]
+			break
+		}
+	}
+
+	require.NotNil(t, agentStep, "should have agent step")
+	require.NotNil(t, agentStep.Agent, "agent step should have agent config")
+	assert.Equal(t, workflow.OutputFormatJSON, agentStep.Agent.OutputFormat, "output format should be json")
+}
+
+// TestDryRunExecutor_AgentStep_OutputFormatText verifies that agent steps
+// with output_format: text are correctly captured in the dry run plan.
+func TestDryRunExecutor_AgentStep_OutputFormatText(t *testing.T) {
+	repo := newMockRepository()
+	repo.workflows["agent_text"] = &workflow.Workflow{
+		Name:    "agent_text",
+		Initial: "generate",
+		Steps: map[string]*workflow.Step{
+			"generate": {
+				Name: "generate",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "gemini",
+					Prompt:       "Generate a text response",
+					OutputFormat: workflow.OutputFormatText,
+				},
+				OnSuccess: "done",
+			},
+			"done": {Name: "done", Type: workflow.StepTypeTerminal},
+		},
+	}
+
+	wfSvc := application.NewWorkflowService(repo, newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := mocks.NewMockExpressionEvaluator()
+	executor := application.NewDryRunExecutor(wfSvc, resolver, evaluator, &mockLogger{})
+
+	plan, err := executor.Execute(context.Background(), "agent_text", nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	var agentStep *workflow.DryRunStep
+	for i := range plan.Steps {
+		if plan.Steps[i].Name == "generate" {
+			agentStep = &plan.Steps[i]
+			break
+		}
+	}
+
+	require.NotNil(t, agentStep, "should have agent step")
+	require.NotNil(t, agentStep.Agent, "agent step should have agent config")
+	assert.Equal(t, workflow.OutputFormatText, agentStep.Agent.OutputFormat, "output format should be text")
+}
+
+// TestDryRunExecutor_AgentStep_NoOutputFormat verifies that agent steps
+// without output_format field show empty/none in the dry run plan (backward compatibility).
+func TestDryRunExecutor_AgentStep_NoOutputFormat(t *testing.T) {
+	repo := newMockRepository()
+	repo.workflows["agent_none"] = &workflow.Workflow{
+		Name:    "agent_none",
+		Initial: "generate",
+		Steps: map[string]*workflow.Step{
+			"generate": {
+				Name: "generate",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider: "codex",
+					Prompt:   "Generate code",
+				},
+				OnSuccess: "done",
+			},
+			"done": {Name: "done", Type: workflow.StepTypeTerminal},
+		},
+	}
+
+	wfSvc := application.NewWorkflowService(repo, newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := mocks.NewMockExpressionEvaluator()
+	executor := application.NewDryRunExecutor(wfSvc, resolver, evaluator, &mockLogger{})
+
+	plan, err := executor.Execute(context.Background(), "agent_none", nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	var agentStep *workflow.DryRunStep
+	for i := range plan.Steps {
+		if plan.Steps[i].Name == "generate" {
+			agentStep = &plan.Steps[i]
+			break
+		}
+	}
+
+	require.NotNil(t, agentStep, "should have agent step")
+	require.NotNil(t, agentStep.Agent, "agent step should have agent config")
+	assert.Equal(t, workflow.OutputFormatNone, agentStep.Agent.OutputFormat, "output format should be empty/none")
+}
+
+// TestDryRunExecutor_AgentStep_MultipleFormats verifies that different agent steps
+// can have different output formats within the same workflow.
+func TestDryRunExecutor_AgentStep_MultipleFormats(t *testing.T) {
+	repo := newMockRepository()
+	repo.workflows["mixed"] = &workflow.Workflow{
+		Name:    "mixed",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": {
+				Name: "step1",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "claude",
+					Prompt:       "Generate JSON",
+					OutputFormat: workflow.OutputFormatJSON,
+				},
+				OnSuccess: "step2",
+			},
+			"step2": {
+				Name: "step2",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "gemini",
+					Prompt:       "Generate text",
+					OutputFormat: workflow.OutputFormatText,
+				},
+				OnSuccess: "step3",
+			},
+			"step3": {
+				Name: "step3",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider: "codex",
+					Prompt:   "No format",
+				},
+				OnSuccess: "done",
+			},
+			"done": {Name: "done", Type: workflow.StepTypeTerminal},
+		},
+	}
+
+	wfSvc := application.NewWorkflowService(repo, newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := mocks.NewMockExpressionEvaluator()
+	executor := application.NewDryRunExecutor(wfSvc, resolver, evaluator, &mockLogger{})
+
+	plan, err := executor.Execute(context.Background(), "mixed", nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	steps := make(map[string]*workflow.DryRunStep)
+	for i := range plan.Steps {
+		steps[plan.Steps[i].Name] = &plan.Steps[i]
+	}
+
+	require.Contains(t, steps, "step1")
+	require.NotNil(t, steps["step1"].Agent)
+	assert.Equal(t, workflow.OutputFormatJSON, steps["step1"].Agent.OutputFormat, "step1 should have json format")
+
+	require.Contains(t, steps, "step2")
+	require.NotNil(t, steps["step2"].Agent)
+	assert.Equal(t, workflow.OutputFormatText, steps["step2"].Agent.OutputFormat, "step2 should have text format")
+
+	require.Contains(t, steps, "step3")
+	require.NotNil(t, steps["step3"].Agent)
+	assert.Equal(t, workflow.OutputFormatNone, steps["step3"].Agent.OutputFormat, "step3 should have no format")
+}
+
+// TestDryRunExecutor_AgentStep_WithConversationMode verifies that output_format
+// is captured correctly for agent steps in conversation mode.
+func TestDryRunExecutor_AgentStep_WithConversationMode(t *testing.T) {
+	repo := newMockRepository()
+	repo.workflows["conversation"] = &workflow.Workflow{
+		Name:    "conversation",
+		Initial: "chat",
+		Steps: map[string]*workflow.Step{
+			"chat": {
+				Name: "chat",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:      "claude",
+					Mode:          "conversation",
+					InitialPrompt: "Start conversation",
+					OutputFormat:  workflow.OutputFormatJSON,
+					Conversation: &workflow.ConversationConfig{
+						MaxTurns: 3,
+					},
+				},
+				OnSuccess: "done",
+			},
+			"done": {Name: "done", Type: workflow.StepTypeTerminal},
+		},
+	}
+
+	wfSvc := application.NewWorkflowService(repo, newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := mocks.NewMockExpressionEvaluator()
+	executor := application.NewDryRunExecutor(wfSvc, resolver, evaluator, &mockLogger{})
+
+	plan, err := executor.Execute(context.Background(), "conversation", nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	var chatStep *workflow.DryRunStep
+	for i := range plan.Steps {
+		if plan.Steps[i].Name == "chat" {
+			chatStep = &plan.Steps[i]
+			break
+		}
+	}
+
+	require.NotNil(t, chatStep, "should have chat step")
+	require.NotNil(t, chatStep.Agent, "chat step should have agent config")
+	assert.Equal(t, workflow.OutputFormatJSON, chatStep.Agent.OutputFormat, "conversation mode should preserve output format")
+}
+
+// TestDryRunExecutor_AgentStep_WithOtherConfigs verifies that output_format
+// is correctly displayed alongside other agent configurations (timeout, options, etc.).
+func TestDryRunExecutor_AgentStep_WithOtherConfigs(t *testing.T) {
+	repo := newMockRepository()
+	repo.workflows["full_config"] = &workflow.Workflow{
+		Name:    "full_config",
+		Initial: "complex",
+		Steps: map[string]*workflow.Step{
+			"complex": {
+				Name: "complex",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider: "claude",
+					Prompt:   "Complex task",
+					Options: map[string]any{
+						"model":       "claude-3-opus",
+						"temperature": 0.7,
+						"max_tokens":  1000,
+					},
+					Timeout:      120,
+					OutputFormat: workflow.OutputFormatJSON,
+				},
+				OnSuccess: "done",
+			},
+			"done": {Name: "done", Type: workflow.StepTypeTerminal},
+		},
+	}
+
+	wfSvc := application.NewWorkflowService(repo, newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := mocks.NewMockExpressionEvaluator()
+	executor := application.NewDryRunExecutor(wfSvc, resolver, evaluator, &mockLogger{})
+
+	plan, err := executor.Execute(context.Background(), "full_config", nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	var complexStep *workflow.DryRunStep
+	for i := range plan.Steps {
+		if plan.Steps[i].Name == "complex" {
+			complexStep = &plan.Steps[i]
+			break
+		}
+	}
+
+	require.NotNil(t, complexStep, "should have complex step")
+	require.NotNil(t, complexStep.Agent, "complex step should have agent config")
+
+	assert.Equal(t, "claude", complexStep.Agent.Provider, "provider should be preserved")
+	assert.Equal(t, 120, complexStep.Agent.Timeout, "timeout should be preserved")
+	assert.NotNil(t, complexStep.Agent.Options, "options should be preserved")
+	assert.Equal(t, workflow.OutputFormatJSON, complexStep.Agent.OutputFormat, "output format should be json alongside other configs")
+}

--- a/internal/application/execution_service.go
+++ b/internal/application/execution_service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/awf-project/awf/internal/domain/ports"
 	"github.com/awf-project/awf/internal/domain/workflow"
 	"github.com/awf-project/awf/pkg/interpolation"
+	"github.com/awf-project/awf/pkg/output"
 	"github.com/awf-project/awf/pkg/retry"
 	"github.com/awf-project/awf/pkg/validation"
 	"github.com/google/uuid"
@@ -515,6 +516,7 @@ func (s *ExecutionService) buildInterpolationContext(
 			Status:     state.Status.String(),
 			Response:   state.Response,
 			TokensUsed: state.TokensUsed,
+			JSON:       state.JSON,
 		}
 	}
 
@@ -1830,6 +1832,11 @@ func (s *ExecutionService) executeAgentStep(
 		state.Response = result.Response
 		// AC6: Token usage in states.step_name.tokens_used
 		state.TokensUsed = result.Tokens
+
+		// F065: Apply output format post-processing
+		if err := s.applyOutputFormat(step, &state, execCtx); err != nil {
+			return "", err
+		}
 	}
 
 	// Handle execution error (e.g., context cancelled, provider error)
@@ -1969,6 +1976,11 @@ func (s *ExecutionService) executeConversationStep(
 		state.Response = result.Response
 		state.TokensUsed = result.TokensTotal
 		state.Conversation = result.State
+
+		// F065: Apply output format post-processing
+		if formatErr := s.applyOutputFormat(step, &state, execCtx); formatErr != nil {
+			return "", formatErr
+		}
 	}
 
 	// 7. Handle execution error
@@ -2094,4 +2106,24 @@ func classifyErrorType(err error) string {
 	default:
 		return "execution"
 	}
+}
+
+// applyOutputFormat applies output_format post-processing to agent step output.
+// It strips code fences and optionally validates/parses JSON, updating state accordingly.
+func (s *ExecutionService) applyOutputFormat(step *workflow.Step, state *workflow.StepState, execCtx *workflow.ExecutionContext) error {
+	if step.Agent.OutputFormat == workflow.OutputFormatNone {
+		return nil
+	}
+	processedOutput, parsedJSON, formatErr := output.ProcessOutputFormat(state.Output, string(step.Agent.OutputFormat))
+	if formatErr != nil {
+		state.Status = workflow.StatusFailed
+		state.Error = formatErr.Error()
+		execCtx.SetStepState(step.Name, *state)
+		return fmt.Errorf("step %s: output format processing: %w", step.Name, formatErr)
+	}
+	state.Output = processedOutput
+	if parsedJSON != nil {
+		state.JSON = parsedJSON
+	}
+	return nil
 }

--- a/internal/application/execution_service_json_field_mapping_test.go
+++ b/internal/application/execution_service_json_field_mapping_test.go
@@ -1,0 +1,397 @@
+package application_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/awf-project/awf/internal/domain/ports"
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/awf-project/awf/internal/testutil/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Feature: F065 - Output Format for Agent Steps
+// Component: T009 - Map StepState.JSON into interpolation context in buildInterpolationContext()
+//
+// Tests verify that buildInterpolationContext() correctly maps StepState.JSON
+// to StepStateData.JSON, enabling template interpolation like {{states.step.JSON.field}}.
+
+// TestExecutionService_buildInterpolationContext_MapsJSONFieldToStepStateData verifies
+// that when an agent step populates StepState.JSON, buildInterpolationContext maps it
+// to StepStateData.JSON for template access in subsequent steps.
+func TestExecutionService_buildInterpolationContext_MapsJSONFieldToStepStateData(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "json-field-mapping-test",
+		Initial: "extract",
+		Steps: map[string]*workflow.Step{
+			"extract": {
+				Name: "extract",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "claude",
+					Prompt:       "Extract data",
+					OutputFormat: workflow.OutputFormatJSON,
+				},
+				OnSuccess: "use",
+			},
+			"use": {
+				Name:      "use",
+				Type:      workflow.StepTypeCommand,
+				Command:   `echo name={{.states.extract.JSON.name}} count={{.states.extract.JSON.count}}`,
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("json-field-mapping-test", wf).
+		WithCommandResult(`echo name=alice count=42`, &ports.CommandResult{
+			Stdout:   "name=alice count=42",
+			ExitCode: 0,
+		}).
+		Build()
+
+	registry := mocks.NewMockAgentRegistry()
+	claude := mocks.NewMockAgentProvider("claude")
+
+	// Agent returns JSON that will be parsed into StepState.JSON
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+		return &workflow.AgentResult{
+			Provider: "claude",
+			Output:   `{"name":"alice","count":42}`,
+			Tokens:   20,
+		}, nil
+	})
+	_ = registry.Register(claude)
+	execSvc.SetAgentRegistry(registry)
+
+	ctx, err := execSvc.Run(context.Background(), "json-field-mapping-test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	// Verify extract step has JSON field populated
+	extractState, exists := ctx.GetStepState("extract")
+	require.True(t, exists)
+	require.NotNil(t, extractState.JSON)
+	jsonObj, ok := extractState.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any for object output")
+	assert.Equal(t, "alice", jsonObj["name"])
+	assert.Equal(t, float64(42), jsonObj["count"])
+
+	// Verify use step successfully interpolated JSON fields
+	useState, exists := ctx.GetStepState("use")
+	require.True(t, exists)
+	assert.Equal(t, workflow.StatusCompleted, useState.Status)
+	assert.Contains(t, useState.Output, "name=alice")
+	assert.Contains(t, useState.Output, "count=42")
+}
+
+// TestExecutionService_buildInterpolationContext_JSONFieldNilWhenNotSet verifies
+// that when a step does not have output_format: json, the JSON field remains nil
+// and templates referencing it don't cause errors (Go template handles nil gracefully).
+func TestExecutionService_buildInterpolationContext_JSONFieldNilWhenNotSet(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "no-json-field-test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": {
+				Name:      "step1",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo hello",
+				OnSuccess: "step2",
+			},
+			"step2": {
+				Name:      "step2",
+				Type:      workflow.StepTypeCommand,
+				Command:   `echo prev={{.states.step1.Output}}`,
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("no-json-field-test", wf).
+		WithCommandResult("echo hello", &ports.CommandResult{
+			Stdout:   "hello",
+			ExitCode: 0,
+		}).
+		WithCommandResult("echo prev=hello", &ports.CommandResult{
+			Stdout:   "prev=hello",
+			ExitCode: 0,
+		}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "no-json-field-test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	// Verify step1 has nil JSON field
+	step1State, exists := ctx.GetStepState("step1")
+	require.True(t, exists)
+	assert.Nil(t, step1State.JSON)
+
+	// Verify step2 completed successfully (didn't try to reference JSON)
+	step2State, exists := ctx.GetStepState("step2")
+	require.True(t, exists)
+	assert.Equal(t, workflow.StatusCompleted, step2State.Status)
+}
+
+// TestExecutionService_buildInterpolationContext_JSONFieldNestedObjectAccess verifies
+// that deeply nested JSON fields can be accessed via dot notation in templates.
+func TestExecutionService_buildInterpolationContext_JSONFieldNestedObjectAccess(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "nested-json-test",
+		Initial: "extract",
+		Steps: map[string]*workflow.Step{
+			"extract": {
+				Name: "extract",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "claude",
+					Prompt:       "Extract nested data",
+					OutputFormat: workflow.OutputFormatJSON,
+				},
+				OnSuccess: "use",
+			},
+			"use": {
+				Name:      "use",
+				Type:      workflow.StepTypeCommand,
+				Command:   `echo user={{.states.extract.JSON.user.name}} city={{.states.extract.JSON.user.address.city}}`,
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("nested-json-test", wf).
+		WithCommandResult("echo user=bob city=NYC", &ports.CommandResult{
+			Stdout:   "user=bob city=NYC",
+			ExitCode: 0,
+		}).
+		Build()
+
+	registry := mocks.NewMockAgentRegistry()
+	claude := mocks.NewMockAgentProvider("claude")
+
+	// Agent returns nested JSON structure
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+		return &workflow.AgentResult{
+			Provider: "claude",
+			Output:   `{"user":{"name":"bob","address":{"city":"NYC","zip":"10001"}}}`,
+			Tokens:   30,
+		}, nil
+	})
+	_ = registry.Register(claude)
+	execSvc.SetAgentRegistry(registry)
+
+	ctx, err := execSvc.Run(context.Background(), "nested-json-test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	// Verify nested JSON structure was populated
+	extractState, exists := ctx.GetStepState("extract")
+	require.True(t, exists)
+	require.NotNil(t, extractState.JSON)
+
+	jsonObj, ok := extractState.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any for object output")
+	user, ok := jsonObj["user"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "bob", user["name"])
+
+	address, ok := user["address"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "NYC", address["city"])
+
+	// Verify nested fields were correctly interpolated
+	useState, exists := ctx.GetStepState("use")
+	require.True(t, exists)
+	assert.Contains(t, useState.Output, "user=bob")
+	assert.Contains(t, useState.Output, "city=NYC")
+}
+
+// TestExecutionService_buildInterpolationContext_JSONFieldFromMultipleSteps verifies
+// that JSON fields from multiple previous steps are all available in the interpolation
+// context simultaneously.
+func TestExecutionService_buildInterpolationContext_JSONFieldFromMultipleSteps(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "multi-json-test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": {
+				Name: "step1",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "claude",
+					Prompt:       "Get user data",
+					OutputFormat: workflow.OutputFormatJSON,
+				},
+				OnSuccess: "step2",
+			},
+			"step2": {
+				Name: "step2",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "claude",
+					Prompt:       "Get config data",
+					OutputFormat: workflow.OutputFormatJSON,
+				},
+				OnSuccess: "combine",
+			},
+			"combine": {
+				Name:      "combine",
+				Type:      workflow.StepTypeCommand,
+				Command:   `echo {{.states.step1.JSON.user}}-{{.states.step2.JSON.env}}`,
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("multi-json-test", wf).
+		WithCommandResult("echo alice-production", &ports.CommandResult{
+			Stdout:   "alice-production",
+			ExitCode: 0,
+		}).
+		Build()
+
+	registry := mocks.NewMockAgentRegistry()
+	claude := mocks.NewMockAgentProvider("claude")
+
+	callCount := 0
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+		callCount++
+		if callCount == 1 {
+			// First call returns user data
+			return &workflow.AgentResult{
+				Provider: "claude",
+				Output:   `{"user":"alice"}`,
+				Tokens:   10,
+			}, nil
+		}
+		// Second call returns config data
+		return &workflow.AgentResult{
+			Provider: "claude",
+			Output:   `{"env":"production"}`,
+			Tokens:   10,
+		}, nil
+	})
+	_ = registry.Register(claude)
+	execSvc.SetAgentRegistry(registry)
+
+	ctx, err := execSvc.Run(context.Background(), "multi-json-test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	// Verify both steps have JSON fields populated
+	step1State, exists := ctx.GetStepState("step1")
+	require.True(t, exists)
+	require.NotNil(t, step1State.JSON)
+	json1, ok := step1State.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any")
+	assert.Equal(t, "alice", json1["user"])
+
+	step2State, exists := ctx.GetStepState("step2")
+	require.True(t, exists)
+	require.NotNil(t, step2State.JSON)
+	json2, ok := step2State.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any")
+	assert.Equal(t, "production", json2["env"])
+
+	// Verify combine step accessed both JSON fields
+	combineState, exists := ctx.GetStepState("combine")
+	require.True(t, exists)
+	assert.Contains(t, combineState.Output, "alice-production")
+}
+
+// TestExecutionService_buildInterpolationContext_JSONFieldWithBothResponseAndJSON verifies
+// that when both Response (legacy heuristic) and JSON (explicit output_format) fields exist,
+// the JSON field takes precedence in templates.
+func TestExecutionService_buildInterpolationContext_JSONFieldWithBothResponseAndJSON(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "dual-field-test",
+		Initial: "extract",
+		Steps: map[string]*workflow.Step{
+			"extract": {
+				Name: "extract",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "claude",
+					Prompt:       "Get data",
+					OutputFormat: workflow.OutputFormatJSON,
+				},
+				OnSuccess: "verify",
+			},
+			"verify": {
+				Name:      "verify",
+				Type:      workflow.StepTypeCommand,
+				Command:   `echo explicit={{.states.extract.JSON.source}}`,
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("dual-field-test", wf).
+		WithCommandResult("echo explicit=output_format", &ports.CommandResult{
+			Stdout:   "explicit=output_format",
+			ExitCode: 0,
+		}).
+		Build()
+
+	registry := mocks.NewMockAgentRegistry()
+	claude := mocks.NewMockAgentProvider("claude")
+
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+		return &workflow.AgentResult{
+			Provider: "claude",
+			Output:   `{"source":"output_format"}`,
+			Tokens:   10,
+		}, nil
+	})
+	_ = registry.Register(claude)
+	execSvc.SetAgentRegistry(registry)
+
+	ctx, err := execSvc.Run(context.Background(), "dual-field-test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	// Verify extract step has JSON field populated
+	extractState, exists := ctx.GetStepState("extract")
+	require.True(t, exists)
+	require.NotNil(t, extractState.JSON)
+	jsonObj, ok := extractState.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any")
+	assert.Equal(t, "output_format", jsonObj["source"])
+
+	// Verify subsequent step could access JSON field
+	verifyState, exists := ctx.GetStepState("verify")
+	require.True(t, exists)
+	assert.Contains(t, verifyState.Output, "explicit=output_format")
+}

--- a/internal/application/execution_service_output_format_test.go
+++ b/internal/application/execution_service_output_format_test.go
@@ -1,0 +1,857 @@
+package application_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/awf-project/awf/internal/application"
+	"github.com/awf-project/awf/internal/domain/ports"
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/awf-project/awf/internal/testutil/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Component: T008
+// Feature: F065 - Output Format for Agent Steps
+
+// TestExecutionService_AgentStep_OutputFormat_JSON_StripsFencesAndParsesJSON verifies
+// that when output_format: json is set on an agent step, the execution service:
+// 1. Strips code fences from agent output
+// 2. Validates the content as JSON
+// 3. Populates states.step.JSON with parsed data
+func TestExecutionService_AgentStep_OutputFormat_JSON_StripsFencesAndParsesJSON(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "json-output-test",
+		Initial: "extract",
+		Steps: map[string]*workflow.Step{
+			"extract": {
+				Name: "extract",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "claude",
+					Prompt:       "Extract structured data",
+					OutputFormat: workflow.OutputFormatJSON,
+				},
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("json-output-test", wf).
+		Build()
+
+	registry := mocks.NewMockAgentRegistry()
+	claude := mocks.NewMockAgentProvider("claude")
+
+	// Mock agent returns JSON wrapped in markdown code fences
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+		return &workflow.AgentResult{
+			Provider: "claude",
+			Output:   "```json\n{\"name\":\"alice\",\"count\":3}\n```",
+			Tokens:   50,
+		}, nil
+	})
+	_ = registry.Register(claude)
+
+	execSvc.SetAgentRegistry(registry)
+
+	ctx, err := execSvc.Run(context.Background(), "json-output-test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	// Verify step state
+	state, exists := ctx.GetStepState("extract")
+	require.True(t, exists)
+	assert.Equal(t, workflow.StatusCompleted, state.Status)
+
+	// Output should have code fences stripped
+	assert.Equal(t, `{"name":"alice","count":3}`, state.Output)
+
+	// JSON field should be populated with parsed data
+	require.NotNil(t, state.JSON)
+	jsonObj, ok := state.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any for object output")
+	assert.Equal(t, "alice", jsonObj["name"])
+	assert.Equal(t, float64(3), jsonObj["count"])
+}
+
+// TestExecutionService_AgentStep_OutputFormat_JSON_NoFences_ParsesDirectly tests
+// that when output_format: json is set but agent output has no code fences,
+// the JSON is parsed directly without modification.
+func TestExecutionService_AgentStep_OutputFormat_JSON_NoFences_ParsesDirectly(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "json-no-fence-test",
+		Initial: "extract",
+		Steps: map[string]*workflow.Step{
+			"extract": {
+				Name: "extract",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "claude",
+					Prompt:       "Return JSON",
+					OutputFormat: workflow.OutputFormatJSON,
+				},
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("json-no-fence-test", wf).
+		Build()
+
+	registry := mocks.NewMockAgentRegistry()
+	claude := mocks.NewMockAgentProvider("claude")
+
+	// Agent returns raw JSON without fences
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+		return &workflow.AgentResult{
+			Provider: "claude",
+			Output:   `{"status":"ok","value":42}`,
+			Tokens:   30,
+		}, nil
+	})
+	_ = registry.Register(claude)
+
+	execSvc.SetAgentRegistry(registry)
+
+	ctx, err := execSvc.Run(context.Background(), "json-no-fence-test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	state, exists := ctx.GetStepState("extract")
+	require.True(t, exists)
+
+	// Output unchanged (no fences to strip)
+	assert.Equal(t, `{"status":"ok","value":42}`, state.Output)
+
+	// JSON should still be parsed
+	require.NotNil(t, state.JSON)
+	jsonObj, ok := state.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any for object output")
+	assert.Equal(t, "ok", jsonObj["status"])
+	assert.Equal(t, float64(42), jsonObj["value"])
+}
+
+// TestExecutionService_AgentStep_OutputFormat_JSON_InvalidJSON_FailsStep verifies
+// that when output_format: json is set but the stripped content is not valid JSON,
+// the step fails with a descriptive error including a preview of the malformed content.
+func TestExecutionService_AgentStep_OutputFormat_JSON_InvalidJSON_FailsStep(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "invalid-json-test",
+		Initial: "extract",
+		Steps: map[string]*workflow.Step{
+			"extract": {
+				Name: "extract",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "claude",
+					Prompt:       "Return data",
+					OutputFormat: workflow.OutputFormatJSON,
+				},
+				OnSuccess: "done",
+				OnFailure: "error",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+			"error": {
+				Name: "error",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("invalid-json-test", wf).
+		Build()
+
+	registry := mocks.NewMockAgentRegistry()
+	claude := mocks.NewMockAgentProvider("claude")
+
+	// Agent returns malformed JSON
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+		return &workflow.AgentResult{
+			Provider: "claude",
+			Output:   "```json\n{invalid json here\n```",
+			Tokens:   20,
+		}, nil
+	})
+	_ = registry.Register(claude)
+
+	execSvc.SetAgentRegistry(registry)
+
+	ctx, err := execSvc.Run(context.Background(), "invalid-json-test", nil)
+
+	// Execution should fail when JSON validation fails
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid JSON")
+	assert.Contains(t, err.Error(), "invalid json here")
+
+	// Context should still track the failed step state
+	state, exists := ctx.GetStepState("extract")
+	require.True(t, exists)
+	assert.Equal(t, workflow.StatusFailed, state.Status)
+
+	// Step state error should also contain validation failure details
+	assert.Contains(t, state.Error, "invalid JSON")
+}
+
+// TestExecutionService_AgentStep_OutputFormat_Text_StripsFencesOnly tests
+// that when output_format: text is set, code fences are stripped but JSON
+// parsing is not performed.
+func TestExecutionService_AgentStep_OutputFormat_Text_StripsFencesOnly(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "text-output-test",
+		Initial: "analyze",
+		Steps: map[string]*workflow.Step{
+			"analyze": {
+				Name: "analyze",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "claude",
+					Prompt:       "Analyze code",
+					OutputFormat: workflow.OutputFormatText,
+				},
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("text-output-test", wf).
+		Build()
+
+	registry := mocks.NewMockAgentRegistry()
+	claude := mocks.NewMockAgentProvider("claude")
+
+	// Agent returns text in bash code fence
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+		return &workflow.AgentResult{
+			Provider: "claude",
+			Output:   "```bash\necho hello world\n```",
+			Tokens:   15,
+		}, nil
+	})
+	_ = registry.Register(claude)
+
+	execSvc.SetAgentRegistry(registry)
+
+	ctx, err := execSvc.Run(context.Background(), "text-output-test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	state, exists := ctx.GetStepState("analyze")
+	require.True(t, exists)
+
+	// Output should have fences stripped
+	assert.Equal(t, "echo hello world", state.Output)
+
+	// JSON field should be nil (no parsing for text format)
+	assert.Nil(t, state.JSON)
+}
+
+// TestExecutionService_AgentStep_OutputFormat_None_BackwardCompatibility verifies
+// that when output_format is not set (empty/none), the agent output is stored
+// unchanged without any stripping or validation.
+func TestExecutionService_AgentStep_OutputFormat_None_BackwardCompatibility(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "no-format-test",
+		Initial: "analyze",
+		Steps: map[string]*workflow.Step{
+			"analyze": {
+				Name: "analyze",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "claude",
+					Prompt:       "Analyze code",
+					OutputFormat: workflow.OutputFormatNone,
+				},
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("no-format-test", wf).
+		Build()
+
+	registry := mocks.NewMockAgentRegistry()
+	claude := mocks.NewMockAgentProvider("claude")
+
+	// Agent returns output with code fences
+	rawOutput := "```json\n{\"data\":\"value\"}\n```"
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+		return &workflow.AgentResult{
+			Provider: "claude",
+			Output:   rawOutput,
+			Tokens:   20,
+		}, nil
+	})
+	_ = registry.Register(claude)
+
+	execSvc.SetAgentRegistry(registry)
+
+	ctx, err := execSvc.Run(context.Background(), "no-format-test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	state, exists := ctx.GetStepState("analyze")
+	require.True(t, exists)
+
+	// Output should be completely unchanged (fences preserved)
+	assert.Equal(t, rawOutput, state.Output)
+
+	// JSON field should be nil (no processing)
+	assert.Nil(t, state.JSON)
+}
+
+// TestExecutionService_AgentStep_OutputFormat_JSON_ArrayParsing verifies that
+// when output_format: json is set and the content is a JSON array, it is correctly
+// parsed but not stored in JSON field (only objects are stored).
+func TestExecutionService_AgentStep_OutputFormat_JSON_ArrayParsing(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "json-array-test",
+		Initial: "extract",
+		Steps: map[string]*workflow.Step{
+			"extract": {
+				Name: "extract",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "claude",
+					Prompt:       "List items",
+					OutputFormat: workflow.OutputFormatJSON,
+				},
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("json-array-test", wf).
+		Build()
+
+	registry := mocks.NewMockAgentRegistry()
+	claude := mocks.NewMockAgentProvider("claude")
+
+	// Agent returns JSON array
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+		return &workflow.AgentResult{
+			Provider: "claude",
+			Output:   `["item1","item2","item3"]`,
+			Tokens:   10,
+		}, nil
+	})
+	_ = registry.Register(claude)
+
+	execSvc.SetAgentRegistry(registry)
+
+	ctx, err := execSvc.Run(context.Background(), "json-array-test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	state, exists := ctx.GetStepState("extract")
+	require.True(t, exists)
+
+	// Output should be the array JSON
+	assert.Equal(t, `["item1","item2","item3"]`, state.Output)
+
+	// JSON field should contain the parsed array
+	require.NotNil(t, state.JSON)
+	jsonArray, ok := state.JSON.([]any)
+	require.True(t, ok, "JSON field should be []any for array output")
+	assert.Equal(t, []any{"item1", "item2", "item3"}, jsonArray)
+}
+
+// TestExecutionService_AgentStep_OutputFormat_JSON_LargeOutput verifies that
+// output format processing works correctly with large outputs near the 1MB limit.
+func TestExecutionService_AgentStep_OutputFormat_JSON_LargeOutput(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "large-json-test",
+		Initial: "generate",
+		Steps: map[string]*workflow.Step{
+			"generate": {
+				Name: "generate",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "claude",
+					Prompt:       "Generate large dataset",
+					OutputFormat: workflow.OutputFormatJSON,
+				},
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("large-json-test", wf).
+		Build()
+
+	registry := mocks.NewMockAgentRegistry()
+	claude := mocks.NewMockAgentProvider("claude")
+
+	// Generate a large JSON object (500KB - well under 1MB limit)
+	largeValue := make([]byte, 500000)
+	for i := range largeValue {
+		largeValue[i] = 'x'
+	}
+	largeJSON := `{"data":"` + string(largeValue) + `"}`
+
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+		return &workflow.AgentResult{
+			Provider: "claude",
+			Output:   "```json\n" + largeJSON + "\n```",
+			Tokens:   100000,
+		}, nil
+	})
+	_ = registry.Register(claude)
+
+	execSvc.SetAgentRegistry(registry)
+
+	ctx, err := execSvc.Run(context.Background(), "large-json-test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	state, exists := ctx.GetStepState("generate")
+	require.True(t, exists)
+
+	// Should successfully parse large JSON
+	require.NotNil(t, state.JSON)
+	jsonObj, ok := state.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any for object output")
+	assert.Contains(t, jsonObj["data"], "xxx")
+}
+
+// TestExecutionService_AgentStep_OutputFormat_JSON_ConversationMode verifies that
+// output format processing (code fence stripping and JSON parsing) works correctly
+// in conversation mode just as it does in single-prompt mode.
+func TestExecutionService_AgentStep_OutputFormat_JSON_ConversationMode(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "conversation-json-test",
+		Initial: "chat",
+		Steps: map[string]*workflow.Step{
+			"chat": {
+				Name: "chat",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:      "claude",
+					Mode:          "conversation",
+					SystemPrompt:  "You are a helpful assistant",
+					InitialPrompt: "Start conversation",
+					OutputFormat:  workflow.OutputFormatJSON,
+					Conversation: &workflow.ConversationConfig{
+						MaxTurns:      5,
+						StopCondition: "response contains 'complete'",
+					},
+				},
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("conversation-json-test", wf).
+		Build()
+
+	registry := mocks.NewMockAgentRegistry()
+	claude := mocks.NewMockAgentProvider("claude")
+
+	// Mock conversation agent returns JSON wrapped in code fences
+	claude.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+		return &workflow.ConversationResult{
+			Provider:     "claude",
+			State:        state,
+			Output:       "```json\n{\"status\":\"complete\",\"result\":\"success\"}\n```",
+			TokensTotal:  40,
+			TokensInput:  20,
+			TokensOutput: 20,
+		}, nil
+	})
+	_ = registry.Register(claude)
+
+	tokenizer := newMockTokenizer()
+	mockRegistry := mocks.NewMockAgentRegistry()
+	mockRegistry.Register(claude)
+	convMgr := application.NewConversationManager(&mockLogger{}, &simpleExpressionEvaluator{}, newMockResolver(), tokenizer, mockRegistry)
+
+	execSvc.SetAgentRegistry(registry)
+	execSvc.SetConversationManager(convMgr)
+
+	ctx, err := execSvc.Run(context.Background(), "conversation-json-test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	state, exists := ctx.GetStepState("chat")
+	require.True(t, exists)
+
+	// Output should have code fences stripped in conversation mode too
+	assert.Equal(t, `{"status":"complete","result":"success"}`, state.Output)
+
+	// JSON field should be populated from conversation output
+	require.NotNil(t, state.JSON)
+	jsonObj, ok := state.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any for object output")
+	assert.Equal(t, "complete", jsonObj["status"])
+	assert.Equal(t, "success", jsonObj["result"])
+}
+
+// TestExecutionService_AgentStep_OutputFormat_JSON_NestedFences tests that when
+// output contains nested code fences, only the outermost fence pair is stripped.
+func TestExecutionService_AgentStep_OutputFormat_JSON_NestedFences(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "nested-fences-test",
+		Initial: "extract",
+		Steps: map[string]*workflow.Step{
+			"extract": {
+				Name: "extract",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "claude",
+					Prompt:       "Return JSON with markdown",
+					OutputFormat: workflow.OutputFormatJSON,
+				},
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("nested-fences-test", wf).
+		Build()
+
+	registry := mocks.NewMockAgentRegistry()
+	claude := mocks.NewMockAgentProvider("claude")
+
+	// Agent returns JSON containing code fences in a string field
+	// Note: JSON strings use literal characters, not escape sequences
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+		return &workflow.AgentResult{
+			Provider: "claude",
+			Output:   "```json\n{\"code\":\"```\\necho hello\\n```\",\"type\":\"bash\"}\n```",
+			Tokens:   50,
+		}, nil
+	})
+	_ = registry.Register(claude)
+
+	execSvc.SetAgentRegistry(registry)
+
+	ctx, err := execSvc.Run(context.Background(), "nested-fences-test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	state, exists := ctx.GetStepState("extract")
+	require.True(t, exists)
+
+	// Only outermost fences should be stripped
+	assert.Equal(t, "{\"code\":\"```\\necho hello\\n```\",\"type\":\"bash\"}", state.Output)
+
+	// JSON should be parsed correctly with nested fence as string value
+	// When JSON unmarshals, \n becomes actual newline character
+	require.NotNil(t, state.JSON)
+	jsonObj, ok := state.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any for object output")
+	assert.Equal(t, "```\necho hello\n```", jsonObj["code"])
+	assert.Equal(t, "bash", jsonObj["type"])
+}
+
+// TestExecutionService_AgentStep_OutputFormat_JSON_MultiStepInterpolation tests that
+// JSON fields from one step can be interpolated in subsequent steps via template access.
+func TestExecutionService_AgentStep_OutputFormat_JSON_MultiStepInterpolation(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "multi-step-json-test",
+		Initial: "extract",
+		Steps: map[string]*workflow.Step{
+			"extract": {
+				Name: "extract",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider:     "claude",
+					Prompt:       "Extract user data",
+					OutputFormat: workflow.OutputFormatJSON,
+				},
+				OnSuccess: "greet",
+			},
+			"greet": {
+				Name:      "greet",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo 'Hello, {{states.extract.JSON.name}}! Count: {{states.extract.JSON.count}}'",
+				OnSuccess: "done",
+			},
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, testMocks := NewTestHarness(t).
+		WithWorkflow("multi-step-json-test", wf).
+		Build()
+
+	registry := mocks.NewMockAgentRegistry()
+	claude := mocks.NewMockAgentProvider("claude")
+
+	// Step 1: Agent returns JSON with name and count
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+		return &workflow.AgentResult{
+			Provider: "claude",
+			Output:   "```json\n{\"name\":\"alice\",\"count\":3}\n```",
+			Tokens:   30,
+		}, nil
+	})
+	_ = registry.Register(claude)
+
+	// Configure the command executor to return the echo output
+	// The interpolation happens before execution, so we match the interpolated command
+	testMocks.Executor.SetCommandResult("echo 'Hello, alice! Count: 3'", &ports.CommandResult{
+		Stdout:   "Hello, alice! Count: 3\n",
+		Stderr:   "",
+		ExitCode: 0,
+	})
+
+	execSvc.SetAgentRegistry(registry)
+
+	ctx, err := execSvc.Run(context.Background(), "multi-step-json-test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	// Verify first step parsed JSON correctly
+	extractState, exists := ctx.GetStepState("extract")
+	require.True(t, exists)
+	require.NotNil(t, extractState.JSON)
+	jsonObj, ok := extractState.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any for object output")
+	assert.Equal(t, "alice", jsonObj["name"])
+	assert.Equal(t, float64(3), jsonObj["count"])
+
+	// Verify second step received interpolated values
+	greetState, exists := ctx.GetStepState("greet")
+	require.True(t, exists)
+	assert.Contains(t, greetState.Output, "Hello, alice!")
+	assert.Contains(t, greetState.Output, "Count: 3")
+}
+
+// TestExecutionService_AgentStep_OutputFormat_Text_DifferentLanguageTags tests that
+// text format strips code fences with various language tags (bash, python, etc).
+func TestExecutionService_AgentStep_OutputFormat_Text_DifferentLanguageTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		langTag  string
+		content  string
+		expected string
+	}{
+		{
+			name:     "bash tag",
+			langTag:  "bash",
+			content:  "echo hello",
+			expected: "echo hello",
+		},
+		{
+			name:     "python tag",
+			langTag:  "python",
+			content:  "print('hello')",
+			expected: "print('hello')",
+		},
+		{
+			name:     "no tag",
+			langTag:  "",
+			content:  "plain text",
+			expected: "plain text",
+		},
+		{
+			name:     "go tag",
+			langTag:  "go",
+			content:  "fmt.Println(\"hello\")",
+			expected: "fmt.Println(\"hello\")",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf := &workflow.Workflow{
+				Name:    "text-tag-test",
+				Initial: "analyze",
+				Steps: map[string]*workflow.Step{
+					"analyze": {
+						Name: "analyze",
+						Type: workflow.StepTypeAgent,
+						Agent: &workflow.AgentConfig{
+							Provider:     "claude",
+							Prompt:       "Return code",
+							OutputFormat: workflow.OutputFormatText,
+						},
+						OnSuccess: "done",
+					},
+					"done": {
+						Name: "done",
+						Type: workflow.StepTypeTerminal,
+					},
+				},
+			}
+
+			execSvc, _ := NewTestHarness(t).
+				WithWorkflow("text-tag-test", wf).
+				Build()
+
+			registry := mocks.NewMockAgentRegistry()
+			claude := mocks.NewMockAgentProvider("claude")
+
+			output := "```" + tt.langTag + "\n" + tt.content + "\n```"
+			claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+				return &workflow.AgentResult{
+					Provider: "claude",
+					Output:   output,
+					Tokens:   20,
+				}, nil
+			})
+			_ = registry.Register(claude)
+
+			execSvc.SetAgentRegistry(registry)
+
+			ctx, err := execSvc.Run(context.Background(), "text-tag-test", nil)
+
+			require.NoError(t, err)
+			assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+			state, exists := ctx.GetStepState("analyze")
+			require.True(t, exists)
+
+			// Fences should be stripped regardless of language tag
+			assert.Equal(t, tt.expected, state.Output)
+
+			// JSON field should be nil for text format
+			assert.Nil(t, state.JSON)
+		})
+	}
+}
+
+// TestExecutionService_AgentStep_OutputFormat_JSON_EmptyOutput tests that
+// empty JSON objects and arrays are handled correctly.
+func TestExecutionService_AgentStep_OutputFormat_JSON_EmptyOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		expected string
+		isEmpty  bool
+	}{
+		{
+			name:     "empty object",
+			output:   "```json\n{}\n```",
+			expected: "{}",
+			isEmpty:  false,
+		},
+		{
+			name:     "empty array",
+			output:   "```json\n[]\n```",
+			expected: "[]",
+			isEmpty:  false,
+		},
+		{
+			name:     "object with empty string",
+			output:   "```json\n{\"value\":\"\"}\n```",
+			expected: "{\"value\":\"\"}",
+			isEmpty:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf := &workflow.Workflow{
+				Name:    "empty-json-test",
+				Initial: "extract",
+				Steps: map[string]*workflow.Step{
+					"extract": {
+						Name: "extract",
+						Type: workflow.StepTypeAgent,
+						Agent: &workflow.AgentConfig{
+							Provider:     "claude",
+							Prompt:       "Return empty data",
+							OutputFormat: workflow.OutputFormatJSON,
+						},
+						OnSuccess: "done",
+					},
+					"done": {
+						Name: "done",
+						Type: workflow.StepTypeTerminal,
+					},
+				},
+			}
+
+			execSvc, _ := NewTestHarness(t).
+				WithWorkflow("empty-json-test", wf).
+				Build()
+
+			registry := mocks.NewMockAgentRegistry()
+			claude := mocks.NewMockAgentProvider("claude")
+
+			claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+				return &workflow.AgentResult{
+					Provider: "claude",
+					Output:   tt.output,
+					Tokens:   10,
+				}, nil
+			})
+			_ = registry.Register(claude)
+
+			execSvc.SetAgentRegistry(registry)
+
+			ctx, err := execSvc.Run(context.Background(), "empty-json-test", nil)
+
+			require.NoError(t, err)
+			assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+			state, exists := ctx.GetStepState("extract")
+			require.True(t, exists)
+
+			// Output should have fences stripped
+			assert.Equal(t, tt.expected, state.Output)
+
+			// Empty objects and arrays are valid JSON but may result in nil JSON field
+			// depending on implementation (array vs object handling)
+		})
+	}
+}

--- a/internal/domain/workflow/agent_config.go
+++ b/internal/domain/workflow/agent_config.go
@@ -9,6 +9,21 @@ import (
 // DefaultAgentTimeout is the default timeout in seconds for agent execution.
 const DefaultAgentTimeout = 300
 
+// OutputFormat represents the format for agent output post-processing.
+type OutputFormat string
+
+const (
+	OutputFormatNone OutputFormat = ""
+	OutputFormatJSON OutputFormat = "json"
+	OutputFormatText OutputFormat = "text"
+)
+
+var validOutputFormats = map[OutputFormat]bool{
+	OutputFormatNone: true,
+	OutputFormatJSON: true,
+	OutputFormatText: true,
+}
+
 // AgentConfig holds configuration for invoking an AI agent.
 type AgentConfig struct {
 	Provider      string              `yaml:"provider"`       // agent provider: claude, codex, gemini, opencode, custom
@@ -21,6 +36,7 @@ type AgentConfig struct {
 	SystemPrompt  string              `yaml:"system_prompt"`  // system prompt preserved across conversation (conversation mode only)
 	InitialPrompt string              `yaml:"initial_prompt"` // first user message in conversation mode (overrides Prompt if set)
 	Conversation  *ConversationConfig `yaml:"conversation"`   // conversation-specific configuration (conversation mode only)
+	OutputFormat  OutputFormat        `yaml:"output_format"`  // output post-processing: json (strip fences + validate), text (strip fences only), or empty (no processing)
 }
 
 // Validate checks if the agent configuration is valid.
@@ -41,6 +57,12 @@ func (c *AgentConfig) Validate(validator ExpressionCompiler) error {
 	// Validate mode value
 	if c.Mode != "single" && c.Mode != "conversation" {
 		return errors.New("mode must be 'single' or 'conversation'")
+	}
+
+	// Normalize and validate output_format
+	c.OutputFormat = OutputFormat(strings.TrimSpace(strings.ToLower(string(c.OutputFormat))))
+	if !validOutputFormats[c.OutputFormat] {
+		return errors.New("output_format must be 'json', 'text', or empty")
 	}
 
 	// Validate mutual exclusivity of Prompt and PromptFile

--- a/internal/domain/workflow/agent_config_output_format_test.go
+++ b/internal/domain/workflow/agent_config_output_format_test.go
@@ -1,0 +1,318 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Feature: F065
+// Component: T002
+// Tests: OutputFormat field validation in AgentConfig
+
+func TestAgentConfig_OutputFormat_ValidValues(t *testing.T) {
+	tests := []struct {
+		name         string
+		outputFormat OutputFormat
+		wantErr      bool
+	}{
+		{
+			name:         "empty/none - backward compatibility",
+			outputFormat: OutputFormatNone,
+			wantErr:      false,
+		},
+		{
+			name:         "json format",
+			outputFormat: OutputFormatJSON,
+			wantErr:      false,
+		},
+		{
+			name:         "text format",
+			outputFormat: OutputFormatText,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Test prompt",
+				OutputFormat: tt.outputFormat,
+			}
+			err := config.Validate(nil)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.outputFormat, config.OutputFormat)
+			}
+		})
+	}
+}
+
+func TestAgentConfig_OutputFormat_InvalidValues(t *testing.T) {
+	tests := []struct {
+		name         string
+		outputFormat OutputFormat
+		errMsg       string
+	}{
+		{
+			name:         "xml format - not supported",
+			outputFormat: "xml",
+			errMsg:       "output_format must be 'json', 'text', or empty",
+		},
+		{
+			name:         "csv format - not supported",
+			outputFormat: "csv",
+			errMsg:       "output_format must be 'json', 'text', or empty",
+		},
+		{
+			name:         "yaml format - not supported",
+			outputFormat: "yaml",
+			errMsg:       "output_format must be 'json', 'text', or empty",
+		},
+		{
+			name:         "random string",
+			outputFormat: "random",
+			errMsg:       "output_format must be 'json', 'text', or empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Test prompt",
+				OutputFormat: tt.outputFormat,
+			}
+			err := config.Validate(nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+func TestAgentConfig_OutputFormat_CaseNormalization(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputFormat    OutputFormat
+		expectedFormat OutputFormat
+	}{
+		{
+			name:           "uppercase JSON",
+			inputFormat:    "JSON",
+			expectedFormat: OutputFormatJSON,
+		},
+		{
+			name:           "mixed case Json",
+			inputFormat:    "Json",
+			expectedFormat: OutputFormatJSON,
+		},
+		{
+			name:           "uppercase TEXT",
+			inputFormat:    "TEXT",
+			expectedFormat: OutputFormatText,
+		},
+		{
+			name:           "mixed case Text",
+			inputFormat:    "Text",
+			expectedFormat: OutputFormatText,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Test prompt",
+				OutputFormat: tt.inputFormat,
+			}
+			err := config.Validate(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedFormat, config.OutputFormat)
+		})
+	}
+}
+
+func TestAgentConfig_OutputFormat_WhitespaceHandling(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputFormat    OutputFormat
+		expectedFormat OutputFormat
+	}{
+		{
+			name:           "leading whitespace",
+			inputFormat:    "  json",
+			expectedFormat: OutputFormatJSON,
+		},
+		{
+			name:           "trailing whitespace",
+			inputFormat:    "json  ",
+			expectedFormat: OutputFormatJSON,
+		},
+		{
+			name:           "both leading and trailing",
+			inputFormat:    "  text  ",
+			expectedFormat: OutputFormatText,
+		},
+		{
+			name:           "whitespace only - becomes empty",
+			inputFormat:    "   ",
+			expectedFormat: OutputFormatNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Test prompt",
+				OutputFormat: tt.inputFormat,
+			}
+			err := config.Validate(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedFormat, config.OutputFormat)
+		})
+	}
+}
+
+func TestAgentConfig_OutputFormat_WithOtherFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		config AgentConfig
+	}{
+		{
+			name: "output_format with prompt",
+			config: AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Analyze this: {{inputs.code}}",
+				OutputFormat: OutputFormatJSON,
+			},
+		},
+		{
+			name: "output_format with prompt_file",
+			config: AgentConfig{
+				Provider:     "claude",
+				PromptFile:   "prompts/analyze.md",
+				OutputFormat: OutputFormatText,
+			},
+		},
+		{
+			name: "output_format with conversation mode",
+			config: AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Initial message",
+				Mode:         "conversation",
+				OutputFormat: OutputFormatJSON,
+			},
+		},
+		{
+			name: "output_format with options",
+			config: AgentConfig{
+				Provider: "claude",
+				Prompt:   "Test",
+				Options: map[string]any{
+					"model":       "claude-sonnet-4-20250514",
+					"max_tokens":  4096,
+					"temperature": 0.7,
+				},
+				OutputFormat: OutputFormatJSON,
+			},
+		},
+		{
+			name: "output_format with timeout",
+			config: AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Test",
+				Timeout:      120,
+				OutputFormat: OutputFormatText,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate(nil)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestAgentConfig_OutputFormat_DoesNotInterfereWithExistingValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  AgentConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "missing provider still fails",
+			config: AgentConfig{
+				Prompt:       "Test",
+				OutputFormat: OutputFormatJSON,
+			},
+			wantErr: true,
+			errMsg:  "provider",
+		},
+		{
+			name: "missing prompt still fails",
+			config: AgentConfig{
+				Provider:     "claude",
+				OutputFormat: OutputFormatJSON,
+			},
+			wantErr: true,
+			errMsg:  "prompt",
+		},
+		{
+			name: "negative timeout still fails",
+			config: AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Test",
+				Timeout:      -1,
+				OutputFormat: OutputFormatJSON,
+			},
+			wantErr: true,
+			errMsg:  "timeout",
+		},
+		{
+			name: "prompt and prompt_file mutual exclusivity still enforced",
+			config: AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Test",
+				PromptFile:   "test.md",
+				OutputFormat: OutputFormatJSON,
+			},
+			wantErr: true,
+			errMsg:  "mutually exclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate(nil)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAgentConfig_OutputFormat_DefaultValue(t *testing.T) {
+	config := AgentConfig{
+		Provider: "claude",
+		Prompt:   "Test prompt",
+	}
+
+	require.Equal(t, OutputFormatNone, config.OutputFormat, "default OutputFormat should be empty/none")
+
+	err := config.Validate(nil)
+	require.NoError(t, err)
+	assert.Equal(t, OutputFormatNone, config.OutputFormat, "empty output_format should remain empty after validation")
+}

--- a/internal/domain/workflow/context.go
+++ b/internal/domain/workflow/context.go
@@ -32,6 +32,7 @@ type StepState struct {
 	StartedAt   time.Time
 	CompletedAt time.Time
 	Response    map[string]any // parsed JSON response from agent steps
+	JSON        any            // parsed JSON output when output_format: json is specified (map[string]any or []any)
 	// F033: Conversation mode fields
 	Conversation       *ConversationState  // conversation history and state (nil for non-conversation steps)
 	TokensUsed         int                 // total tokens used in conversation mode

--- a/internal/domain/workflow/context_json_test.go
+++ b/internal/domain/workflow/context_json_test.go
@@ -1,0 +1,355 @@
+package workflow_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Component: T003
+// Feature: F065
+
+func TestStepState_JSONField_NilByDefault(t *testing.T) {
+	state := workflow.StepState{
+		Name:   "test-step",
+		Status: workflow.StatusPending,
+		Output: "raw output",
+	}
+
+	assert.Nil(t, state.JSON, "JSON should be nil when output_format is not specified")
+}
+
+func TestStepState_JSONField_ParsedJSONObject(t *testing.T) {
+	state := workflow.StepState{
+		Name:   "agent-step",
+		Status: workflow.StatusCompleted,
+		Output: `{"name":"alice","count":3}`,
+		JSON: map[string]any{
+			"name":  "alice",
+			"count": float64(3),
+		},
+	}
+
+	assert.NotNil(t, state.JSON)
+	jsonObj, ok := state.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any for object output")
+	assert.Equal(t, "alice", jsonObj["name"])
+	assert.Equal(t, float64(3), jsonObj["count"])
+}
+
+func TestStepState_JSONField_ParsedJSONArray(t *testing.T) {
+	state := workflow.StepState{
+		Name:   "agent-step",
+		Status: workflow.StatusCompleted,
+		Output: `[1,2,3]`,
+		JSON:   []any{float64(1), float64(2), float64(3)},
+	}
+
+	assert.NotNil(t, state.JSON)
+	arr, ok := state.JSON.([]any)
+	require.True(t, ok, "JSON should be []any for array output")
+	assert.Len(t, arr, 3)
+	assert.Equal(t, float64(1), arr[0])
+}
+
+func TestStepState_JSONField_NestedObject(t *testing.T) {
+	state := workflow.StepState{
+		Name:   "complex-agent",
+		Status: workflow.StatusCompleted,
+		JSON: map[string]any{
+			"user": map[string]any{
+				"name": "bob",
+				"age":  float64(30),
+			},
+			"status": "active",
+		},
+	}
+
+	assert.NotNil(t, state.JSON)
+	jsonObj, ok := state.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any for object output")
+	user, ok := jsonObj["user"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "bob", user["name"])
+	assert.Equal(t, float64(30), user["age"])
+}
+
+func TestStepState_JSONField_EmptyObject(t *testing.T) {
+	state := workflow.StepState{
+		Name:   "empty-json",
+		Status: workflow.StatusCompleted,
+		Output: "{}",
+		JSON:   map[string]any{},
+	}
+
+	assert.NotNil(t, state.JSON)
+	assert.Empty(t, state.JSON)
+}
+
+func TestStepState_JSONField_JSONSerialization(t *testing.T) {
+	original := workflow.StepState{
+		Name:   "json-step",
+		Status: workflow.StatusCompleted,
+		Output: `{"key":"value"}`,
+		JSON: map[string]any{
+			"key": "value",
+		},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded workflow.StepState
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.Name, decoded.Name)
+	assert.NotNil(t, decoded.JSON)
+	jsonObj, ok := decoded.JSON.(map[string]any)
+	require.True(t, ok, "JSON should deserialize as map[string]any")
+	assert.Equal(t, "value", jsonObj["key"])
+}
+
+func TestStepState_JSONField_NilSerialization(t *testing.T) {
+	state := workflow.StepState{
+		Name:   "no-json",
+		Status: workflow.StatusCompleted,
+		Output: "plain text",
+		JSON:   nil,
+	}
+
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+
+	var decoded workflow.StepState
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Nil(t, decoded.JSON)
+}
+
+func TestStepState_JSONField_ComplexTypes(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "string", value: "test"},
+		{name: "number", value: float64(42)},
+		{name: "boolean", value: true},
+		{name: "null", value: nil},
+		{name: "array", value: []any{"a", "b", "c"}},
+		{name: "nested_map", value: map[string]any{"inner": "value"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := workflow.StepState{
+				Name:   "type-test",
+				Status: workflow.StatusCompleted,
+				JSON: map[string]any{
+					"field": tt.value,
+				},
+			}
+
+			assert.NotNil(t, state.JSON)
+			jsonObj, ok := state.JSON.(map[string]any)
+			require.True(t, ok, "JSON should be map[string]any")
+			assert.Equal(t, tt.value, jsonObj["field"])
+		})
+	}
+}
+
+func TestStepState_JSONField_ExecutionContextIntegration(t *testing.T) {
+	ctx := workflow.NewExecutionContext("test-id", "test-workflow")
+
+	state := workflow.StepState{
+		Name:   "agent-json-step",
+		Status: workflow.StatusCompleted,
+		Output: `{"result":"success"}`,
+		JSON: map[string]any{
+			"result": "success",
+		},
+	}
+
+	ctx.SetStepState("agent-json-step", state)
+
+	retrieved, ok := ctx.GetStepState("agent-json-step")
+	require.True(t, ok)
+	assert.NotNil(t, retrieved.JSON)
+	jsonObj, ok := retrieved.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any")
+	assert.Equal(t, "success", jsonObj["result"])
+}
+
+func TestStepState_JSONField_MixedStepsInContext(t *testing.T) {
+	ctx := workflow.NewExecutionContext("test-id", "mixed-workflow")
+
+	// Step with no JSON (output_format not specified)
+	shellStep := workflow.StepState{
+		Name:   "shell-command",
+		Status: workflow.StatusCompleted,
+		Output: "plain output",
+		JSON:   nil,
+	}
+
+	// Step with JSON (output_format: json)
+	jsonStep := workflow.StepState{
+		Name:   "agent-json",
+		Status: workflow.StatusCompleted,
+		Output: `{"status":"ok"}`,
+		JSON: map[string]any{
+			"status": "ok",
+		},
+	}
+
+	// Step with text output_format (JSON is nil)
+	textStep := workflow.StepState{
+		Name:   "agent-text",
+		Status: workflow.StatusCompleted,
+		Output: "cleaned text output",
+		JSON:   nil,
+	}
+
+	ctx.SetStepState("shell-command", shellStep)
+	ctx.SetStepState("agent-json", jsonStep)
+	ctx.SetStepState("agent-text", textStep)
+
+	shell, ok := ctx.GetStepState("shell-command")
+	require.True(t, ok)
+	assert.Nil(t, shell.JSON)
+
+	agentJSON, ok := ctx.GetStepState("agent-json")
+	require.True(t, ok)
+	assert.NotNil(t, agentJSON.JSON)
+	jsonObj, ok := agentJSON.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any")
+	assert.Equal(t, "ok", jsonObj["status"])
+
+	text, ok := ctx.GetStepState("agent-text")
+	require.True(t, ok)
+	assert.Nil(t, text.JSON)
+}
+
+func TestStepState_JSONField_LargeObject(t *testing.T) {
+	largeJSON := make(map[string]any)
+	for i := 0; i < 100; i++ {
+		largeJSON[string(rune('a'+i%26))+string(rune('0'+i/26))] = float64(i)
+	}
+
+	state := workflow.StepState{
+		Name:   "large-json",
+		Status: workflow.StatusCompleted,
+		JSON:   largeJSON,
+	}
+
+	assert.NotNil(t, state.JSON)
+	jsonObj, ok := state.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any")
+	assert.Len(t, jsonObj, 100)
+}
+
+func TestStepState_JSONField_DeepNesting(t *testing.T) {
+	deepJSON := map[string]any{
+		"level1": map[string]any{
+			"level2": map[string]any{
+				"level3": map[string]any{
+					"level4": map[string]any{
+						"value": "deep",
+					},
+				},
+			},
+		},
+	}
+
+	state := workflow.StepState{
+		Name:   "deep-nested",
+		Status: workflow.StatusCompleted,
+		JSON:   deepJSON,
+	}
+
+	assert.NotNil(t, state.JSON)
+	jsonObj, ok := state.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any")
+	level1, ok := jsonObj["level1"].(map[string]any)
+	require.True(t, ok)
+	level2, ok := level1["level2"].(map[string]any)
+	require.True(t, ok)
+	level3, ok := level2["level3"].(map[string]any)
+	require.True(t, ok)
+	level4, ok := level3["level4"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "deep", level4["value"])
+}
+
+func TestStepState_JSONField_SpecialCharacters(t *testing.T) {
+	state := workflow.StepState{
+		Name:   "special-chars",
+		Status: workflow.StatusCompleted,
+		JSON: map[string]any{
+			"unicode":   "Hello 世界",
+			"emoji":     "🚀",
+			"escaped":   "line1\nline2\ttab",
+			"quotes":    `"quoted"`,
+			"backslash": `path\to\file`,
+		},
+	}
+
+	jsonObj, ok := state.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any")
+	assert.Equal(t, "Hello 世界", jsonObj["unicode"])
+	assert.Equal(t, "🚀", jsonObj["emoji"])
+	assert.Equal(t, "line1\nline2\ttab", jsonObj["escaped"])
+}
+
+func TestStepState_JSONField_NumberTypes(t *testing.T) {
+	state := workflow.StepState{
+		Name:   "numbers",
+		Status: workflow.StatusCompleted,
+		JSON: map[string]any{
+			"integer":  float64(42),
+			"negative": float64(-100),
+			"decimal":  3.14159,
+			"zero":     float64(0),
+			"large":    float64(1e10),
+		},
+	}
+
+	jsonObj, ok := state.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any")
+	assert.Equal(t, float64(42), jsonObj["integer"])
+	assert.Equal(t, float64(-100), jsonObj["negative"])
+	assert.Equal(t, 3.14159, jsonObj["decimal"])
+	assert.Equal(t, float64(0), jsonObj["zero"])
+	assert.Equal(t, float64(1e10), jsonObj["large"])
+}
+
+func TestStepState_JSONField_ArrayTypes(t *testing.T) {
+	state := workflow.StepState{
+		Name:   "arrays",
+		Status: workflow.StatusCompleted,
+		JSON: map[string]any{
+			"strings": []any{"a", "b", "c"},
+			"numbers": []any{float64(1), float64(2), float64(3)},
+			"mixed":   []any{"text", float64(42), true, nil},
+			"empty":   []any{},
+			"nested":  []any{[]any{float64(1), float64(2)}, []any{float64(3), float64(4)}},
+		},
+	}
+
+	jsonObj, ok := state.JSON.(map[string]any)
+	require.True(t, ok, "JSON should be map[string]any")
+
+	strArr, ok := jsonObj["strings"].([]any)
+	require.True(t, ok)
+	assert.Equal(t, "a", strArr[0])
+
+	mixedArr, ok := jsonObj["mixed"].([]any)
+	require.True(t, ok)
+	assert.Equal(t, "text", mixedArr[0])
+	assert.Equal(t, float64(42), mixedArr[1])
+	assert.Equal(t, true, mixedArr[2])
+	assert.Nil(t, mixedArr[3])
+}

--- a/internal/domain/workflow/dry_run.go
+++ b/internal/domain/workflow/dry_run.go
@@ -81,4 +81,5 @@ type DryRunAgent struct {
 	CLICommand     string
 	Options        map[string]any
 	Timeout        int
+	OutputFormat   OutputFormat
 }

--- a/internal/domain/workflow/dry_run_output_format_test.go
+++ b/internal/domain/workflow/dry_run_output_format_test.go
@@ -1,0 +1,269 @@
+package workflow
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Feature: F065
+// Component: T004
+// Tests: OutputFormat field in DryRunAgent struct
+
+func TestDryRunAgent_OutputFormat_FieldExists(t *testing.T) {
+	agent := DryRunAgent{
+		Provider:       "claude",
+		ResolvedPrompt: "Analyze this code",
+		CLICommand:     "claude agent -p 'prompt'",
+		Options: map[string]any{
+			"model": "claude-sonnet-4-20250514",
+		},
+		Timeout:      300,
+		OutputFormat: OutputFormatJSON,
+	}
+
+	assert.Equal(t, OutputFormatJSON, agent.OutputFormat)
+}
+
+func TestDryRunAgent_OutputFormat_AllValidFormats(t *testing.T) {
+	tests := []struct {
+		name   string
+		format OutputFormat
+	}{
+		{
+			name:   "none/empty format",
+			format: OutputFormatNone,
+		},
+		{
+			name:   "json format",
+			format: OutputFormatJSON,
+		},
+		{
+			name:   "text format",
+			format: OutputFormatText,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agent := DryRunAgent{
+				Provider:       "claude",
+				ResolvedPrompt: "Test prompt",
+				OutputFormat:   tt.format,
+			}
+
+			assert.Equal(t, tt.format, agent.OutputFormat)
+		})
+	}
+}
+
+func TestDryRunAgent_OutputFormat_JSONSerialization(t *testing.T) {
+	tests := []struct {
+		name         string
+		agent        DryRunAgent
+		expectedJSON string
+	}{
+		{
+			name: "with json format",
+			agent: DryRunAgent{
+				Provider:       "claude",
+				ResolvedPrompt: "Extract JSON from code",
+				CLICommand:     "claude agent -p 'prompt'",
+				Timeout:        120,
+				OutputFormat:   OutputFormatJSON,
+			},
+			expectedJSON: `{"Provider":"claude","ResolvedPrompt":"Extract JSON from code","CLICommand":"claude agent -p 'prompt'","Options":null,"Timeout":120,"OutputFormat":"json"}`,
+		},
+		{
+			name: "with text format",
+			agent: DryRunAgent{
+				Provider:       "gemini",
+				ResolvedPrompt: "Generate text",
+				CLICommand:     "gemini agent -p 'prompt'",
+				Timeout:        60,
+				OutputFormat:   OutputFormatText,
+			},
+			expectedJSON: `{"Provider":"gemini","ResolvedPrompt":"Generate text","CLICommand":"gemini agent -p 'prompt'","Options":null,"Timeout":60,"OutputFormat":"text"}`,
+		},
+		{
+			name: "with empty format - backward compatibility",
+			agent: DryRunAgent{
+				Provider:       "claude",
+				ResolvedPrompt: "Default behavior",
+				CLICommand:     "claude agent -p 'prompt'",
+				Timeout:        300,
+				OutputFormat:   OutputFormatNone,
+			},
+			expectedJSON: `{"Provider":"claude","ResolvedPrompt":"Default behavior","CLICommand":"claude agent -p 'prompt'","Options":null,"Timeout":300,"OutputFormat":""}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonBytes, err := json.Marshal(tt.agent)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.expectedJSON, string(jsonBytes))
+		})
+	}
+}
+
+func TestDryRunAgent_OutputFormat_JSONDeserialization(t *testing.T) {
+	tests := []struct {
+		name           string
+		jsonInput      string
+		expectedFormat OutputFormat
+	}{
+		{
+			name:           "deserialize json format",
+			jsonInput:      `{"Provider":"claude","ResolvedPrompt":"test","CLICommand":"cmd","Timeout":300,"OutputFormat":"json"}`,
+			expectedFormat: OutputFormatJSON,
+		},
+		{
+			name:           "deserialize text format",
+			jsonInput:      `{"Provider":"claude","ResolvedPrompt":"test","CLICommand":"cmd","Timeout":300,"OutputFormat":"text"}`,
+			expectedFormat: OutputFormatText,
+		},
+		{
+			name:           "deserialize empty format",
+			jsonInput:      `{"Provider":"claude","ResolvedPrompt":"test","CLICommand":"cmd","Timeout":300,"OutputFormat":""}`,
+			expectedFormat: OutputFormatNone,
+		},
+		{
+			name:           "missing OutputFormat field defaults to empty",
+			jsonInput:      `{"Provider":"claude","ResolvedPrompt":"test","CLICommand":"cmd","Timeout":300}`,
+			expectedFormat: OutputFormatNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var agent DryRunAgent
+			err := json.Unmarshal([]byte(tt.jsonInput), &agent)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedFormat, agent.OutputFormat)
+		})
+	}
+}
+
+func TestDryRunAgent_OutputFormat_InDryRunStep(t *testing.T) {
+	step := DryRunStep{
+		Name:        "analyze_code",
+		Type:        StepTypeAgent,
+		Description: "Analyze code with agent",
+		Agent: &DryRunAgent{
+			Provider:       "claude",
+			ResolvedPrompt: "Analyze: {{inputs.code}}",
+			CLICommand:     "claude agent -p 'Analyze: test.go'",
+			Options: map[string]any{
+				"model":      "claude-sonnet-4-20250514",
+				"max_tokens": 4096,
+			},
+			Timeout:      180,
+			OutputFormat: OutputFormatJSON,
+		},
+	}
+
+	require.NotNil(t, step.Agent)
+	assert.Equal(t, OutputFormatJSON, step.Agent.OutputFormat)
+}
+
+func TestDryRunAgent_OutputFormat_InCompletePlan(t *testing.T) {
+	plan := DryRunPlan{
+		WorkflowName: "analyze-workflow",
+		Description:  "Workflow with agent output formats",
+		Inputs: map[string]DryRunInput{
+			"code_path": {
+				Name:     "code_path",
+				Value:    "src/main.go",
+				Required: true,
+			},
+		},
+		Steps: []DryRunStep{
+			{
+				Name:        "extract_json",
+				Type:        StepTypeAgent,
+				Description: "Extract JSON structure",
+				Agent: &DryRunAgent{
+					Provider:       "claude",
+					ResolvedPrompt: "Extract JSON from src/main.go",
+					CLICommand:     "claude agent -p 'prompt'",
+					Timeout:        120,
+					OutputFormat:   OutputFormatJSON,
+				},
+			},
+			{
+				Name:        "generate_summary",
+				Type:        StepTypeAgent,
+				Description: "Generate plain text summary",
+				Agent: &DryRunAgent{
+					Provider:       "gemini",
+					ResolvedPrompt: "Summarize code",
+					CLICommand:     "gemini agent -p 'prompt'",
+					Timeout:        60,
+					OutputFormat:   OutputFormatText,
+				},
+			},
+			{
+				Name:        "legacy_step",
+				Type:        StepTypeAgent,
+				Description: "Legacy step without format",
+				Agent: &DryRunAgent{
+					Provider:       "claude",
+					ResolvedPrompt: "Old style prompt",
+					CLICommand:     "claude agent -p 'prompt'",
+					Timeout:        300,
+					OutputFormat:   OutputFormatNone,
+				},
+			},
+		},
+	}
+
+	jsonBytes, err := json.Marshal(plan)
+	require.NoError(t, err)
+
+	var decoded DryRunPlan
+	err = json.Unmarshal(jsonBytes, &decoded)
+	require.NoError(t, err)
+
+	require.Len(t, decoded.Steps, 3)
+	assert.Equal(t, OutputFormatJSON, decoded.Steps[0].Agent.OutputFormat)
+	assert.Equal(t, OutputFormatText, decoded.Steps[1].Agent.OutputFormat)
+	assert.Equal(t, OutputFormatNone, decoded.Steps[2].Agent.OutputFormat)
+}
+
+func TestDryRunAgent_OutputFormat_WithOptions(t *testing.T) {
+	agent := DryRunAgent{
+		Provider:       "claude",
+		ResolvedPrompt: "Complex prompt with {{inputs.data}}",
+		CLICommand:     "claude agent -p 'prompt' --model claude-sonnet-4-20250514",
+		Options: map[string]any{
+			"model":       "claude-sonnet-4-20250514",
+			"temperature": 0.7,
+			"max_tokens":  4096,
+			"top_p":       0.9,
+		},
+		Timeout:      240,
+		OutputFormat: OutputFormatJSON,
+	}
+
+	jsonBytes, err := json.Marshal(agent)
+	require.NoError(t, err)
+
+	var decoded DryRunAgent
+	err = json.Unmarshal(jsonBytes, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, OutputFormatJSON, decoded.OutputFormat)
+	assert.Equal(t, "claude", decoded.Provider)
+	assert.Equal(t, 240, decoded.Timeout)
+	assert.NotNil(t, decoded.Options)
+	assert.Equal(t, "claude-sonnet-4-20250514", decoded.Options["model"])
+}
+
+func TestDryRunAgent_OutputFormat_ZeroValue(t *testing.T) {
+	var agent DryRunAgent
+
+	assert.Equal(t, OutputFormatNone, agent.OutputFormat, "zero value should be empty/none")
+}

--- a/internal/infrastructure/repository/yaml_mapper.go
+++ b/internal/infrastructure/repository/yaml_mapper.go
@@ -429,6 +429,7 @@ func mapAgentConfigFlat(y *yamlStep) *workflow.AgentConfig {
 		SystemPrompt:  y.SystemPrompt,
 		InitialPrompt: y.InitialPrompt,
 		Conversation:  mapConversationConfig(y.Conversation),
+		OutputFormat:  workflow.OutputFormat(y.OutputFormat),
 		// Timeout is handled separately via step.Timeout
 		Command: "", // Not supported in flat structure - stub
 	}

--- a/internal/infrastructure/repository/yaml_mapper_output_format_test.go
+++ b/internal/infrastructure/repository/yaml_mapper_output_format_test.go
@@ -1,0 +1,436 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Feature: F065 - Output Format for Agent Steps
+
+// mapAgentConfigFlat Tests - OutputFormat Happy Path
+
+func TestMapAgentConfigFlat_OutputFormat_HappyPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		yamlStep yamlStep
+		want     *workflow.AgentConfig
+	}{
+		{
+			name: "output format json",
+			yamlStep: yamlStep{
+				Provider:     "claude",
+				Prompt:       "Generate JSON response",
+				OutputFormat: "json",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Generate JSON response",
+				OutputFormat: workflow.OutputFormat("json"),
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "output format text",
+			yamlStep: yamlStep{
+				Provider:     "claude",
+				Prompt:       "Generate text response",
+				OutputFormat: "text",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Generate text response",
+				OutputFormat: workflow.OutputFormat("text"),
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "output format json with codex provider",
+			yamlStep: yamlStep{
+				Provider:     "codex",
+				Prompt:       "Extract data as JSON",
+				OutputFormat: "json",
+				Options: map[string]any{
+					"model":       "gpt-4",
+					"temperature": 0.3,
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:     "codex",
+				Prompt:       "Extract data as JSON",
+				OutputFormat: workflow.OutputFormat("json"),
+				Options: map[string]any{
+					"model":       "gpt-4",
+					"temperature": 0.3,
+				},
+			},
+		},
+		{
+			name: "output format text with gemini provider",
+			yamlStep: yamlStep{
+				Provider:     "gemini",
+				Prompt:       "Explain concept",
+				OutputFormat: "text",
+				Options: map[string]any{
+					"model": "gemini-pro",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:     "gemini",
+				Prompt:       "Explain concept",
+				OutputFormat: workflow.OutputFormat("text"),
+				Options: map[string]any{
+					"model": "gemini-pro",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapAgentConfigFlat(&tt.yamlStep)
+
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want.Provider, got.Provider)
+			assert.Equal(t, tt.want.Prompt, got.Prompt)
+			assert.Equal(t, tt.want.OutputFormat, got.OutputFormat)
+			assert.Equal(t, tt.want.Options, got.Options)
+		})
+	}
+}
+
+// mapAgentConfigFlat Tests - OutputFormat Edge Cases
+
+func TestMapAgentConfigFlat_OutputFormat_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		yamlStep yamlStep
+		want     *workflow.AgentConfig
+	}{
+		{
+			name: "output format not specified defaults to empty",
+			yamlStep: yamlStep{
+				Provider: "claude",
+				Prompt:   "No output format",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:     "claude",
+				Prompt:       "No output format",
+				OutputFormat: workflow.OutputFormat(""),
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "output format empty string",
+			yamlStep: yamlStep{
+				Provider:     "claude",
+				Prompt:       "Empty format",
+				OutputFormat: "",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Empty format",
+				OutputFormat: workflow.OutputFormat(""),
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "output format with uppercase JSON",
+			yamlStep: yamlStep{
+				Provider:     "claude",
+				Prompt:       "Generate response",
+				OutputFormat: "JSON",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Generate response",
+				OutputFormat: workflow.OutputFormat("JSON"),
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "output format with mixed case Text",
+			yamlStep: yamlStep{
+				Provider:     "claude",
+				Prompt:       "Generate response",
+				OutputFormat: "Text",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Generate response",
+				OutputFormat: workflow.OutputFormat("Text"),
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "output format with whitespace",
+			yamlStep: yamlStep{
+				Provider:     "claude",
+				Prompt:       "Generate response",
+				OutputFormat: " json ",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Generate response",
+				OutputFormat: workflow.OutputFormat(" json "),
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "invalid output format value",
+			yamlStep: yamlStep{
+				Provider:     "claude",
+				Prompt:       "Generate response",
+				OutputFormat: "xml",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Generate response",
+				OutputFormat: workflow.OutputFormat("xml"),
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapAgentConfigFlat(&tt.yamlStep)
+
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want.Provider, got.Provider)
+			assert.Equal(t, tt.want.Prompt, got.Prompt)
+			assert.Equal(t, tt.want.OutputFormat, got.OutputFormat)
+			assert.Equal(t, tt.want.Options, got.Options)
+		})
+	}
+}
+
+// mapAgentConfigFlat Tests - OutputFormat with Other Fields
+
+func TestMapAgentConfigFlat_OutputFormat_WithPromptFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		yamlStep yamlStep
+		want     *workflow.AgentConfig
+	}{
+		{
+			name: "output format json with prompt file",
+			yamlStep: yamlStep{
+				Provider:     "claude",
+				PromptFile:   "prompts/extract-data.md",
+				OutputFormat: "json",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:     "claude",
+				PromptFile:   "prompts/extract-data.md",
+				OutputFormat: workflow.OutputFormat("json"),
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "output format text with prompt file",
+			yamlStep: yamlStep{
+				Provider:     "claude",
+				PromptFile:   "prompts/analyze.md",
+				OutputFormat: "text",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:     "claude",
+				PromptFile:   "prompts/analyze.md",
+				OutputFormat: workflow.OutputFormat("text"),
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "output format with prompt file and inline prompt",
+			yamlStep: yamlStep{
+				Provider:     "claude",
+				Prompt:       "Inline prompt",
+				PromptFile:   "prompts/base.md",
+				OutputFormat: "json",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:     "claude",
+				Prompt:       "Inline prompt",
+				PromptFile:   "prompts/base.md",
+				OutputFormat: workflow.OutputFormat("json"),
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapAgentConfigFlat(&tt.yamlStep)
+
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want.Provider, got.Provider)
+			assert.Equal(t, tt.want.Prompt, got.Prompt)
+			assert.Equal(t, tt.want.PromptFile, got.PromptFile)
+			assert.Equal(t, tt.want.OutputFormat, got.OutputFormat)
+			assert.Equal(t, tt.want.Options, got.Options)
+		})
+	}
+}
+
+func TestMapAgentConfigFlat_OutputFormat_WithConversationMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		yamlStep yamlStep
+		want     *workflow.AgentConfig
+	}{
+		{
+			name: "conversation mode with json output format",
+			yamlStep: yamlStep{
+				Provider:      "claude",
+				Mode:          "conversation",
+				SystemPrompt:  "You are a data extraction assistant",
+				InitialPrompt: "Extract entities from: {{.inputs.text}}",
+				OutputFormat:  "json",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:      "claude",
+				Mode:          "conversation",
+				SystemPrompt:  "You are a data extraction assistant",
+				InitialPrompt: "Extract entities from: {{.inputs.text}}",
+				OutputFormat:  workflow.OutputFormat("json"),
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "conversation mode with text output format",
+			yamlStep: yamlStep{
+				Provider:      "claude",
+				Mode:          "conversation",
+				SystemPrompt:  "You are a helpful assistant",
+				InitialPrompt: "Help with: {{.inputs.task}}",
+				OutputFormat:  "text",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:      "claude",
+				Mode:          "conversation",
+				SystemPrompt:  "You are a helpful assistant",
+				InitialPrompt: "Help with: {{.inputs.task}}",
+				OutputFormat:  workflow.OutputFormat("text"),
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+		{
+			name: "single mode with output format",
+			yamlStep: yamlStep{
+				Provider:     "claude",
+				Mode:         "single",
+				Prompt:       "Extract data",
+				OutputFormat: "json",
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+			want: &workflow.AgentConfig{
+				Provider:     "claude",
+				Mode:         "single",
+				Prompt:       "Extract data",
+				OutputFormat: workflow.OutputFormat("json"),
+				Options: map[string]any{
+					"model": "claude-3-5-sonnet-20241022",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapAgentConfigFlat(&tt.yamlStep)
+
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want.Provider, got.Provider)
+			assert.Equal(t, tt.want.Mode, got.Mode)
+			assert.Equal(t, tt.want.SystemPrompt, got.SystemPrompt)
+			assert.Equal(t, tt.want.InitialPrompt, got.InitialPrompt)
+			assert.Equal(t, tt.want.OutputFormat, got.OutputFormat)
+			assert.Equal(t, tt.want.Options, got.Options)
+		})
+	}
+}
+
+func TestMapAgentConfigFlat_OutputFormat_NoProvider(t *testing.T) {
+	yamlStep := yamlStep{
+		Provider:     "",
+		Prompt:       "This should be ignored",
+		OutputFormat: "json",
+		Options: map[string]any{
+			"model": "claude-3-5-sonnet-20241022",
+		},
+	}
+
+	got := mapAgentConfigFlat(&yamlStep)
+
+	assert.Nil(t, got)
+}

--- a/internal/infrastructure/repository/yaml_types.go
+++ b/internal/infrastructure/repository/yaml_types.go
@@ -65,10 +65,11 @@ type yamlStep struct {
 
 	// Agent configuration (for AI agent steps - F039)
 	// Flat structure: provider, prompt, options directly on step
-	Provider   string         `yaml:"provider"`    // agent provider: claude, codex, gemini, opencode, custom
-	Prompt     string         `yaml:"prompt"`      // prompt template with {{inputs.*}} and {{states.*}}
-	PromptFile string         `yaml:"prompt_file"` // path to external prompt template file
-	Options    map[string]any `yaml:"options"`     // provider-specific options (model, temperature, max_tokens, etc.)
+	Provider     string         `yaml:"provider"`      // agent provider: claude, codex, gemini, opencode, custom
+	Prompt       string         `yaml:"prompt"`        // prompt template with {{inputs.*}} and {{states.*}}
+	PromptFile   string         `yaml:"prompt_file"`   // path to external prompt template file
+	Options      map[string]any `yaml:"options"`       // provider-specific options (model, temperature, max_tokens, etc.)
+	OutputFormat string         `yaml:"output_format"` // output post-processing: json, text (F065)
 
 	// Agent conversation mode (F033) - extends agent configuration
 	Mode          string                  `yaml:"mode"`           // execution mode: "single" (default) or "conversation"

--- a/pkg/interpolation/reference.go
+++ b/pkg/interpolation/reference.go
@@ -50,6 +50,7 @@ var ValidStateProperties = map[string]bool{
 	"Status":     true,
 	"Response":   true,
 	"TokensUsed": true,
+	"JSON":       true,
 }
 
 // ValidErrorProperties lists known error properties in error hooks.

--- a/pkg/interpolation/reference_json_field_test.go
+++ b/pkg/interpolation/reference_json_field_test.go
@@ -1,0 +1,317 @@
+package interpolation_test
+
+import (
+	"testing"
+
+	"github.com/awf-project/awf/pkg/interpolation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidStateProperties_IncludesJSON verifies that the JSON field
+// is included in ValidStateProperties for F065.
+func TestValidStateProperties_IncludesJSON(t *testing.T) {
+	assert.True(t, interpolation.ValidStateProperties["JSON"],
+		"JSON field must be in ValidStateProperties for F065")
+}
+
+// TestValidStateProperties_AllFields verifies all expected fields
+// including the new JSON field are present.
+func TestValidStateProperties_AllFields(t *testing.T) {
+	expectedFields := []string{
+		"Output",
+		"Stderr",
+		"ExitCode",
+		"Status",
+		"Response",
+		"TokensUsed",
+		"JSON", // F065: new field for explicit JSON output
+	}
+
+	for _, field := range expectedFields {
+		assert.True(t, interpolation.ValidStateProperties[field],
+			"ValidStateProperties must include %s", field)
+	}
+
+	// Verify exact count - no extra fields
+	assert.Equal(t, len(expectedFields), len(interpolation.ValidStateProperties),
+		"ValidStateProperties should have exactly %d fields", len(expectedFields))
+}
+
+// TestValidStateProperties_NoLowercaseJSON verifies that lowercase
+// "json" is not accepted (Go naming conventions require uppercase).
+func TestValidStateProperties_NoLowercaseJSON(t *testing.T) {
+	assert.False(t, interpolation.ValidStateProperties["json"],
+		"lowercase 'json' should not be in ValidStateProperties")
+	assert.False(t, interpolation.ValidStateProperties["Json"],
+		"mixed-case 'Json' should not be in ValidStateProperties")
+}
+
+// TestExtractReferences_JSONField tests that JSON field references
+// are correctly parsed from templates.
+func TestExtractReferences_JSONField(t *testing.T) {
+	tests := []struct {
+		name         string
+		template     string
+		wantType     interpolation.ReferenceType
+		wantPath     string
+		wantProperty string
+	}{
+		{
+			name:         "JSON field reference",
+			template:     "{{states.agent_step.JSON}}",
+			wantType:     interpolation.TypeStates,
+			wantPath:     "agent_step",
+			wantProperty: "JSON",
+		},
+		{
+			name:         "JSON field with nested access",
+			template:     "{{states.agent_step.JSON.name}}",
+			wantType:     interpolation.TypeStates,
+			wantPath:     "agent_step",
+			wantProperty: "JSON",
+		},
+		{
+			name:         "leading dot syntax",
+			template:     "{{.states.agent_step.JSON}}",
+			wantType:     interpolation.TypeStates,
+			wantPath:     "agent_step",
+			wantProperty: "JSON",
+		},
+		{
+			name:         "leading dot with nested access",
+			template:     "{{.states.agent_step.JSON.field}}",
+			wantType:     interpolation.TypeStates,
+			wantPath:     "agent_step",
+			wantProperty: "JSON",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			refs, err := interpolation.ExtractReferences(tt.template)
+			require.NoError(t, err)
+			require.Len(t, refs, 1, "should extract exactly one reference")
+
+			assert.Equal(t, tt.wantType, refs[0].Type)
+			assert.Equal(t, tt.wantPath, refs[0].Path)
+			assert.Equal(t, tt.wantProperty, refs[0].Property)
+		})
+	}
+}
+
+// TestExtractReferences_JSONFieldMultiple tests multiple JSON field
+// references in the same template.
+func TestExtractReferences_JSONFieldMultiple(t *testing.T) {
+	template := "user: {{.states.step1.JSON.name}}, count: {{.states.step2.JSON.count}}"
+
+	refs, err := interpolation.ExtractReferences(template)
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+
+	// First reference
+	assert.Equal(t, interpolation.TypeStates, refs[0].Type)
+	assert.Equal(t, "step1", refs[0].Path)
+	assert.Equal(t, "JSON", refs[0].Property)
+
+	// Second reference
+	assert.Equal(t, interpolation.TypeStates, refs[1].Type)
+	assert.Equal(t, "step2", refs[1].Path)
+	assert.Equal(t, "JSON", refs[1].Property)
+}
+
+// TestExtractReferences_JSONvsResponse verifies that JSON and Response
+// are treated as separate properties (both valid).
+func TestExtractReferences_JSONvsResponse(t *testing.T) {
+	tests := []struct {
+		name         string
+		template     string
+		wantProperty string
+	}{
+		{
+			name:         "Response field",
+			template:     "{{.states.step.Response.field}}",
+			wantProperty: "Response",
+		},
+		{
+			name:         "JSON field",
+			template:     "{{.states.step.JSON.field}}",
+			wantProperty: "JSON",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			refs, err := interpolation.ExtractReferences(tt.template)
+			require.NoError(t, err)
+			require.Len(t, refs, 1)
+			assert.Equal(t, tt.wantProperty, refs[0].Property)
+
+			// Verify both are valid
+			assert.True(t, interpolation.ValidStateProperties[tt.wantProperty])
+		})
+	}
+}
+
+// TestParseReference_JSONField tests low-level parsing of JSON field references.
+func TestParseReference_JSONField(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		wantType     interpolation.ReferenceType
+		wantNS       string
+		wantPath     string
+		wantProperty string
+	}{
+		{
+			name:         "states.step.JSON",
+			path:         "states.step.JSON",
+			wantType:     interpolation.TypeStates,
+			wantNS:       "states",
+			wantPath:     "step",
+			wantProperty: "JSON",
+		},
+		{
+			name:         "leading dot stripped",
+			path:         ".states.step.JSON",
+			wantType:     interpolation.TypeStates,
+			wantNS:       "states",
+			wantPath:     "step",
+			wantProperty: "JSON",
+		},
+		{
+			name:         "with nested field access",
+			path:         "states.agent_step.JSON.name",
+			wantType:     interpolation.TypeStates,
+			wantNS:       "states",
+			wantPath:     "agent_step",
+			wantProperty: "JSON", // Property is always the first field after step name
+		},
+		{
+			name:         "deeply nested JSON access",
+			path:         "states.step.JSON.level1.level2.value",
+			wantType:     interpolation.TypeStates,
+			wantNS:       "states",
+			wantPath:     "step",
+			wantProperty: "JSON",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref := interpolation.ParseReference(tt.path)
+
+			assert.Equal(t, tt.wantType, ref.Type)
+			assert.Equal(t, tt.wantNS, ref.Namespace)
+			assert.Equal(t, tt.wantPath, ref.Path)
+			assert.Equal(t, tt.wantProperty, ref.Property)
+		})
+	}
+}
+
+// TestExtractReferences_JSONFieldEdgeCases tests edge cases for JSON field parsing.
+func TestExtractReferences_JSONFieldEdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		wantLen  int
+		wantErr  bool
+	}{
+		{
+			name:     "JSON in plain text (not a reference)",
+			template: "this JSON should be parsed",
+			wantLen:  0,
+		},
+		{
+			name:     "JSON without states namespace",
+			template: "{{JSON.field}}",
+			wantLen:  1,
+			// Should be parsed as unknown type
+		},
+		{
+			name:     "lowercase json should still parse (but won't validate)",
+			template: "{{.states.step.json}}",
+			wantLen:  1,
+		},
+		{
+			name:     "JSON in different namespaces",
+			template: "{{.states.step.JSON}} and {{.inputs.JSON}}",
+			wantLen:  2,
+		},
+		{
+			name:     "empty JSON reference",
+			template: "{{.states..JSON}}",
+			wantLen:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			refs, err := interpolation.ExtractReferences(tt.template)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, refs, tt.wantLen)
+		})
+	}
+}
+
+// TestExtractReferences_RealWorldJSONUsage tests realistic JSON field usage
+// patterns from actual workflows.
+func TestExtractReferences_RealWorldJSONUsage(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		wantLen  int
+	}{
+		{
+			name:     "shell command with JSON field",
+			template: `curl -X POST -d '{"name": "{{.states.agent_step.JSON.name}}"}' https://api.example.com`,
+			wantLen:  1,
+		},
+		{
+			name:     "multiline script with JSON access",
+			template: "#!/bin/bash\nNAME={{.states.agent_step.JSON.name}}\nCOUNT={{.states.agent_step.JSON.count}}\necho \"Processing $NAME with $COUNT items\"",
+			wantLen:  2,
+		},
+		{
+			name:     "JSON output construction from JSON field",
+			template: `{"workflow": "{{.workflow.Name}}", "result": {"name": "{{.states.agent_step.JSON.name}}", "status": "{{.states.agent_step.JSON.status}}"}}`,
+			wantLen:  3,
+		},
+		{
+			name:     "conditional based on JSON field",
+			template: `{{if .states.agent_step.JSON.enabled}}ENABLED=1{{else}}ENABLED=0{{end}}`,
+			wantLen:  3, // "if", "else", "end" are each parsed as separate references
+		},
+		{
+			name:     "combining JSON and Response fields",
+			template: "explicit: {{.states.step1.JSON.value}}, auto: {{.states.step2.Response.value}}",
+			wantLen:  2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			refs, err := interpolation.ExtractReferences(tt.template)
+			require.NoError(t, err)
+			assert.Len(t, refs, tt.wantLen)
+		})
+	}
+}
+
+// TestCategorizeNamespace_JSONNotANamespace verifies that "JSON" itself
+// is not a namespace, only a property of states.
+func TestCategorizeNamespace_JSONNotANamespace(t *testing.T) {
+	refType := interpolation.CategorizeNamespace("JSON")
+	assert.Equal(t, interpolation.TypeUnknown, refType,
+		"JSON should not be recognized as a namespace")
+
+	refType = interpolation.CategorizeNamespace("json")
+	assert.Equal(t, interpolation.TypeUnknown, refType,
+		"json (lowercase) should not be recognized as a namespace")
+}

--- a/pkg/interpolation/reference_test.go
+++ b/pkg/interpolation/reference_test.go
@@ -403,9 +403,9 @@ func TestValidationMaps(t *testing.T) {
 		{
 			name:           "ValidStateProperties",
 			validMap:       interpolation.ValidStateProperties,
-			expectedKeys:   []string{"Output", "Stderr", "ExitCode", "Status", "Response", "TokensUsed"},
+			expectedKeys:   []string{"Output", "Stderr", "ExitCode", "Status", "Response", "TokensUsed", "JSON"},
 			invalidKeys:    []string{"stdout", "result", ""},
-			forbiddenLower: []string{"output", "stderr", "exit_code", "status", "response", "tokens"},
+			forbiddenLower: []string{"output", "stderr", "exit_code", "status", "response", "tokens", "json"},
 		},
 		{
 			name:           "ValidErrorProperties",
@@ -665,9 +665,9 @@ func TestValidationMaps_Comprehensive(t *testing.T) {
 		},
 		"ValidStateProperties": {
 			validMap:   interpolation.ValidStateProperties,
-			required:   []string{"Output", "Stderr", "ExitCode", "Status", "Response", "TokensUsed"},
+			required:   []string{"Output", "Stderr", "ExitCode", "Status", "Response", "TokensUsed", "JSON"},
 			invalid:    []string{"stdout", "result", ""},
-			deprecated: []string{"output", "stderr", "exit_code", "status", "response", "tokensused"},
+			deprecated: []string{"output", "stderr", "exit_code", "status", "response", "tokensused", "json"},
 		},
 		"ValidErrorProperties": {
 			validMap:   interpolation.ValidErrorProperties,

--- a/pkg/interpolation/resolver.go
+++ b/pkg/interpolation/resolver.go
@@ -42,6 +42,7 @@ type StepStateData struct {
 	Status     string
 	Response   map[string]any // parsed JSON response from agent steps
 	TokensUsed int            // total tokens used from agent steps
+	JSON       any            // explicit JSON output from output_format (map[string]any or []any)
 }
 
 // WorkflowData holds workflow metadata for interpolation.

--- a/pkg/interpolation/resolver_json_field_test.go
+++ b/pkg/interpolation/resolver_json_field_test.go
@@ -1,0 +1,418 @@
+package interpolation_test
+
+import (
+	"testing"
+
+	"github.com/awf-project/awf/pkg/interpolation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTemplateResolver_StepStateDataJSON tests the JSON field on StepStateData
+// for F065: Output Format for Agent Steps.
+// This field stores explicitly parsed JSON output (separate from auto-parsed Response field).
+func TestTemplateResolver_StepStateDataJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		states   map[string]interpolation.StepStateData
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "JSON field with simple string value",
+			template: "name: {{.states.agent_step.JSON.name}}",
+			states: map[string]interpolation.StepStateData{
+				"agent_step": {
+					Output: `{"name":"alice","count":3}`,
+					JSON: map[string]any{
+						"name": "alice",
+					},
+				},
+			},
+			want: "name: alice",
+		},
+		{
+			name:     "JSON field with numeric value",
+			template: "count: {{.states.agent_step.JSON.count}}",
+			states: map[string]interpolation.StepStateData{
+				"agent_step": {
+					Output: `{"name":"alice","count":3}`,
+					JSON: map[string]any{
+						"count": 3,
+					},
+				},
+			},
+			want: "count: 3",
+		},
+		{
+			name:     "JSON field with multiple fields",
+			template: "user: {{.states.agent_step.JSON.name}}, count: {{.states.agent_step.JSON.count}}",
+			states: map[string]interpolation.StepStateData{
+				"agent_step": {
+					Output: `{"name":"alice","count":3}`,
+					JSON: map[string]any{
+						"name":  "alice",
+						"count": 3,
+					},
+				},
+			},
+			want: "user: alice, count: 3",
+		},
+		{
+			name:     "JSON field with nested objects",
+			template: "city: {{.states.agent_step.JSON.address.city}}",
+			states: map[string]interpolation.StepStateData{
+				"agent_step": {
+					Output: `{"address":{"city":"Seattle","zipcode":"98101"}}`,
+					JSON: map[string]any{
+						"address": map[string]any{
+							"city":    "Seattle",
+							"zipcode": "98101",
+						},
+					},
+				},
+			},
+			want: "city: Seattle",
+		},
+		{
+			name:     "JSON field with deeply nested objects",
+			template: "value: {{.states.agent_step.JSON.level1.level2.value}}",
+			states: map[string]interpolation.StepStateData{
+				"agent_step": {
+					Output: `{"level1":{"level2":{"value":"deep"}}}`,
+					JSON: map[string]any{
+						"level1": map[string]any{
+							"level2": map[string]any{
+								"value": "deep",
+							},
+						},
+					},
+				},
+			},
+			want: "value: deep",
+		},
+		{
+			name:     "JSON field is nil when not set",
+			template: "{{.states.agent_step.Output}}",
+			states: map[string]interpolation.StepStateData{
+				"agent_step": {
+					Output: "plain output",
+					JSON:   nil,
+				},
+			},
+			want: "plain output",
+		},
+		{
+			name:     "JSON field is empty map",
+			template: "output: {{.states.agent_step.Output}}",
+			states: map[string]interpolation.StepStateData{
+				"agent_step": {
+					Output: "{}",
+					JSON:   map[string]any{},
+				},
+			},
+			want: "output: {}",
+		},
+		{
+			name:     "JSON field with boolean values",
+			template: "enabled: {{.states.agent_step.JSON.enabled}}, active: {{.states.agent_step.JSON.active}}",
+			states: map[string]interpolation.StepStateData{
+				"agent_step": {
+					Output: `{"enabled":true,"active":false}`,
+					JSON: map[string]any{
+						"enabled": true,
+						"active":  false,
+					},
+				},
+			},
+			want: "enabled: true, active: false",
+		},
+		{
+			name:     "JSON field with float values",
+			template: "score: {{.states.agent_step.JSON.score}}",
+			states: map[string]interpolation.StepStateData{
+				"agent_step": {
+					Output: `{"score":98.5}`,
+					JSON: map[string]any{
+						"score": 98.5,
+					},
+				},
+			},
+			want: "score: 98.5",
+		},
+		{
+			name:     "JSON field separate from Response field",
+			template: "json_name: {{.states.agent_step.JSON.name}}, response_role: {{.states.agent_step.Response.role}}",
+			states: map[string]interpolation.StepStateData{
+				"agent_step": {
+					Output: `{"name":"alice"}`,
+					JSON: map[string]any{
+						"name": "alice",
+					},
+					Response: map[string]any{
+						"role": "admin",
+					},
+				},
+			},
+			want: "json_name: alice, response_role: admin",
+		},
+		{
+			name:     "accessing non-existent JSON field should error",
+			template: "{{.states.agent_step.JSON.nonexistent}}",
+			states: map[string]interpolation.StepStateData{
+				"agent_step": {
+					Output: `{"name":"alice"}`,
+					JSON: map[string]any{
+						"name": "alice",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:     "accessing JSON on step without JSON field should error",
+			template: "{{.states.command_step.JSON.name}}",
+			states: map[string]interpolation.StepStateData{
+				"command_step": {
+					Output: "plain command output",
+					JSON:   nil,
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	resolver := interpolation.NewTemplateResolver()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			ctx.States = tt.states
+
+			got, err := resolver.Resolve(tt.template, ctx)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestTemplateResolver_JSONFieldWithArrays tests JSON field access for array outputs
+// (F065 US2: array elements accessible via index notation).
+// Note: This test documents the EXPECTED behavior once array handling is implemented.
+// Arrays in JSON will be stored as []any and need proper handling in the execution layer.
+func TestTemplateResolver_JSONFieldWithArrays(t *testing.T) {
+	t.Skip("STUB: Array handling in JSON field not yet implemented - needs execution layer support")
+
+	tests := []struct {
+		name     string
+		template string
+		states   map[string]interpolation.StepStateData
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "JSON field with array stored as slice",
+			template: "first: {{index .states.agent_step.JSON.items 0}}",
+			states: map[string]interpolation.StepStateData{
+				"agent_step": {
+					Output: `{"items":["alice","bob","charlie"]}`,
+					JSON: map[string]any{
+						"items": []any{"alice", "bob", "charlie"},
+					},
+				},
+			},
+			want: "first: alice",
+		},
+		{
+			name:     "top-level array in JSON field",
+			template: "count: {{len .states.agent_step.JSONArray}}",
+			states: map[string]interpolation.StepStateData{
+				"agent_step": {
+					Output: `["alice","bob","charlie"]`,
+					// When top-level is array, needs special handling
+					// This is a stub for future implementation
+				},
+			},
+			want:    "count: 3",
+			wantErr: false,
+		},
+	}
+
+	resolver := interpolation.NewTemplateResolver()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			ctx.States = tt.states
+
+			got, err := resolver.Resolve(tt.template, ctx)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestTemplateResolver_JSONFieldBackwardCompatibility tests that existing workflows
+// without JSON field continue to work (F065 US4).
+func TestTemplateResolver_JSONFieldBackwardCompatibility(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		states   map[string]interpolation.StepStateData
+		want     string
+	}{
+		{
+			name:     "step without JSON field uses Output",
+			template: "result: {{.states.step.Output}}",
+			states: map[string]interpolation.StepStateData{
+				"step": {
+					Output: "raw output with markdown fences",
+					JSON:   nil, // JSON not populated
+				},
+			},
+			want: "result: raw output with markdown fences",
+		},
+		{
+			name:     "step with Response but no JSON",
+			template: "name: {{.states.step.Response.name}}",
+			states: map[string]interpolation.StepStateData{
+				"step": {
+					Output: "success",
+					Response: map[string]any{
+						"name": "alice",
+					},
+					JSON: nil, // JSON not populated
+				},
+			},
+			want: "name: alice",
+		},
+		{
+			name:     "multiple steps without JSON field",
+			template: "{{.states.step1.Output}} then {{.states.step2.Output}}",
+			states: map[string]interpolation.StepStateData{
+				"step1": {Output: "first", JSON: nil},
+				"step2": {Output: "second", JSON: nil},
+			},
+			want: "first then second",
+		},
+	}
+
+	resolver := interpolation.NewTemplateResolver()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := interpolation.NewContext()
+			ctx.States = tt.states
+
+			got, err := resolver.Resolve(tt.template, ctx)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestTemplateResolver_JSONFieldComplexScenarios tests complex use cases
+// combining JSON field with other interpolation features.
+func TestTemplateResolver_JSONFieldComplexScenarios(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		ctx      func() *interpolation.Context
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "JSON field with workflow metadata",
+			template: "workflow {{.workflow.Name}} processed {{.states.agent_step.JSON.count}} items",
+			ctx: func() *interpolation.Context {
+				c := interpolation.NewContext()
+				c.Workflow.Name = "test-workflow"
+				c.States = map[string]interpolation.StepStateData{
+					"agent_step": {
+						JSON: map[string]any{"count": 42},
+					},
+				}
+				return c
+			},
+			want: "workflow test-workflow processed 42 items",
+		},
+		{
+			name:     "JSON field with inputs",
+			template: "user {{.inputs.username}} has role {{.states.agent_step.JSON.role}}",
+			ctx: func() *interpolation.Context {
+				c := interpolation.NewContext()
+				c.Inputs = map[string]any{"username": "alice"}
+				c.States = map[string]interpolation.StepStateData{
+					"agent_step": {
+						JSON: map[string]any{"role": "admin"},
+					},
+				}
+				return c
+			},
+			want: "user alice has role admin",
+		},
+		{
+			name:     "multiple steps with JSON fields",
+			template: "step1: {{.states.step1.JSON.name}}, step2: {{.states.step2.JSON.count}}",
+			ctx: func() *interpolation.Context {
+				c := interpolation.NewContext()
+				c.States = map[string]interpolation.StepStateData{
+					"step1": {
+						JSON: map[string]any{"name": "alice"},
+					},
+					"step2": {
+						JSON: map[string]any{"count": 3},
+					},
+				}
+				return c
+			},
+			want: "step1: alice, step2: 3",
+		},
+		{
+			name:     "JSON field in conditional template",
+			template: `{{if .states.agent_step.JSON.enabled}}feature enabled{{else}}feature disabled{{end}}`,
+			ctx: func() *interpolation.Context {
+				c := interpolation.NewContext()
+				c.States = map[string]interpolation.StepStateData{
+					"agent_step": {
+						JSON: map[string]any{"enabled": true},
+					},
+				}
+				return c
+			},
+			want: "feature enabled",
+		},
+	}
+
+	resolver := interpolation.NewTemplateResolver()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.ctx()
+
+			got, err := resolver.Resolve(tt.template, ctx)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/output/format.go
+++ b/pkg/output/format.go
@@ -1,0 +1,66 @@
+// Package output provides format-specific post-processing for agent step outputs.
+// It supports JSON validation/parsing and markdown code fence stripping.
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+var (
+	codeFenceRegex = regexp.MustCompile(`(?s)^\s*` + "```" + `[a-zA-Z0-9]*\r?\n(.*?)\r?\n` + "```")
+	fenceMarker    = regexp.MustCompile("```")
+	endsWithFence  = regexp.MustCompile(`\n` + "```" + `\s*$`)
+)
+
+// StripCodeFences removes outermost markdown code fences from input.
+// Returns the inner content or the original input if no fences found.
+func StripCodeFences(input string) string {
+	matches := codeFenceRegex.FindStringSubmatch(input)
+	if len(matches) > 1 {
+		content := matches[1]
+		fenceCount := len(fenceMarker.FindAllString(content, -1))
+		if fenceCount > 0 && endsWithFence.MatchString(input) {
+			greedyRegex := regexp.MustCompile(`(?s)^\s*` + "```" + `[a-zA-Z0-9]*\r?\n(.*)\r?\n` + "```" + `\s*$`)
+			greedyMatches := greedyRegex.FindStringSubmatch(input)
+			if len(greedyMatches) > 1 {
+				return greedyMatches[1]
+			}
+		}
+		return content
+	}
+	return input
+}
+
+// ValidateAndParseJSON validates JSON syntax and parses into map or slice.
+// Returns parsed data as map[string]any or []any, or error if invalid.
+func ValidateAndParseJSON(input string) (any, error) {
+	var result any
+	if err := json.Unmarshal([]byte(input), &result); err != nil {
+		preview := input
+		if len(input) > 200 {
+			preview = input[:200]
+		}
+		return nil, fmt.Errorf("invalid JSON: %w (content: %s)", err, preview)
+	}
+	return result, nil
+}
+
+// ProcessOutputFormat applies format-specific processing to agent output.
+// For "json": strips fences then validates/parses JSON.
+// For "text": strips fences only.
+// For "": returns output unchanged with nil parsed data.
+func ProcessOutputFormat(output, format string) (processed string, parsed any, err error) {
+	switch format {
+	case "json":
+		processed = StripCodeFences(output)
+		parsed, err = ValidateAndParseJSON(processed)
+		return processed, parsed, err
+	case "text":
+		processed = StripCodeFences(output)
+		return processed, nil, nil
+	default:
+		return output, nil, nil
+	}
+}

--- a/pkg/output/format_test.go
+++ b/pkg/output/format_test.go
@@ -1,0 +1,480 @@
+package output_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awf-project/awf/pkg/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Feature: F065
+
+func TestStripCodeFences_NoFences(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain text without fences",
+			input: `{"key":"value"}`,
+			want:  `{"key":"value"}`,
+		},
+		{
+			name:  "multiline text without fences",
+			input: "line1\nline2\nline3",
+			want:  "line1\nline2\nline3",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "whitespace only",
+			input: "   \n  \t  ",
+			want:  "   \n  \t  ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := output.StripCodeFences(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStripCodeFences_WithFences(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "json code fence",
+			input: "```json\n{\"key\":\"value\"}\n```",
+			want:  `{"key":"value"}`,
+		},
+		{
+			name:  "bash code fence",
+			input: "```bash\necho hello\n```",
+			want:  "echo hello",
+		},
+		{
+			name:  "no language tag",
+			input: "```\ncontent here\n```",
+			want:  "content here",
+		},
+		{
+			name:  "multiline content",
+			input: "```json\n{\n  \"name\": \"alice\",\n  \"count\": 3\n}\n```",
+			want:  "{\n  \"name\": \"alice\",\n  \"count\": 3\n}",
+		},
+		{
+			name:  "leading whitespace before fence",
+			input: "  ```json\n{\"key\":\"value\"}\n```",
+			want:  `{"key":"value"}`,
+		},
+		{
+			name:  "trailing whitespace after fence",
+			input: "```json\n{\"key\":\"value\"}\n```  ",
+			want:  `{"key":"value"}`,
+		},
+		{
+			name:  "both leading and trailing whitespace",
+			input: "  ```json\n{\"key\":\"value\"}\n```  \n",
+			want:  `{"key":"value"}`,
+		},
+		{
+			name:  "empty content inside fences",
+			input: "```json\n\n```",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := output.StripCodeFences(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStripCodeFences_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "only outermost fence stripped when nested",
+			input: "```json\n```inner\ncode\n```\n```",
+			want:  "```inner\ncode\n```",
+		},
+		{
+			name:  "multiple fence blocks - only first processed",
+			input: "```json\n{\"a\":1}\n```\nsome text\n```json\n{\"b\":2}\n```",
+			want:  `{"a":1}`,
+		},
+		{
+			name:  "windows line endings CRLF",
+			input: "```json\r\n{\"key\":\"value\"}\r\n```",
+			want:  `{"key":"value"}`,
+		},
+		{
+			name:  "mixed line endings",
+			input: "```json\r\n{\"key\":\"value\"}\n```",
+			want:  `{"key":"value"}`,
+		},
+		{
+			name:  "fence with capital letters in language tag",
+			input: "```JSON\n{\"key\":\"value\"}\n```",
+			want:  `{"key":"value"}`,
+		},
+		{
+			name:  "fence with numbers in language tag",
+			input: "```python3\nprint('hello')\n```",
+			want:  "print('hello')",
+		},
+		{
+			name:  "incomplete fence - opening only",
+			input: "```json\n{\"key\":\"value\"}",
+			want:  "```json\n{\"key\":\"value\"}",
+		},
+		{
+			name:  "incomplete fence - closing only",
+			input: "{\"key\":\"value\"}\n```",
+			want:  "{\"key\":\"value\"}\n```",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := output.StripCodeFences(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStripCodeFences_LargeInput(t *testing.T) {
+	largeContent := strings.Repeat("x", 1024*1024)
+	input := "```json\n" + largeContent + "\n```"
+
+	got := output.StripCodeFences(input)
+
+	assert.Equal(t, largeContent, got)
+}
+
+func TestValidateAndParseJSON_ValidJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantType string
+	}{
+		{
+			name:     "valid object",
+			input:    `{"key":"value"}`,
+			wantType: "map[string]any",
+		},
+		{
+			name:     "valid object with nested fields",
+			input:    `{"name":"alice","count":3,"nested":{"inner":"value"}}`,
+			wantType: "map[string]any",
+		},
+		{
+			name:     "valid array",
+			input:    `[1,2,3]`,
+			wantType: "[]any",
+		},
+		{
+			name:     "valid array of objects",
+			input:    `[{"id":1},{"id":2}]`,
+			wantType: "[]any",
+		},
+		{
+			name:     "valid empty object",
+			input:    `{}`,
+			wantType: "map[string]any",
+		},
+		{
+			name:     "valid empty array",
+			input:    `[]`,
+			wantType: "[]any",
+		},
+		{
+			name:     "valid with whitespace",
+			input:    `  {"key": "value"}  `,
+			wantType: "map[string]any",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := output.ValidateAndParseJSON(tt.input)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+
+			switch tt.wantType {
+			case "map[string]any":
+				_, ok := got.(map[string]any)
+				assert.True(t, ok, "expected map[string]any, got %T", got)
+			case "[]any":
+				_, ok := got.([]any)
+				assert.True(t, ok, "expected []any, got %T", got)
+			}
+		})
+	}
+}
+
+func TestValidateAndParseJSON_ValidJSONContent(t *testing.T) {
+	input := `{"name":"alice","count":3}`
+
+	got, err := output.ValidateAndParseJSON(input)
+	require.NoError(t, err)
+
+	result, ok := got.(map[string]any)
+	require.True(t, ok, "expected map[string]any")
+	assert.Equal(t, "alice", result["name"])
+	assert.Equal(t, float64(3), result["count"])
+}
+
+func TestValidateAndParseJSON_InvalidJSON(t *testing.T) {
+	tests := []struct {
+		name              string
+		input             string
+		wantErrContains   string
+		wantPreviewPrefix string
+	}{
+		{
+			name:              "malformed object",
+			input:             `{"key":`,
+			wantErrContains:   "invalid JSON",
+			wantPreviewPrefix: `{"key":`,
+		},
+		{
+			name:              "unquoted key",
+			input:             `{key:"value"}`,
+			wantErrContains:   "invalid JSON",
+			wantPreviewPrefix: `{key:"value"}`,
+		},
+		{
+			name:              "trailing comma",
+			input:             `{"key":"value",}`,
+			wantErrContains:   "invalid JSON",
+			wantPreviewPrefix: `{"key":"value",}`,
+		},
+		{
+			name:              "single quoted string",
+			input:             `{'key':'value'}`,
+			wantErrContains:   "invalid JSON",
+			wantPreviewPrefix: `{'key':'value'}`,
+		},
+		{
+			name:              "empty string",
+			input:             "",
+			wantErrContains:   "invalid JSON",
+			wantPreviewPrefix: "",
+		},
+		{
+			name:              "whitespace only",
+			input:             "   \n  ",
+			wantErrContains:   "invalid JSON",
+			wantPreviewPrefix: "   \n  ",
+		},
+		{
+			name:              "plain text",
+			input:             "not json at all",
+			wantErrContains:   "invalid JSON",
+			wantPreviewPrefix: "not json at all",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := output.ValidateAndParseJSON(tt.input)
+			require.Error(t, err)
+			assert.Nil(t, got)
+			assert.Contains(t, err.Error(), tt.wantErrContains)
+
+			if tt.input != "" {
+				expectedPreview := tt.input
+				if len(expectedPreview) > 200 {
+					expectedPreview = expectedPreview[:200]
+				}
+				assert.Contains(t, err.Error(), expectedPreview)
+			}
+		})
+	}
+}
+
+func TestValidateAndParseJSON_ErrorPreviewTruncation(t *testing.T) {
+	var b strings.Builder
+	for i := 0; i < 300; i++ {
+		b.WriteString(string(rune('0' + (i % 10))))
+		b.WriteString(string(rune('a' + (i % 26))))
+	}
+	longInput := b.String()
+
+	got, err := output.ValidateAndParseJSON(longInput)
+	require.Error(t, err)
+	assert.Nil(t, got)
+
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, longInput[:200])
+	assert.NotContains(t, errMsg, longInput[201:])
+}
+
+func TestProcessOutputFormat_JSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		output      string
+		wantOutput  string
+		wantParsed  map[string]any
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:       "json format with fences and valid JSON",
+			output:     "```json\n{\"key\":\"value\"}\n```",
+			wantOutput: `{"key":"value"}`,
+			wantParsed: map[string]any{"key": "value"},
+		},
+		{
+			name:       "json format with valid JSON no fences",
+			output:     `{"key":"value"}`,
+			wantOutput: `{"key":"value"}`,
+			wantParsed: map[string]any{"key": "value"},
+		},
+		{
+			name:       "json format with nested object",
+			output:     "```json\n{\"user\":{\"name\":\"alice\",\"age\":30}}\n```",
+			wantOutput: `{"user":{"name":"alice","age":30}}`,
+			wantParsed: map[string]any{"user": map[string]any{"name": "alice", "age": float64(30)}},
+		},
+		{
+			name:        "json format with invalid JSON after stripping",
+			output:      "```json\n{\"key\":\n```",
+			wantErr:     true,
+			errContains: "invalid JSON",
+		},
+		{
+			name:        "json format with plain text",
+			output:      "```json\nnot json\n```",
+			wantErr:     true,
+			errContains: "invalid JSON",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processed, parsed, err := output.ProcessOutputFormat(tt.output, "json")
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOutput, processed)
+
+			result, ok := parsed.(map[string]any)
+			require.True(t, ok, "expected map[string]any, got %T", parsed)
+
+			for k, v := range tt.wantParsed {
+				assert.Equal(t, v, result[k])
+			}
+		})
+	}
+}
+
+func TestProcessOutputFormat_Text(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     string
+		wantOutput string
+	}{
+		{
+			name:       "text format with bash fences",
+			output:     "```bash\necho hello\n```",
+			wantOutput: "echo hello",
+		},
+		{
+			name:       "text format with json fences (no validation)",
+			output:     "```json\n{\"key\":\"value\"}\n```",
+			wantOutput: `{"key":"value"}`,
+		},
+		{
+			name:       "text format with plain text",
+			output:     "```\nplain text content\n```",
+			wantOutput: "plain text content",
+		},
+		{
+			name:       "text format with no fences",
+			output:     "raw text output",
+			wantOutput: "raw text output",
+		},
+		{
+			name:       "text format with python fences",
+			output:     "```python\nprint('hello')\n```",
+			wantOutput: "print('hello')",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processed, parsed, err := output.ProcessOutputFormat(tt.output, "text")
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOutput, processed)
+			assert.Nil(t, parsed)
+		})
+	}
+}
+
+func TestProcessOutputFormat_Empty(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     string
+		wantOutput string
+	}{
+		{
+			name:       "empty format with fences (no stripping)",
+			output:     "```json\n{\"key\":\"value\"}\n```",
+			wantOutput: "```json\n{\"key\":\"value\"}\n```",
+		},
+		{
+			name:       "empty format with plain text",
+			output:     "raw output",
+			wantOutput: "raw output",
+		},
+		{
+			name:       "empty format preserves everything",
+			output:     "line1\n```code\nstuff\n```\nline2",
+			wantOutput: "line1\n```code\nstuff\n```\nline2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processed, parsed, err := output.ProcessOutputFormat(tt.output, "")
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOutput, processed)
+			assert.Nil(t, parsed)
+		})
+	}
+}
+
+func TestProcessOutputFormat_BackwardCompatibility(t *testing.T) {
+	rawOutput := "Agent response with ```json\n{\"key\":\"value\"}\n``` embedded"
+
+	processed, parsed, err := output.ProcessOutputFormat(rawOutput, "")
+
+	require.NoError(t, err)
+	assert.Equal(t, rawOutput, processed)
+	assert.Nil(t, parsed)
+}


### PR DESCRIPTION
## Summary

- b910ef9 feat(workflow): add output_format field for agent steps

## Changes

```
 .go-arch-lint.yml                                  |   4 +
 CHANGELOG.md                                       |  10 +
 README.md                                          |   1 +
 docs/README.md                                     |   1 +
 docs/reference/interpolation.md                    |  58 +-
 docs/user-guide/agent-steps.md                     | 139 +++-
 docs/user-guide/examples.md                        |   2 +-
 docs/user-guide/workflow-syntax.md                 |   1 +
 internal/application/dry_run_executor.go           |   7 +-
 .../dry_run_executor_output_format_test.go         | 320 ++++++++
 internal/application/execution_service.go          |  32 +
 .../execution_service_json_field_mapping_test.go   | 397 ++++++++++
 .../execution_service_output_format_test.go        | 857 +++++++++++++++++++++
 internal/domain/workflow/agent_config.go           |  22 +
 .../workflow/agent_config_output_format_test.go    | 318 ++++++++
 internal/domain/workflow/context.go                |   1 +
 internal/domain/workflow/context_json_test.go      | 355 +++++++++
 internal/domain/workflow/dry_run.go                |   1 +
 .../domain/workflow/dry_run_output_format_test.go  | 269 +++++++
 internal/infrastructure/repository/yaml_mapper.go  |   1 +
 .../repository/yaml_mapper_output_format_test.go   | 436 +++++++++++
 internal/infrastructure/repository/yaml_types.go   |   9 +-
 pkg/interpolation/reference.go                     |   1 +
 pkg/interpolation/reference_json_field_test.go     | 317 ++++++++
 pkg/interpolation/reference_test.go                |   8 +-
 pkg/interpolation/resolver.go                      |   1 +
 pkg/interpolation/resolver_json_field_test.go      | 418 ++++++++++
 pkg/output/format.go                               |  66 ++
 pkg/output/format_test.go                          | 480 ++++++++++++
 29 files changed, 4515 insertions(+), 17 deletions(-)
```

Closes #219


---
Generated with awf commit workflow

