### PR TITLE
feat(workflow): add exit-code-based transition routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Zero breaking changes: all existing consumers compile unchanged
 
 ### Added
+- **F068**: Exit Code Based Transition Routing
+  - Transitions with `when` conditions are now evaluated on non-zero exit paths, not just success paths
+  - `states.<step>.ExitCode` supports all 6 numeric comparison operators (`==`, `!=`, `<`, `>`, `<=`, `>=`) in transition conditions
+  - Transitions take priority over `continue_on_error` and `on_failure` when defined (first matching transition wins)
+  - Exit code and output conditions can be mixed freely in the same workflow (e.g., step 1 routes by `ExitCode`, step 2 routes by `Output`)
+  - Extracted shared `resolveNextStep` into package-level function to eliminate duplication between `ExecutionService` and `InteractiveExecutor`
+  - Full backward compatibility: workflows without `ExitCode` transitions behave unchanged
 - **F065**: Output Format for Agent Steps
   - New `output_format` field on agent steps: `json` (fence stripping + JSON validation) or `text` (fence stripping only)
   - Automatic markdown code fence stripping from agent output (outermost `` ```lang...``` `` removed)
@@ -300,6 +307,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Affects: Template interpolation, workflow validation, all state references
 
 ### Added
+- **F068**: Exit Code Based Transition Routing
 - **F065**: Output Format for Agent Steps
 - **F063**: Prompt File Loading for Agent Steps
 - **C056**: Add doc.go to 9 Key Infrastructure and Interface Packages

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Go CLI tool for orchestrating AI agents (Claude, Gemini, Codex) through YAML-c
 
 ## Features
 
-- **State Machine Execution** - Define workflows as state machines with conditional transitions
+- **State Machine Execution** - Define workflows as state machines with conditional transitions based on exit codes, command output, or custom expressions
 - **Agent Steps** - Invoke AI CLI agents (Claude, Codex, Gemini) with prompt templates and response parsing
 - **Output Formatting for Agent Steps** - Automatically strip markdown code fences and validate JSON output
 - **External Prompt Files** - Load agent prompts from `.md` files with full template interpolation and helper functions

--- a/docs/reference/interpolation.md
+++ b/docs/reference/interpolation.md
@@ -61,8 +61,9 @@ analyze:
 
 #### ExitCode
 
-The exit code from the step's command execution. Use in transitions and expressions:
+The exit code from the step's command execution. Use in transitions, expressions, and templates:
 
+**In transitions (numeric comparison):**
 ```yaml
 transitions:
   - when: "states.test_run.ExitCode == 0"
@@ -70,6 +71,28 @@ transitions:
   - when: "states.test_run.ExitCode > 0"
     goto: failure
 ```
+
+**In templates (as string):**
+```yaml
+report_failure:
+  type: step
+  command: |
+    echo "Test failed with exit code: {{.states.test_run.ExitCode}}"
+    notify-on-error --code={{.states.test_run.ExitCode}}
+```
+
+**Numeric range expressions:**
+```yaml
+transitions:
+  - when: "states.build.ExitCode >= 100 and states.build.ExitCode < 128"
+    goto: handle_user_error
+  - when: "states.build.ExitCode >= 128"
+    goto: handle_signal
+```
+
+On POSIX systems, exit codes are typically 0–255. Exit code 0 indicates success; non-zero indicates failure.
+
+**Transition priority:** Transitions are evaluated on both success and failure paths. When a matching transition is found, it takes priority over `on_success`, `on_failure`, and `continue_on_error`. If no transition matches, the legacy routing applies as fallback.
 
 #### TokensUsed
 

--- a/docs/user-guide/workflow-syntax.md
+++ b/docs/user-guide/workflow-syntax.md
@@ -1188,12 +1188,63 @@ process:
 | `when` | string | Expression to evaluate (optional for default) |
 | `goto` | string | Target state if condition matches |
 
+### Exit Code Routing Examples
+
+Route based on command exit codes:
+
+```yaml
+test_runner:
+  type: step
+  command: pytest
+  transitions:
+    - when: "states.test_runner.ExitCode == 0"
+      goto: deploy
+    - when: "states.test_runner.ExitCode > 1"
+      goto: critical_failure
+    - when: "states.test_runner.ExitCode != 0"  # Catch exit code 1
+      goto: report_warnings
+    - goto: unknown_error
+```
+
+### Output-Based Routing Examples
+
+Route based on command output:
+
+```yaml
+check_config:
+  type: step
+  command: validate-config.sh
+  transitions:
+    - when: "states.check_config.Output contains 'READY'"
+      goto: deploy
+    - when: "states.check_config.Output contains 'WARNING'"
+      goto: review_config
+    - goto: abort
+```
+
+### Combined Routing
+
+Mix exit code and output conditions:
+
+```yaml
+build:
+  type: step
+  command: make build
+  transitions:
+    - when: "states.build.ExitCode == 0 and states.build.Output contains 'OPTIMIZED'"
+      goto: fast_deploy
+    - when: "states.build.ExitCode == 0"
+      goto: standard_deploy
+    - goto: fix_errors
+```
+
 ### Supported Operators
 
 | Type | Operators |
 |------|-----------|
-| Comparison | `==`, `!=`, `<`, `>`, `<=`, `>=` |
+| Comparison | `==`, `!=`, `<`, `>`, `<=`, `>=` (numeric for ExitCode, string for Output) |
 | Logical | `and`, `or`, `not` |
+| String | `contains`, `startsWith`, `endsWith` |
 | Grouping | `(expr)` |
 
 ### Available Variables
@@ -1201,11 +1252,17 @@ process:
 | Variable | Description |
 |----------|-------------|
 | `inputs.name` | Input values |
-| `states.step_name.ExitCode` | Step exit code |
-| `states.step_name.Output` | Step output |
+| `states.step_name.ExitCode` | Step exit code (integer, POSIX 0-255) |
+| `states.step_name.Output` | Step output (string) |
 | `env.VAR_NAME` | Environment variables |
 
-Transitions are evaluated in order; first match wins. A transition without `when` acts as default fallback.
+### Transition Evaluation
+
+- Transitions are evaluated **on both success and failure paths** (non-zero exit codes included)
+- Transitions are evaluated **in order**; first matching condition wins
+- When a transition matches, it **takes priority** over `on_success`, `on_failure`, and `continue_on_error`
+- A transition without `when` acts as **default fallback**
+- If no transition matches and no default fallback exists, falls back to legacy `on_success`/`on_failure` behavior
 
 ---
 

--- a/internal/application/execution_service.go
+++ b/internal/application/execution_service.go
@@ -391,29 +391,7 @@ func (s *ExecutionService) resolveNextStep(
 	intCtx *interpolation.Context,
 	success bool,
 ) (string, error) {
-	// If transitions are defined, evaluate them first
-	if len(step.Transitions) > 0 && s.evaluator != nil {
-		evalFunc := func(expr string) (bool, error) {
-			return s.evaluator.EvaluateBool(expr, intCtx)
-		}
-
-		nextStep, found, err := step.Transitions.EvaluateFirstMatch(evalFunc)
-		if err != nil {
-			return "", fmt.Errorf("evaluate transitions: %w", err)
-		}
-		if found {
-			s.logger.Debug("transition matched", "step", step.Name, "next", nextStep)
-			return nextStep, nil
-		}
-		// No transition matched, fall through to legacy handling
-		s.logger.Debug("no transition matched, using legacy", "step", step.Name)
-	}
-
-	// Legacy fallback: use OnSuccess/OnFailure
-	if success {
-		return step.OnSuccess, nil
-	}
-	return step.OnFailure, nil
+	return resolveNextStep(step, intCtx, success, s.evaluator, s.logger)
 }
 
 // checkpoint saves the current execution state.
@@ -1186,6 +1164,7 @@ func (s *ExecutionService) handleExecutionError(
 
 // handleNonZeroExit processes non-zero exit codes, following OnFailure or ContinueOnError paths.
 // Updates state, executes post-hooks, and returns the next step or error.
+// Transitions are evaluated first (ADR-001); ContinueOnError/OnFailure are legacy fallback.
 func (s *ExecutionService) handleNonZeroExit(
 	stepCtx context.Context,
 	step *workflow.Step,
@@ -1194,7 +1173,6 @@ func (s *ExecutionService) handleNonZeroExit(
 	result *ports.CommandResult,
 ) (string, error) {
 	state.Status = workflow.StatusFailed
-	// Include stderr in error if available, otherwise just exit code
 	if result.Stderr != "" {
 		state.Error = result.Stderr
 	} else {
@@ -1208,16 +1186,16 @@ func (s *ExecutionService) handleNonZeroExit(
 		s.logger.Warn("post-hook failed", "step", step.Name, "error", err)
 	}
 
-	// If continue_on_error is true, follow on_success path
-	if step.ContinueOnError {
-		return step.OnSuccess, nil
+	// Transitions take priority over ContinueOnError/OnFailure (ADR-001).
+	// Pass ContinueOnError as success so the legacy fallback selects OnSuccess vs OnFailure correctly.
+	nextStep, err := s.resolveNextStep(step, intCtx, step.ContinueOnError)
+	if err != nil {
+		return "", err
+	}
+	if nextStep != "" || step.ContinueOnError {
+		return nextStep, nil
 	}
 
-	if step.OnFailure != "" {
-		return step.OnFailure, nil
-	}
-
-	// Return error with stderr if available for better error classification
 	if result.Stderr != "" {
 		return "", fmt.Errorf("step %s: %s", step.Name, result.Stderr)
 	}

--- a/internal/application/execution_service_transitions_test.go
+++ b/internal/application/execution_service_transitions_test.go
@@ -384,3 +384,636 @@ func TestResolveNextStep_TransitionEvaluationError(t *testing.T) {
 	assert.Contains(t, err.Error(), "evaluate transitions", "error should indicate transition evaluation failure")
 	assert.Equal(t, workflow.StatusFailed, ctx.Status)
 }
+
+// F068: Exit Code Based Transition Routing
+// Tests for handleNonZeroExit calling resolveNextStep before legacy fallback.
+
+func TestResolveNextStep_NonZeroExit_TransitionMatches(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "start",
+		Steps: map[string]*workflow.Step{
+			"start": builders.NewStepBuilder("start").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("exit 1").
+				WithTransitions(workflow.Transitions{
+					{When: "true", Goto: "transition_target"},
+				}).
+				WithOnFailure("legacy_failure").
+				Build(),
+			"transition_target": {
+				Name: "transition_target",
+				Type: workflow.StepTypeTerminal,
+			},
+			"legacy_failure": {
+				Name: "legacy_failure",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("exit 1", &ports.CommandResult{Stderr: "", ExitCode: 1}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+	assert.Equal(t, "transition_target", ctx.CurrentStep, "transition should take priority over OnFailure on non-zero exit")
+}
+
+func TestResolveNextStep_NonZeroExit_NoMatchFallsBackToOnFailure(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "start",
+		Steps: map[string]*workflow.Step{
+			"start": builders.NewStepBuilder("start").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("exit 1").
+				WithTransitions(workflow.Transitions{
+					{When: "false", Goto: "never_reached"},
+				}).
+				WithOnFailure("legacy_failure").
+				Build(),
+			"never_reached": {
+				Name: "never_reached",
+				Type: workflow.StepTypeTerminal,
+			},
+			"legacy_failure": {
+				Name: "legacy_failure",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("exit 1", &ports.CommandResult{Stderr: "", ExitCode: 1}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+	assert.Equal(t, "legacy_failure", ctx.CurrentStep, "should fallback to OnFailure when no transition matches on non-zero exit")
+}
+
+func TestResolveNextStep_ExitCode42_RoutingViaTransition(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "build",
+		Steps: map[string]*workflow.Step{
+			"build": builders.NewStepBuilder("build").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("exit 42").
+				WithTransitions(workflow.Transitions{
+					{When: "states.build.ExitCode == 42", Goto: "specific_handler"},
+					{When: "states.build.ExitCode == 0", Goto: "deploy"},
+				}).
+				WithOnFailure("generic_failure").
+				Build(),
+			"specific_handler": {
+				Name: "specific_handler",
+				Type: workflow.StepTypeTerminal,
+			},
+			"deploy": {
+				Name: "deploy",
+				Type: workflow.StepTypeTerminal,
+			},
+			"generic_failure": {
+				Name: "generic_failure",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("exit 42", &ports.CommandResult{Stderr: "", ExitCode: 42}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+	assert.Equal(t, "specific_handler", ctx.CurrentStep, "should route to specific_handler when ExitCode == 42")
+}
+
+// F068 T001: handleNonZeroExit comprehensive test coverage
+// Tests for exit code-based routing with transitions before legacy fallback
+
+func TestHandleNonZeroExit_NumericComparison_GreaterThan(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": builders.NewStepBuilder("step1").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("exit 3").
+				WithTransitions(workflow.Transitions{
+					{When: "states.step1.ExitCode > 1", Goto: "high_error"},
+				}).
+				WithOnFailure("default_fail").
+				Build(),
+			"high_error": {
+				Name: "high_error",
+				Type: workflow.StepTypeTerminal,
+			},
+			"default_fail": {
+				Name: "default_fail",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("exit 3", &ports.CommandResult{Stderr: "", ExitCode: 3}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "high_error", ctx.CurrentStep, "exit code 3 > 1 should route to high_error")
+}
+
+func TestHandleNonZeroExit_NumericComparison_LessThan(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": builders.NewStepBuilder("step1").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("exit 2").
+				WithTransitions(workflow.Transitions{
+					{When: "states.step1.ExitCode < 5", Goto: "low_error"},
+				}).
+				WithOnFailure("default_fail").
+				Build(),
+			"low_error": {
+				Name: "low_error",
+				Type: workflow.StepTypeTerminal,
+			},
+			"default_fail": {
+				Name: "default_fail",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("exit 2", &ports.CommandResult{Stderr: "", ExitCode: 2}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "low_error", ctx.CurrentStep, "exit code 2 < 5 should route to low_error")
+}
+
+func TestHandleNonZeroExit_NumericComparison_NotEqual(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": builders.NewStepBuilder("step1").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("exit 1").
+				WithTransitions(workflow.Transitions{
+					{When: "states.step1.ExitCode != 0", Goto: "any_error"},
+				}).
+				WithOnSuccess("success").
+				Build(),
+			"any_error": {
+				Name: "any_error",
+				Type: workflow.StepTypeTerminal,
+			},
+			"success": {
+				Name: "success",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("exit 1", &ports.CommandResult{Stderr: "", ExitCode: 1}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "any_error", ctx.CurrentStep, "exit code 1 != 0 should route to any_error")
+}
+
+func TestHandleNonZeroExit_ContinueOnError_TransitionTakesPriority(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": builders.NewStepBuilder("step1").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("exit 1").
+				WithContinueOnError(true).
+				WithTransitions(workflow.Transitions{
+					{When: "true", Goto: "transition_target"},
+				}).
+				WithOnSuccess("legacy_success").
+				Build(),
+			"transition_target": {
+				Name: "transition_target",
+				Type: workflow.StepTypeTerminal,
+			},
+			"legacy_success": {
+				Name: "legacy_success",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("exit 1", &ports.CommandResult{Stderr: "", ExitCode: 1}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "transition_target", ctx.CurrentStep, "transition should take priority even with ContinueOnError=true")
+}
+
+func TestHandleNonZeroExit_ContinueOnError_WithoutTransition_FollowsOnSuccess(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": builders.NewStepBuilder("step1").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("exit 1").
+				WithContinueOnError(true).
+				WithTransitions(workflow.Transitions{
+					{When: "false", Goto: "never_reached"},
+				}).
+				WithOnSuccess("continued").
+				Build(),
+			"never_reached": {
+				Name: "never_reached",
+				Type: workflow.StepTypeTerminal,
+			},
+			"continued": {
+				Name: "continued",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("exit 1", &ports.CommandResult{Stderr: "", ExitCode: 1}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "continued", ctx.CurrentStep, "with ContinueOnError=true and no matching transition, should follow OnSuccess")
+}
+
+func TestHandleNonZeroExit_ExitCodeZeroButTransitionOnNonZero(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": builders.NewStepBuilder("step1").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("echo success").
+				WithTransitions(workflow.Transitions{
+					{When: "states.step1.ExitCode != 0", Goto: "error_handler"},
+				}).
+				WithOnSuccess("normal_success").
+				Build(),
+			"error_handler": {
+				Name: "error_handler",
+				Type: workflow.StepTypeTerminal,
+			},
+			"normal_success": {
+				Name: "normal_success",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("echo success", &ports.CommandResult{Stdout: "success\n", ExitCode: 0}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "normal_success", ctx.CurrentStep, "exit code 0 should not match ExitCode != 0 transition, should follow OnSuccess")
+}
+
+func TestHandleNonZeroExit_MixedExitCodeAndOutputTransitions(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": builders.NewStepBuilder("step1").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("exit 1").
+				WithTransitions(workflow.Transitions{
+					{When: "states.step1.Output contains 'ERROR'", Goto: "parse_error"},
+					{When: "states.step1.ExitCode == 1", Goto: "exit_error"},
+				}).
+				WithOnFailure("default_failure").
+				Build(),
+			"parse_error": {
+				Name: "parse_error",
+				Type: workflow.StepTypeTerminal,
+			},
+			"exit_error": {
+				Name: "exit_error",
+				Type: workflow.StepTypeTerminal,
+			},
+			"default_failure": {
+				Name: "default_failure",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("exit 1", &ports.CommandResult{Stdout: "", Stderr: "", ExitCode: 1}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "exit_error", ctx.CurrentStep, "first matching transition (ExitCode == 1) should win over later Output condition")
+}
+
+func TestHandleNonZeroExit_DefaultTransitionOnNonZeroExit(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": builders.NewStepBuilder("step1").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("exit 99").
+				WithTransitions(workflow.Transitions{
+					{When: "states.step1.ExitCode == 42", Goto: "specific"},
+					{When: "", Goto: "default_handler"}, // Default transition
+				}).
+				WithOnFailure("failure").
+				Build(),
+			"specific": {
+				Name: "specific",
+				Type: workflow.StepTypeTerminal,
+			},
+			"default_handler": {
+				Name: "default_handler",
+				Type: workflow.StepTypeTerminal,
+			},
+			"failure": {
+				Name: "failure",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("exit 99", &ports.CommandResult{Stderr: "", ExitCode: 99}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "default_handler", ctx.CurrentStep, "default transition (empty When) should catch unmatched exit codes")
+}
+
+func TestHandleNonZeroExit_ExitCodeInInterpolation(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": builders.NewStepBuilder("step1").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("exit 5").
+				WithTransitions(workflow.Transitions{
+					{When: "states.step1.ExitCode == 5", Goto: "log_step"},
+				}).
+				WithOnFailure("failure").
+				Build(),
+			"log_step": builders.NewStepBuilder("log_step").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("echo Exit code was: {{states.step1.ExitCode}}").
+				WithOnSuccess("done").
+				Build(),
+			"done": {
+				Name: "done",
+				Type: workflow.StepTypeTerminal,
+			},
+			"failure": {
+				Name: "failure",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("exit 5", &ports.CommandResult{Stderr: "", ExitCode: 5}).
+		WithCommandResult("echo Exit code was: 5", &ports.CommandResult{Stdout: "Exit code was: 5\n", ExitCode: 0}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "done", ctx.CurrentStep, "should complete workflow after log_step via ExitCode == 5 transition")
+	// Verify ExitCode was captured and interpolated correctly
+	assert.Equal(t, 5, ctx.States["step1"].ExitCode, "step1 state should have ExitCode=5")
+}
+
+func TestHandleNonZeroExit_RangeOperators_GreaterOrEqual(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": builders.NewStepBuilder("step1").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("exit 5").
+				WithTransitions(workflow.Transitions{
+					{When: "states.step1.ExitCode >= 5", Goto: "critical"},
+				}).
+				WithOnFailure("failure").
+				Build(),
+			"critical": {
+				Name: "critical",
+				Type: workflow.StepTypeTerminal,
+			},
+			"failure": {
+				Name: "failure",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("exit 5", &ports.CommandResult{Stderr: "", ExitCode: 5}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "critical", ctx.CurrentStep, "exit code 5 >= 5 should route to critical")
+}
+
+func TestHandleNonZeroExit_RangeOperators_LessOrEqual(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": builders.NewStepBuilder("step1").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("exit 2").
+				WithTransitions(workflow.Transitions{
+					{When: "states.step1.ExitCode <= 2", Goto: "minor"},
+				}).
+				WithOnFailure("failure").
+				Build(),
+			"minor": {
+				Name: "minor",
+				Type: workflow.StepTypeTerminal,
+			},
+			"failure": {
+				Name: "failure",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("exit 2", &ports.CommandResult{Stderr: "", ExitCode: 2}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "minor", ctx.CurrentStep, "exit code 2 <= 2 should route to minor")
+}
+
+func TestHandleNonZeroExit_MultipleSteps_SecondStepExitCodeRouting(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": builders.NewStepBuilder("step1").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("echo ok").
+				WithOnSuccess("step2").
+				Build(),
+			"step2": builders.NewStepBuilder("step2").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("exit 7").
+				WithTransitions(workflow.Transitions{
+					{When: "states.step2.ExitCode == 7", Goto: "caught_step2_error"},
+				}).
+				WithOnFailure("uncaught_failure").
+				Build(),
+			"caught_step2_error": {
+				Name: "caught_step2_error",
+				Type: workflow.StepTypeTerminal,
+			},
+			"uncaught_failure": {
+				Name: "uncaught_failure",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("echo ok", &ports.CommandResult{Stdout: "ok\n", ExitCode: 0}).
+		WithCommandResult("exit 7", &ports.CommandResult{Stderr: "", ExitCode: 7}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "caught_step2_error", ctx.CurrentStep, "second step should route by ExitCode == 7 transition")
+}
+
+func TestHandleNonZeroExit_WithoutTransitions_FallsBackToOnFailure(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": builders.NewStepBuilder("step1").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("exit 1").
+				WithOnFailure("failure_handler").
+				Build(),
+			"failure_handler": {
+				Name: "failure_handler",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("exit 1", &ports.CommandResult{Stderr: "", ExitCode: 1}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "failure_handler", ctx.CurrentStep, "without transitions, should follow OnFailure for non-zero exit")
+}
+
+func TestHandleNonZeroExit_ExitCode0IsSuccess_NotCaughtByFailurePath(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": builders.NewStepBuilder("step1").
+				WithType(workflow.StepTypeCommand).
+				WithCommand("echo success").
+				WithTransitions(workflow.Transitions{
+					{When: "states.step1.ExitCode == 0", Goto: "success_via_transition"},
+				}).
+				WithOnSuccess("success_via_legacy").
+				WithOnFailure("failure").
+				Build(),
+			"success_via_transition": {
+				Name: "success_via_transition",
+				Type: workflow.StepTypeTerminal,
+			},
+			"success_via_legacy": {
+				Name: "success_via_legacy",
+				Type: workflow.StepTypeTerminal,
+			},
+			"failure": {
+				Name: "failure",
+				Type: workflow.StepTypeTerminal,
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarnessWithEvaluator(t, infraexpr.NewExprEvaluator()).
+		WithWorkflow("test", wf).
+		WithCommandResult("echo success", &ports.CommandResult{Stdout: "success\n", ExitCode: 0}).
+		Build()
+
+	ctx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "success_via_transition", ctx.CurrentStep, "exit code 0 should follow success path (handleSuccess, not handleNonZeroExit)")
+}

--- a/internal/application/interactive_executor.go
+++ b/internal/application/interactive_executor.go
@@ -532,26 +532,7 @@ func (e *InteractiveExecutor) resolveNextStep(
 	intCtx *interpolation.Context,
 	success bool,
 ) (string, error) {
-	// If transitions are defined, evaluate them first
-	if len(step.Transitions) > 0 && e.evaluator != nil {
-		evalFunc := func(expr string) (bool, error) {
-			return e.evaluator.EvaluateBool(expr, intCtx)
-		}
-
-		nextStep, found, err := step.Transitions.EvaluateFirstMatch(evalFunc)
-		if err != nil {
-			return "", fmt.Errorf("evaluate transitions: %w", err)
-		}
-		if found {
-			return nextStep, nil
-		}
-	}
-
-	// Legacy fallback
-	if success {
-		return step.OnSuccess, nil
-	}
-	return step.OnFailure, nil
+	return resolveNextStep(step, intCtx, success, e.evaluator, e.logger)
 }
 
 // HandleExecutionError handles the case where command execution returns an error.
@@ -603,10 +584,23 @@ func (e *InteractiveExecutor) HandleNonZeroExit(
 		e.logger.Warn("post-hook failed", "step", step.Name, "error", err)
 	}
 
-	// Determine next step based on error handling configuration
-	if step.ContinueOnError {
-		return step.OnSuccess, nil
+	intCtx.States[step.Name] = interpolation.StepStateData{
+		Output:   state.Output,
+		Stderr:   state.Stderr,
+		ExitCode: state.ExitCode,
+		Status:   state.Status.String(),
 	}
+
+	// Evaluate transitions first (success=false for non-zero exit), then fall back to legacy routing
+	nextStep, err := e.resolveNextStep(step, intCtx, step.ContinueOnError)
+	if err != nil {
+		return "", err
+	}
+	if nextStep != "" || step.ContinueOnError {
+		return nextStep, nil
+	}
+
+	// Fall back to legacy OnFailure
 	if step.OnFailure != "" {
 		return step.OnFailure, nil
 	}

--- a/internal/application/interactive_executor_transitions_test.go
+++ b/internal/application/interactive_executor_transitions_test.go
@@ -1,0 +1,569 @@
+package application_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/awf-project/awf/internal/application"
+	"github.com/awf-project/awf/internal/domain/ports"
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/awf-project/awf/internal/infrastructure/expression"
+	"github.com/awf-project/awf/pkg/interpolation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// F068 T002: handleNonZeroExit transition routing tests for InteractiveExecutor
+//
+// These tests verify that InteractiveExecutor.HandleNonZeroExit correctly evaluates
+// transitions before falling back to legacy OnFailure/ContinueOnError behavior.
+// This is the mirror/complement to ExecutionService tests (F068 T001).
+
+func TestInteractiveExecutor_HandleNonZeroExit_TransitionMatches(t *testing.T) {
+	// Happy path: transition condition matches on non-zero exit
+	wfSvc := application.NewWorkflowService(newMockRepository(), newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	executor := application.NewInteractiveExecutor(
+		wfSvc,
+		newMockExecutor(),
+		newMockParallelExecutor(),
+		newMockStateStore(),
+		&mockLogger{},
+		newMockResolver(),
+		expression.NewExprEvaluator(),
+		newMockPrompt(),
+	)
+
+	step := &workflow.Step{
+		Name:    "build_step",
+		Command: "exit 1",
+		Transitions: workflow.Transitions{
+			{When: "true", Goto: "error_handler"},
+		},
+		OnFailure: "legacy_failure",
+		Hooks:     workflow.StepHooks{},
+	}
+
+	state := workflow.StepState{
+		Name:        step.Name,
+		Status:      workflow.StatusFailed,
+		ExitCode:    1,
+		StartedAt:   time.Now(),
+		CompletedAt: time.Now(),
+	}
+
+	result := &ports.CommandResult{
+		ExitCode: 1,
+		Stderr:   "build failed",
+	}
+
+	intCtx := interpolation.NewContext()
+
+	nextStep, err := executor.HandleNonZeroExit(context.Background(), step, &state, result, intCtx)
+
+	require.NoError(t, err, "should not return error when transition matches")
+	assert.Equal(t, "error_handler", nextStep, "should follow matching transition over OnFailure")
+}
+
+func TestInteractiveExecutor_HandleNonZeroExit_ExitCodeEqualityComparison(t *testing.T) {
+	// Edge case: transition uses ExitCode == specific_value
+	wfSvc := application.NewWorkflowService(newMockRepository(), newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	executor := application.NewInteractiveExecutor(
+		wfSvc,
+		newMockExecutor(),
+		newMockParallelExecutor(),
+		newMockStateStore(),
+		&mockLogger{},
+		newMockResolver(),
+		expression.NewExprEvaluator(),
+		newMockPrompt(),
+	)
+
+	step := &workflow.Step{
+		Name:    "check_step",
+		Command: "exit 42",
+		Transitions: workflow.Transitions{
+			{When: "states.check_step.ExitCode == 42", Goto: "specific_handler"},
+		},
+		OnFailure: "generic_failure",
+		Hooks:     workflow.StepHooks{},
+	}
+
+	state := workflow.StepState{
+		Name:        step.Name,
+		Status:      workflow.StatusFailed,
+		ExitCode:    42,
+		StartedAt:   time.Now(),
+		CompletedAt: time.Now(),
+	}
+
+	result := &ports.CommandResult{
+		ExitCode: 42,
+		Stderr:   "custom exit code",
+	}
+
+	intCtx := interpolation.NewContext()
+
+	nextStep, err := executor.HandleNonZeroExit(context.Background(), step, &state, result, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "specific_handler", nextStep, "should match when ExitCode == 42")
+}
+
+func TestInteractiveExecutor_HandleNonZeroExit_ExitCodeGreaterThanComparison(t *testing.T) {
+	// Edge case: transition uses ExitCode > threshold
+	wfSvc := application.NewWorkflowService(newMockRepository(), newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	executor := application.NewInteractiveExecutor(
+		wfSvc,
+		newMockExecutor(),
+		newMockParallelExecutor(),
+		newMockStateStore(),
+		&mockLogger{},
+		newMockResolver(),
+		expression.NewExprEvaluator(),
+		newMockPrompt(),
+	)
+
+	step := &workflow.Step{
+		Name:    "severity_check",
+		Command: "exit 5",
+		Transitions: workflow.Transitions{
+			{When: "states.severity_check.ExitCode > 3", Goto: "high_severity"},
+		},
+		OnFailure: "default_failure",
+		Hooks:     workflow.StepHooks{},
+	}
+
+	state := workflow.StepState{
+		Name:        step.Name,
+		Status:      workflow.StatusFailed,
+		ExitCode:    5,
+		StartedAt:   time.Now(),
+		CompletedAt: time.Now(),
+	}
+
+	result := &ports.CommandResult{
+		ExitCode: 5,
+		Stderr:   "",
+	}
+
+	intCtx := interpolation.NewContext()
+
+	nextStep, err := executor.HandleNonZeroExit(context.Background(), step, &state, result, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "high_severity", nextStep, "should match when ExitCode > 3")
+}
+
+func TestInteractiveExecutor_HandleNonZeroExit_NoTransitionMatch_FallsBackToOnFailure(t *testing.T) {
+	// Edge case: transition condition is false, should fall back to legacy OnFailure
+	wfSvc := application.NewWorkflowService(newMockRepository(), newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	executor := application.NewInteractiveExecutor(
+		wfSvc,
+		newMockExecutor(),
+		newMockParallelExecutor(),
+		newMockStateStore(),
+		&mockLogger{},
+		newMockResolver(),
+		expression.NewExprEvaluator(),
+		newMockPrompt(),
+	)
+
+	step := &workflow.Step{
+		Name:    "deploy_step",
+		Command: "exit 1",
+		Transitions: workflow.Transitions{
+			{When: "states.deploy_step.ExitCode == 0", Goto: "success_handler"},
+		},
+		OnFailure: "fallback_failure",
+		Hooks:     workflow.StepHooks{},
+	}
+
+	state := workflow.StepState{
+		Name:        step.Name,
+		Status:      workflow.StatusFailed,
+		ExitCode:    1,
+		StartedAt:   time.Now(),
+		CompletedAt: time.Now(),
+	}
+
+	result := &ports.CommandResult{
+		ExitCode: 1,
+		Stderr:   "deployment failed",
+	}
+
+	intCtx := interpolation.NewContext()
+
+	nextStep, err := executor.HandleNonZeroExit(context.Background(), step, &state, result, intCtx)
+
+	require.NoError(t, err, "should fall back to OnFailure when no transition matches")
+	assert.Equal(t, "fallback_failure", nextStep, "should use OnFailure when transition does not match")
+}
+
+func TestInteractiveExecutor_HandleNonZeroExit_MultipleTransitions_FirstMatchWins(t *testing.T) {
+	// Edge case: multiple transitions exist, first matching should win
+	wfSvc := application.NewWorkflowService(newMockRepository(), newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	executor := application.NewInteractiveExecutor(
+		wfSvc,
+		newMockExecutor(),
+		newMockParallelExecutor(),
+		newMockStateStore(),
+		&mockLogger{},
+		newMockResolver(),
+		expression.NewExprEvaluator(),
+		newMockPrompt(),
+	)
+
+	step := &workflow.Step{
+		Name:    "multi_exit",
+		Command: "exit 2",
+		Transitions: workflow.Transitions{
+			{When: "states.multi_exit.ExitCode > 1", Goto: "first_match"},
+			{When: "states.multi_exit.ExitCode > 0", Goto: "second_match"},
+		},
+		OnFailure: "legacy_failure",
+		Hooks:     workflow.StepHooks{},
+	}
+
+	state := workflow.StepState{
+		Name:        step.Name,
+		Status:      workflow.StatusFailed,
+		ExitCode:    2,
+		StartedAt:   time.Now(),
+		CompletedAt: time.Now(),
+	}
+
+	result := &ports.CommandResult{
+		ExitCode: 2,
+		Stderr:   "",
+	}
+
+	intCtx := interpolation.NewContext()
+
+	nextStep, err := executor.HandleNonZeroExit(context.Background(), step, &state, result, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "first_match", nextStep, "should select first matching transition")
+}
+
+func TestInteractiveExecutor_HandleNonZeroExit_DefaultTransition_AlwaysMatches(t *testing.T) {
+	// Edge case: empty When condition (default transition) should always match
+	wfSvc := application.NewWorkflowService(newMockRepository(), newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	executor := application.NewInteractiveExecutor(
+		wfSvc,
+		newMockExecutor(),
+		newMockParallelExecutor(),
+		newMockStateStore(),
+		&mockLogger{},
+		newMockResolver(),
+		expression.NewExprEvaluator(),
+		newMockPrompt(),
+	)
+
+	step := &workflow.Step{
+		Name:    "with_default",
+		Command: "exit 99",
+		Transitions: workflow.Transitions{
+			{When: "false", Goto: "never_matched"},
+			{When: "", Goto: "default_handler"}, // Default transition
+		},
+		OnFailure: "legacy_failure",
+		Hooks:     workflow.StepHooks{},
+	}
+
+	state := workflow.StepState{
+		Name:        step.Name,
+		Status:      workflow.StatusFailed,
+		ExitCode:    99,
+		StartedAt:   time.Now(),
+		CompletedAt: time.Now(),
+	}
+
+	result := &ports.CommandResult{
+		ExitCode: 99,
+		Stderr:   "",
+	}
+
+	intCtx := interpolation.NewContext()
+
+	nextStep, err := executor.HandleNonZeroExit(context.Background(), step, &state, result, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "default_handler", nextStep, "should match default transition (empty When)")
+}
+
+func TestInteractiveExecutor_HandleNonZeroExit_ContinueOnError_TransitionTakesPriority(t *testing.T) {
+	// Edge case: when ContinueOnError=true AND transition matches,
+	// transition should take priority over OnSuccess
+	wfSvc := application.NewWorkflowService(newMockRepository(), newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	executor := application.NewInteractiveExecutor(
+		wfSvc,
+		newMockExecutor(),
+		newMockParallelExecutor(),
+		newMockStateStore(),
+		&mockLogger{},
+		newMockResolver(),
+		expression.NewExprEvaluator(),
+		newMockPrompt(),
+	)
+
+	step := &workflow.Step{
+		Name:            "tolerant_step",
+		Command:         "exit 1",
+		ContinueOnError: true,
+		Transitions: workflow.Transitions{
+			{When: "true", Goto: "transition_target"},
+		},
+		OnSuccess: "legacy_success",
+		Hooks:     workflow.StepHooks{},
+	}
+
+	state := workflow.StepState{
+		Name:        step.Name,
+		Status:      workflow.StatusFailed,
+		ExitCode:    1,
+		StartedAt:   time.Now(),
+		CompletedAt: time.Now(),
+	}
+
+	result := &ports.CommandResult{
+		ExitCode: 1,
+		Stderr:   "",
+	}
+
+	intCtx := interpolation.NewContext()
+
+	nextStep, err := executor.HandleNonZeroExit(context.Background(), step, &state, result, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "transition_target", nextStep, "transition should take priority over ContinueOnError")
+}
+
+func TestInteractiveExecutor_HandleNonZeroExit_ContinueOnError_WithoutTransition_FollowsOnSuccess(t *testing.T) {
+	// Edge case: ContinueOnError=true AND no transition matches,
+	// should follow OnSuccess (not OnFailure)
+	wfSvc := application.NewWorkflowService(newMockRepository(), newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	executor := application.NewInteractiveExecutor(
+		wfSvc,
+		newMockExecutor(),
+		newMockParallelExecutor(),
+		newMockStateStore(),
+		&mockLogger{},
+		newMockResolver(),
+		expression.NewExprEvaluator(),
+		newMockPrompt(),
+	)
+
+	step := &workflow.Step{
+		Name:            "continue_step",
+		Command:         "exit 1",
+		ContinueOnError: true,
+		Transitions: workflow.Transitions{
+			{When: "false", Goto: "never_reached"},
+		},
+		OnSuccess: "continued_path",
+		Hooks:     workflow.StepHooks{},
+	}
+
+	state := workflow.StepState{
+		Name:        step.Name,
+		Status:      workflow.StatusFailed,
+		ExitCode:    1,
+		StartedAt:   time.Now(),
+		CompletedAt: time.Now(),
+	}
+
+	result := &ports.CommandResult{
+		ExitCode: 1,
+		Stderr:   "",
+	}
+
+	intCtx := interpolation.NewContext()
+
+	nextStep, err := executor.HandleNonZeroExit(context.Background(), step, &state, result, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "continued_path", nextStep, "should follow OnSuccess when ContinueOnError=true and no transition matches")
+}
+
+func TestInteractiveExecutor_HandleNonZeroExit_ExitCodeNotEqualComparison(t *testing.T) {
+	// Edge case: transition uses ExitCode != value
+	wfSvc := application.NewWorkflowService(newMockRepository(), newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	executor := application.NewInteractiveExecutor(
+		wfSvc,
+		newMockExecutor(),
+		newMockParallelExecutor(),
+		newMockStateStore(),
+		&mockLogger{},
+		newMockResolver(),
+		expression.NewExprEvaluator(),
+		newMockPrompt(),
+	)
+
+	step := &workflow.Step{
+		Name:    "not_equal_test",
+		Command: "exit 5",
+		Transitions: workflow.Transitions{
+			{When: "states.not_equal_test.ExitCode != 0", Goto: "any_error"},
+		},
+		OnFailure: "legacy_failure",
+		Hooks:     workflow.StepHooks{},
+	}
+
+	state := workflow.StepState{
+		Name:        step.Name,
+		Status:      workflow.StatusFailed,
+		ExitCode:    5,
+		StartedAt:   time.Now(),
+		CompletedAt: time.Now(),
+	}
+
+	result := &ports.CommandResult{
+		ExitCode: 5,
+		Stderr:   "",
+	}
+
+	intCtx := interpolation.NewContext()
+
+	nextStep, err := executor.HandleNonZeroExit(context.Background(), step, &state, result, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "any_error", nextStep, "should match when ExitCode != 0")
+}
+
+func TestInteractiveExecutor_HandleNonZeroExit_ExitCodeLessThanComparison(t *testing.T) {
+	// Edge case: transition uses ExitCode < threshold
+	wfSvc := application.NewWorkflowService(newMockRepository(), newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	executor := application.NewInteractiveExecutor(
+		wfSvc,
+		newMockExecutor(),
+		newMockParallelExecutor(),
+		newMockStateStore(),
+		&mockLogger{},
+		newMockResolver(),
+		expression.NewExprEvaluator(),
+		newMockPrompt(),
+	)
+
+	step := &workflow.Step{
+		Name:    "less_than_test",
+		Command: "exit 2",
+		Transitions: workflow.Transitions{
+			{When: "states.less_than_test.ExitCode < 10", Goto: "minor_error"},
+		},
+		OnFailure: "major_error",
+		Hooks:     workflow.StepHooks{},
+	}
+
+	state := workflow.StepState{
+		Name:        step.Name,
+		Status:      workflow.StatusFailed,
+		ExitCode:    2,
+		StartedAt:   time.Now(),
+		CompletedAt: time.Now(),
+	}
+
+	result := &ports.CommandResult{
+		ExitCode: 2,
+		Stderr:   "",
+	}
+
+	intCtx := interpolation.NewContext()
+
+	nextStep, err := executor.HandleNonZeroExit(context.Background(), step, &state, result, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "minor_error", nextStep, "should match when ExitCode < 10")
+}
+
+func TestInteractiveExecutor_HandleNonZeroExit_NoTransitions_LegacyOnFailure(t *testing.T) {
+	// Happy path: no transitions defined, should use OnFailure (backward compatibility)
+	wfSvc := application.NewWorkflowService(newMockRepository(), newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	executor := application.NewInteractiveExecutor(
+		wfSvc,
+		newMockExecutor(),
+		newMockParallelExecutor(),
+		newMockStateStore(),
+		&mockLogger{},
+		newMockResolver(),
+		expression.NewExprEvaluator(),
+		newMockPrompt(),
+	)
+
+	step := &workflow.Step{
+		Name:      "legacy_step",
+		Command:   "exit 1",
+		OnFailure: "legacy_handler",
+		Hooks:     workflow.StepHooks{},
+	}
+
+	state := workflow.StepState{
+		Name:        step.Name,
+		Status:      workflow.StatusFailed,
+		ExitCode:    1,
+		StartedAt:   time.Now(),
+		CompletedAt: time.Now(),
+	}
+
+	result := &ports.CommandResult{
+		ExitCode: 1,
+		Stderr:   "",
+	}
+
+	intCtx := interpolation.NewContext()
+
+	nextStep, err := executor.HandleNonZeroExit(context.Background(), step, &state, result, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "legacy_handler", nextStep, "should use OnFailure when no transitions defined")
+}
+
+func TestInteractiveExecutor_HandleNonZeroExit_NilStep_ReturnsError(t *testing.T) {
+	// Error handling: nil step should return error
+	wfSvc := application.NewWorkflowService(newMockRepository(), newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	executor := application.NewInteractiveExecutor(
+		wfSvc,
+		newMockExecutor(),
+		newMockParallelExecutor(),
+		newMockStateStore(),
+		&mockLogger{},
+		newMockResolver(),
+		expression.NewExprEvaluator(),
+		newMockPrompt(),
+	)
+
+	state := &workflow.StepState{}
+	result := &ports.CommandResult{ExitCode: 1}
+	intCtx := interpolation.NewContext()
+
+	nextStep, err := executor.HandleNonZeroExit(context.Background(), nil, state, result, intCtx)
+
+	require.Error(t, err, "should return error when step is nil")
+	assert.Empty(t, nextStep, "nextStep should be empty")
+}
+
+func TestInteractiveExecutor_HandleNonZeroExit_NilResult_ReturnsError(t *testing.T) {
+	// Error handling: nil result should return error
+	wfSvc := application.NewWorkflowService(newMockRepository(), newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+	executor := application.NewInteractiveExecutor(
+		wfSvc,
+		newMockExecutor(),
+		newMockParallelExecutor(),
+		newMockStateStore(),
+		&mockLogger{},
+		newMockResolver(),
+		expression.NewExprEvaluator(),
+		newMockPrompt(),
+	)
+
+	step := &workflow.Step{
+		Name: "test_step",
+	}
+	state := &workflow.StepState{}
+	intCtx := interpolation.NewContext()
+
+	nextStep, err := executor.HandleNonZeroExit(context.Background(), step, state, nil, intCtx)
+
+	require.Error(t, err, "should return error when result is nil")
+	assert.Empty(t, nextStep, "nextStep should be empty")
+}

--- a/internal/application/transition_resolver.go
+++ b/internal/application/transition_resolver.go
@@ -1,0 +1,42 @@
+package application
+
+import (
+	"fmt"
+
+	"github.com/awf-project/awf/internal/domain/ports"
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/awf-project/awf/pkg/interpolation"
+)
+
+// resolveNextStep evaluates transitions for a step and returns the next step name.
+// If transitions are defined and an evaluator is available, it evaluates them first.
+// If no transition matches, it falls back to legacy OnSuccess/OnFailure fields.
+func resolveNextStep(
+	step *workflow.Step,
+	intCtx *interpolation.Context,
+	success bool,
+	evaluator ports.ExpressionEvaluator,
+	logger ports.Logger,
+) (string, error) {
+	if len(step.Transitions) > 0 && evaluator != nil {
+		evalFunc := func(expr string) (bool, error) {
+			return evaluator.EvaluateBool(expr, intCtx)
+		}
+
+		nextStep, found, err := step.Transitions.EvaluateFirstMatch(evalFunc)
+		if err != nil {
+			return "", fmt.Errorf("evaluate transitions: %w", err)
+		}
+		if found {
+			logger.Debug("transition matched", "step", step.Name, "next", nextStep)
+			return nextStep, nil
+		}
+		logger.Debug("no transition matched, using legacy", "step", step.Name)
+	}
+
+	// Legacy fallback: use OnSuccess/OnFailure
+	if success {
+		return step.OnSuccess, nil
+	}
+	return step.OnFailure, nil
+}

--- a/pkg/expression/evaluator.go
+++ b/pkg/expression/evaluator.go
@@ -79,7 +79,7 @@ func preprocessExpression(exprStr string) string {
 }
 
 // BuildExprContext converts an interpolation.Context to a map for expression evaluation.
-// The map structure allows dot-access patterns like inputs.name, states.step.exit_code.
+// The map structure allows dot-access patterns like inputs.name, states.step.ExitCode.
 func BuildExprContext(ctx *interpolation.Context) map[string]any {
 	result := map[string]any{
 		"inputs":   make(map[string]any),

--- a/pkg/expression/evaluator_test.go
+++ b/pkg/expression/evaluator_test.go
@@ -625,10 +625,10 @@ func TestBuildExprContext(t *testing.T) {
 				"inputs": map[string]any{"mode": "full", "count": 10},
 				"states": map[string]any{
 					"step1": map[string]any{
-						"output":    "out",
-						"stderr":    "err",
-						"exit_code": 0,
-						"status":    "completed",
+						"output":   "out",
+						"stderr":   "err",
+						"ExitCode": 0,
+						"status":   "completed",
 					},
 				},
 				"env": map[string]any{"HOME": "/home/user"},
@@ -1309,6 +1309,361 @@ func TestBuildExprContext_NilSafety(t *testing.T) {
 			result := BuildExprContext(tt.ctx)
 			require.NotNil(t, result)
 			tt.checkFunc(t, result)
+		})
+	}
+}
+
+func TestExprEvaluator_ExitCodeNumericOperators(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		ctx     *interpolation.Context
+		want    bool
+		wantErr bool
+	}{
+		// Equality operator (==)
+		{
+			name: "exit code equality true",
+			expr: `states.build.ExitCode == 0`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"build": {ExitCode: 0},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "exit code equality false",
+			expr: `states.build.ExitCode == 0`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"build": {ExitCode: 1},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "exit code equality with non-zero value",
+			expr: `states.lint.ExitCode == 2`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"lint": {ExitCode: 2},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+
+		// Inequality operator (!=)
+		{
+			name: "exit code inequality true",
+			expr: `states.test.ExitCode != 0`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"test": {ExitCode: 1},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "exit code inequality false",
+			expr: `states.test.ExitCode != 0`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"test": {ExitCode: 0},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "exit code inequality with specific value",
+			expr: `states.check.ExitCode != 42`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"check": {ExitCode: 1},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+
+		// Greater than operator (>)
+		{
+			name: "exit code greater than true",
+			expr: `states.build.ExitCode > 1`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"build": {ExitCode: 3},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "exit code greater than false equal",
+			expr: `states.build.ExitCode > 1`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"build": {ExitCode: 1},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "exit code greater than false less",
+			expr: `states.build.ExitCode > 1`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"build": {ExitCode: 0},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+
+		// Less than operator (<)
+		{
+			name: "exit code less than true",
+			expr: `states.check.ExitCode < 5`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"check": {ExitCode: 3},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "exit code less than false equal",
+			expr: `states.check.ExitCode < 5`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"check": {ExitCode: 5},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "exit code less than false greater",
+			expr: `states.check.ExitCode < 5`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"check": {ExitCode: 10},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+
+		// Greater than or equal operator (>=)
+		{
+			name: "exit code greater or equal true (greater)",
+			expr: `states.deploy.ExitCode >= 0`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"deploy": {ExitCode: 5},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "exit code greater or equal true (equal)",
+			expr: `states.deploy.ExitCode >= 5`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"deploy": {ExitCode: 5},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "exit code greater or equal false",
+			expr: `states.deploy.ExitCode >= 5`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"deploy": {ExitCode: 2},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+
+		// Less than or equal operator (<=)
+		{
+			name: "exit code less or equal true (less)",
+			expr: `states.verify.ExitCode <= 1`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"verify": {ExitCode: 0},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "exit code less or equal true (equal)",
+			expr: `states.verify.ExitCode <= 1`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"verify": {ExitCode: 1},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "exit code less or equal false",
+			expr: `states.verify.ExitCode <= 1`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"verify": {ExitCode: 2},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+
+		// Compound conditions: ExitCode with Output (US2 - mixed routing)
+		{
+			name: "exit code and output true",
+			expr: `states.check.ExitCode == 0 && states.output.Output contains "READY"`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"check":  {ExitCode: 0},
+					"output": {Output: "System READY for deployment"},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "exit code and output false (exit code mismatch)",
+			expr: `states.check.ExitCode == 0 && states.output.Output contains "READY"`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"check":  {ExitCode: 1},
+					"output": {Output: "System READY for deployment"},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "exit code and output false (output mismatch)",
+			expr: `states.check.ExitCode == 0 && states.output.Output contains "READY"`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"check":  {ExitCode: 0},
+					"output": {Output: "System failed"},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "exit code or output true (exit code matches)",
+			expr: `states.check.ExitCode == 0 || states.fallback.Output contains "ERROR"`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"check":    {ExitCode: 0},
+					"fallback": {Output: "All clear"},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "exit code or output true (output matches)",
+			expr: `states.check.ExitCode == 0 || states.fallback.Output contains "ERROR"`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"check":    {ExitCode: 1},
+					"fallback": {Output: "ERROR: deployment failed"},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "exit code or output false (neither matches)",
+			expr: `states.check.ExitCode == 0 || states.fallback.Output contains "ERROR"`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"check":    {ExitCode: 1},
+					"fallback": {Output: "All clear"},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+
+		// Range-based routing (US3 - numeric range operators)
+		{
+			name: "exit code in range (> 1)",
+			expr: `states.step.ExitCode > 1`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"step": {ExitCode: 3},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "exit code == specific value (== 3)",
+			expr: `states.step.ExitCode == 3`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"step": {ExitCode: 3},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "exit code not equal (!= 0)",
+			expr: `states.step.ExitCode != 0`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"step": {ExitCode: 3},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "exit code in upper range (< 5)",
+			expr: `states.step.ExitCode < 5`,
+			ctx: &interpolation.Context{
+				States: map[string]interpolation.StepStateData{
+					"step": {ExitCode: 3},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := NewExprEvaluator()
+			got, err := e.Evaluate(tt.expr, tt.ctx)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/tests/integration/execution/conditions_test.go
+++ b/tests/integration/execution/conditions_test.go
@@ -153,7 +153,7 @@ states:
     type: step
     command: exit 0
     transitions:
-      - when: 'states.check.exit_code == 0'
+      - when: 'states.check.ExitCode == 0'
         goto: success
       - goto: failure
   success:
@@ -272,7 +272,7 @@ func TestExpressionEvaluator_Integration(t *testing.T) {
 	}{
 		{
 			name: "access nested state data",
-			expr: `states.build.exit_code == 0 and states.build.output != ""`,
+			expr: `states.build.ExitCode == 0 and states.build.Output != ""`,
 			ctx: &interpolation.Context{
 				States: map[string]interpolation.StepStateData{
 					"build": {ExitCode: 0, Output: "success"},
@@ -827,4 +827,363 @@ states:
 			assert.Equal(t, tt.wantFinalStep, execCtx.CurrentStep)
 		})
 	}
+}
+
+func TestExitCodeRouting_US1_BasicRouting(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	workflow := `
+name: exit-code-routing-test
+states:
+  initial: build
+  build:
+    type: step
+    command: exit 42
+    transitions:
+      - when: 'states.build.ExitCode == 42'
+        goto: handle_exit_42
+      - goto: handle_other_exit
+  handle_exit_42:
+    type: terminal
+    status: success
+  handle_other_exit:
+    type: terminal
+    status: failure
+`
+	workflowPath := filepath.Join(tmpDir, "workflow.yaml")
+	err := os.WriteFile(workflowPath, []byte(workflow), 0o644)
+	require.NoError(t, err)
+
+	log := &conditionsMockLogger{}
+	repo := repository.NewYAMLRepository(tmpDir)
+	stateStore := store.NewJSONStore(filepath.Join(tmpDir, "states"))
+	shellExecutor := executor.NewShellExecutor()
+	parallelExecutor := application.NewParallelExecutor(log)
+	resolver := interpolation.NewTemplateResolver()
+	exprEvaluator := infraExpr.NewExprEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, stateStore, shellExecutor, log, infraExpr.NewExprValidator())
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc,
+		shellExecutor,
+		parallelExecutor,
+		stateStore,
+		log,
+		resolver,
+		nil,
+		exprEvaluator,
+	)
+
+	ctx := context.Background()
+	execCtx, err := execSvc.Run(ctx, "workflow", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "handle_exit_42", execCtx.CurrentStep)
+}
+
+func TestExitCodeRouting_US1_MultipleExitCodes(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	workflow := `
+name: multi-exit-code-test
+states:
+  initial: check
+  check:
+    type: step
+    command: echo "checking"
+    transitions:
+      - when: 'states.check.ExitCode == 0'
+        goto: success_path
+      - when: 'states.check.ExitCode != 0'
+        goto: failure_path
+      - goto: unknown_path
+  success_path:
+    type: terminal
+    status: success
+  failure_path:
+    type: terminal
+    status: failure
+  unknown_path:
+    type: terminal
+    status: failure
+`
+	workflowPath := filepath.Join(tmpDir, "workflow.yaml")
+	err := os.WriteFile(workflowPath, []byte(workflow), 0o644)
+	require.NoError(t, err)
+
+	log := &conditionsMockLogger{}
+	repo := repository.NewYAMLRepository(tmpDir)
+	stateStore := store.NewJSONStore(filepath.Join(tmpDir, "states"))
+	shellExecutor := executor.NewShellExecutor()
+	parallelExecutor := application.NewParallelExecutor(log)
+	resolver := interpolation.NewTemplateResolver()
+	exprEvaluator := infraExpr.NewExprEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, stateStore, shellExecutor, log, infraExpr.NewExprValidator())
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc,
+		shellExecutor,
+		parallelExecutor,
+		stateStore,
+		log,
+		resolver,
+		nil,
+		exprEvaluator,
+	)
+
+	ctx := context.Background()
+	execCtx, err := execSvc.Run(ctx, "workflow", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "success_path", execCtx.CurrentStep)
+}
+
+func TestExitCodeRouting_US2_MixedExitCodeAndOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	workflow := `
+name: mixed-routing-test
+states:
+  initial: step1
+  step1:
+    type: step
+    command: echo "ready" && exit 1
+    capture:
+      stdout: output
+    transitions:
+      - when: 'states.step1.ExitCode == 1'
+        goto: step2
+      - goto: error1
+  step2:
+    type: step
+    command: echo "processing"
+    capture:
+      stdout: output
+    transitions:
+      - when: 'states.step2.Output contains "processing"'
+        goto: final_success
+      - goto: error2
+  final_success:
+    type: terminal
+    status: success
+  error1:
+    type: terminal
+    status: failure
+  error2:
+    type: terminal
+    status: failure
+`
+	workflowPath := filepath.Join(tmpDir, "workflow.yaml")
+	err := os.WriteFile(workflowPath, []byte(workflow), 0o644)
+	require.NoError(t, err)
+
+	log := &conditionsMockLogger{}
+	repo := repository.NewYAMLRepository(tmpDir)
+	stateStore := store.NewJSONStore(filepath.Join(tmpDir, "states"))
+	shellExecutor := executor.NewShellExecutor()
+	parallelExecutor := application.NewParallelExecutor(log)
+	resolver := interpolation.NewTemplateResolver()
+	exprEvaluator := infraExpr.NewExprEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, stateStore, shellExecutor, log, infraExpr.NewExprValidator())
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc,
+		shellExecutor,
+		parallelExecutor,
+		stateStore,
+		log,
+		resolver,
+		nil,
+		exprEvaluator,
+	)
+
+	ctx := context.Background()
+	execCtx, err := execSvc.Run(ctx, "workflow", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "final_success", execCtx.CurrentStep)
+}
+
+func TestExitCodeRouting_US3_NumericOperators(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	workflow := `
+name: numeric-ops-test
+states:
+  initial: check_gt
+  check_gt:
+    type: step
+    command: exit 3
+    transitions:
+      - when: 'states.check_gt.ExitCode > 1'
+        goto: success1
+      - goto: failure1
+  success1:
+    type: step
+    command: echo "check_eq"
+    transitions:
+      - when: 'states.check_gt.ExitCode == 3'
+        goto: success2
+      - goto: failure2
+  success2:
+    type: step
+    command: echo "check_ne"
+    transitions:
+      - when: 'states.check_gt.ExitCode != 0'
+        goto: success3
+      - goto: failure3
+  success3:
+    type: step
+    command: echo "check_lt"
+    transitions:
+      - when: 'states.check_gt.ExitCode < 5'
+        goto: success4
+      - goto: failure4
+  success4:
+    type: terminal
+    status: success
+  failure1:
+    type: terminal
+    status: failure
+  failure2:
+    type: terminal
+    status: failure
+  failure3:
+    type: terminal
+    status: failure
+  failure4:
+    type: terminal
+    status: failure
+`
+	workflowPath := filepath.Join(tmpDir, "workflow.yaml")
+	err := os.WriteFile(workflowPath, []byte(workflow), 0o644)
+	require.NoError(t, err)
+
+	log := &conditionsMockLogger{}
+	repo := repository.NewYAMLRepository(tmpDir)
+	stateStore := store.NewJSONStore(filepath.Join(tmpDir, "states"))
+	shellExecutor := executor.NewShellExecutor()
+	parallelExecutor := application.NewParallelExecutor(log)
+	resolver := interpolation.NewTemplateResolver()
+	exprEvaluator := infraExpr.NewExprEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, stateStore, shellExecutor, log, infraExpr.NewExprValidator())
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc,
+		shellExecutor,
+		parallelExecutor,
+		stateStore,
+		log,
+		resolver,
+		nil,
+		exprEvaluator,
+	)
+
+	ctx := context.Background()
+	execCtx, err := execSvc.Run(ctx, "workflow", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "success4", execCtx.CurrentStep)
+}
+
+func TestExitCodeRouting_US4_InterpolationContext(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	workflow := `
+name: interpolation-test
+states:
+  initial: step1
+  step1:
+    type: step
+    command: exit 2
+    transitions:
+      - when: 'states.step1.ExitCode == 2'
+        goto: step2
+      - goto: error
+  step2:
+    type: step
+    command: echo "code={{states.step1.ExitCode}}"
+    on_success: final
+  error:
+    type: terminal
+    status: failure
+  final:
+    type: terminal
+    status: success
+`
+	workflowPath := filepath.Join(tmpDir, "workflow.yaml")
+	err := os.WriteFile(workflowPath, []byte(workflow), 0o644)
+	require.NoError(t, err)
+
+	log := &conditionsMockLogger{}
+	repo := repository.NewYAMLRepository(tmpDir)
+	stateStore := store.NewJSONStore(filepath.Join(tmpDir, "states"))
+	shellExecutor := executor.NewShellExecutor()
+	parallelExecutor := application.NewParallelExecutor(log)
+	resolver := interpolation.NewTemplateResolver()
+	exprEvaluator := infraExpr.NewExprEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, stateStore, shellExecutor, log, infraExpr.NewExprValidator())
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc,
+		shellExecutor,
+		parallelExecutor,
+		stateStore,
+		log,
+		resolver,
+		nil,
+		exprEvaluator,
+	)
+
+	ctx := context.Background()
+	execCtx, err := execSvc.Run(ctx, "workflow", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "final", execCtx.CurrentStep)
+}
+
+func TestExitCodeRouting_FixExitCodeCasing(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	workflow := `
+name: exit-code-casing-test
+states:
+  initial: check
+  check:
+    type: step
+    command: exit 0
+    transitions:
+      - when: 'states.check.ExitCode == 0'
+        goto: success
+      - goto: failure
+  success:
+    type: terminal
+    status: success
+  failure:
+    type: terminal
+    status: failure
+`
+	workflowPath := filepath.Join(tmpDir, "workflow.yaml")
+	err := os.WriteFile(workflowPath, []byte(workflow), 0o644)
+	require.NoError(t, err)
+
+	log := &conditionsMockLogger{}
+	repo := repository.NewYAMLRepository(tmpDir)
+	stateStore := store.NewJSONStore(filepath.Join(tmpDir, "states"))
+	shellExecutor := executor.NewShellExecutor()
+	parallelExecutor := application.NewParallelExecutor(log)
+	resolver := interpolation.NewTemplateResolver()
+	exprEvaluator := infraExpr.NewExprEvaluator()
+
+	wfSvc := application.NewWorkflowService(repo, stateStore, shellExecutor, log, infraExpr.NewExprValidator())
+	execSvc := application.NewExecutionServiceWithEvaluator(
+		wfSvc,
+		shellExecutor,
+		parallelExecutor,
+		stateStore,
+		log,
+		resolver,
+		nil,
+		exprEvaluator,
+	)
+
+	ctx := context.Background()
+	execCtx, err := execSvc.Run(ctx, "workflow", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "success", execCtx.CurrentStep)
 }


### PR DESCRIPTION
## Summary

- 216a7a7 feat(workflow): add exit-code-based transition routing

## Changes

```
 CHANGELOG.md                                       |   8 +
 README.md                                          |   2 +-
 docs/reference/interpolation.md                    |  25 +-
 docs/user-guide/workflow-syntax.md                 |  65 ++-
 internal/application/execution_service.go          |  40 +-
 .../execution_service_transitions_test.go          | 633 +++++++++++++++++++++
 internal/application/interactive_executor.go       |  40 +-
 .../interactive_executor_transitions_test.go       | 569 ++++++++++++++++++
 internal/application/transition_resolver.go        |  42 ++
 pkg/expression/evaluator.go                        |   2 +-
 pkg/expression/evaluator_test.go                   | 357 +++++++++++-
 tests/integration/execution/conditions_test.go     | 363 +++++++++++-
 12 files changed, 2082 insertions(+), 64 deletions(-)
```

Closes #222


---
Generated with awf commit workflow

