### PR TITLE
fix(external-file): prefer local scripts/prompts over global XDG paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Risk**: Unreplaced references silently evaluate to `0` (expr-lang zero-value semantics)
 
 ### Fixed
+- **B005**: Local scripts and prompts now override global XDG paths when using `{{.awf.scripts_dir}}` or `{{.awf.prompts_dir}}`
+  - `loadExternalFile()` now checks `<workflow_dir>/scripts/` (or `prompts/`) before falling back to the global XDG directory
+  - New `resolveLocalOverGlobal()` helper detects XDG-prefixed paths and substitutes local equivalents when they exist
+  - Applies to both `script_file` and `prompt_file` fields
+  - **Workaround removal**: Users no longer need to use relative paths to get local-first resolution
 
 - **B004**: Validator no longer forces dead-code transitions on parallel branch children
   - Parallel branch children (`step.Branches`) can now omit `on_success`/`on_failure` and `Transitions`
@@ -234,6 +239,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Impact: Enables programmatic error handling in CI/CD pipelines, searchable error documentation, and consistent error messages across output formats
 
 ### Fixed
+- **B005**: Local scripts and prompts now override global XDG paths when using `{{.awf.scripts_dir}}` or `{{.awf.prompts_dir}}`
+  - `loadExternalFile()` now checks `<workflow_dir>/scripts/` (or `prompts/`) before falling back to the global XDG directory
+  - New `resolveLocalOverGlobal()` helper detects XDG-prefixed paths and substitutes local equivalents when they exist
+  - Applies to both `script_file` and `prompt_file` fields
+  - **Workaround removal**: Users no longer need to use relative paths to get local-first resolution
 
 - **B003**: Fixed while loop `break_when` condition not evaluating correctly
   - Root cause: Integration tests used `simpleExpressionEvaluator` mock with outdated lowercase keys (`output`, `exit_code`) and hardcoded value matching
@@ -607,6 +617,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Reduced `validateRules` complexity 31→20 via type-checked validator wrappers
 
 ### Fixed
+- **B005**: Local scripts and prompts now override global XDG paths when using `{{.awf.scripts_dir}}` or `{{.awf.prompts_dir}}`
+  - `loadExternalFile()` now checks `<workflow_dir>/scripts/` (or `prompts/`) before falling back to the global XDG directory
+  - New `resolveLocalOverGlobal()` helper detects XDG-prefixed paths and substitutes local equivalents when they exist
+  - Applies to both `script_file` and `prompt_file` fields
+  - **Workaround removal**: Users no longer need to use relative paths to get local-first resolution
 
 - **[B002] CLIExecutor Missing Process Group Management**
   - Fixed orphan process accumulation when agent provider processes (claude, codex, gemini, opencode) persist after workflow cancellation
@@ -768,6 +783,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - YAML parsing reports all errors instead of silently skipping malformed steps
 
 ### Fixed
+- **B005**: Local scripts and prompts now override global XDG paths when using `{{.awf.scripts_dir}}` or `{{.awf.prompts_dir}}`
+  - `loadExternalFile()` now checks `<workflow_dir>/scripts/` (or `prompts/`) before falling back to the global XDG directory
+  - New `resolveLocalOverGlobal()` helper detects XDG-prefixed paths and substitutes local equivalents when they exist
+  - Applies to both `script_file` and `prompt_file` fields
+  - **Workaround removal**: Users no longer need to use relative paths to get local-first resolution
 
 - **F048**: Loop body transitions now honored (while and foreach loops)
   - Loop executor now evaluates transitions after each body step execution

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,8 @@ Populate AWF context variables (.awf.config_dir, .awf.cache_dir) in application 
 
 Inject optional dependencies like XDG paths via SetAWFPaths() pattern in application layer; never import infrastructure modules directly from application layer
 
+Restrict local XDG overrides to scripts_dir and prompts_dir only; use allowlist-based matching against AWF map values to prevent unintended path resolution
+
 ## Common Pitfalls
 
 Preserve existing infrastructure layers when adding domain registries; ADR-004 enforces infrastructure plugin registry coexistence for separate lifecycle concerns
@@ -255,6 +257,10 @@ Always resolve relative prompt file paths against workflow.SourceDir, not curren
 
 Enforce 1MB size limit on loaded prompt files via io.LimitReader; prevents accidental memory issues and provides fast failure feedback for misconfigured paths
 
+Always resolve script_file and prompt_file paths against workflow.SourceDir first, then check for local XDG overrides via resolveLocalOverGlobal() before falling back to global XDG paths
+
+Never initialize interpolation context with nil AWF map; always pass initialized empty map to prevent nil dereference in path resolution helpers
+
 ## Test Conventions
 
 Integration tests use compile-time interface checks (var _ PortInterface = (*Implementation)(nil)) to verify port implementation at build time
@@ -264,6 +270,8 @@ Use HTTPDoer interface in pkg/httputil tests to mock HTTP behavior (timeouts, DN
 Write unit tests for prompt file validation, interpolation, and YAML mapping before integration tests; use table-driven tests for path resolution scenarios
 
 Write unit tests for prompt file validation, interpolation, and YAML mapping before integration tests; use table-driven tests for path resolution scenarios
+
+Never use switch statements to populate table-driven test variables; declare all fields in struct literals to prevent silent zero-value failures from missed case names
 
 ## Review Standards
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A Go CLI tool for orchestrating AI agents (Claude, Gemini, Codex) through YAML-c
 - **State Machine Execution** - Define workflows as state machines with conditional transitions based on exit codes, command output, or custom expressions
 - **Agent Steps** - Invoke AI CLI agents (Claude, Codex, Gemini) with prompt templates and response parsing
 - **Output Formatting for Agent Steps** - Automatically strip markdown code fences and validate JSON output
-- **External Prompt Files** - Load agent prompts from `.md` files with full template interpolation and helper functions
-- **External Script Files** - Load shell commands from `.sh` files with template interpolation and path resolution
+- **External Prompt Files** - Load agent prompts from `.md` files with full template interpolation, helper functions, and local override support
+- **External Script Files** - Load shell commands from `.sh` files with template interpolation, path resolution, and local override support
 - **Conversation Mode** - Multi-turn conversations with automatic context window management and token counting
 - **Parallel Execution** - Run multiple steps concurrently with configurable strategies
 - **Loop Constructs** - For-each and while loops with full context access

--- a/docs/reference/interpolation.md
+++ b/docs/reference/interpolation.md
@@ -283,6 +283,33 @@ deploy:
   on_success: done
 ```
 
+#### Local-Before-Global Resolution
+
+When using `{{.awf.prompts_dir}}` or `{{.awf.scripts_dir}}`, AWF implements **local-before-global resolution**. This enables per-project overrides of shared global files:
+
+1. **Local override preferred** — If a file exists in the workflow's local directory (`<workflow_dir>/prompts/` or `<workflow_dir>/scripts/`), it is used
+2. **Global fallback** — If no local file exists, the global XDG directory is used
+3. **Example**: `script_file: "{{.awf.scripts_dir}}/deploy.sh"` checks for:
+   - `<workflow_dir>/scripts/deploy.sh` (local override)
+   - Then `~/.config/awf/scripts/deploy.sh` (global fallback)
+
+This allows teams to maintain shared scripts globally while letting projects override them locally:
+
+```yaml
+# Project structure
+my-project/
+├── .awf/
+│   ├── workflows/
+│   │   └── deploy.yaml
+│   └── scripts/
+│       └── deploy.sh        # Local override — takes precedence
+└── ...
+
+# ~/.config/awf/scripts/deploy.sh exists globally but is superseded
+```
+
+The same behavior applies to `prompt_file` with `{{.awf.prompts_dir}}`.
+
 ## Template Helper Functions
 
 When interpolating template expressions, the following helper functions are available:

--- a/docs/user-guide/agent-steps.md
+++ b/docs/user-guide/agent-steps.md
@@ -251,11 +251,35 @@ Paths can be:
    prompt_file: ~/my-prompts/template.md      # Expands to user's home directory
    ```
 
-4. **XDG-compliant system directories:**
+4. **XDG prompts directory with local override** — via template interpolation with local-before-global resolution:
    ```yaml
-   prompt_file: "{{.awf.prompts_dir}}/analyze.md"  # ~/.config/awf/prompts/analyze.md (or per XDG_CONFIG_HOME)
-   prompt_file: "{{.awf.data_dir}}/templates/*.md"
+   prompt_file: "{{.awf.prompts_dir}}/analyze.md"
+   # Checks in order:
+   # 1. <workflow_dir>/prompts/analyze.md (local override)
+   # 2. ~/.config/awf/prompts/analyze.md (global fallback)
    ```
+
+#### Local-Before-Global Resolution
+
+When using `{{.awf.prompts_dir}}` in `prompt_file`, AWF prioritizes local project files over global ones:
+
+- **If local file exists** at `<workflow_dir>/prompts/<suffix>` → use it
+- **If local file missing** → fall back to global `~/.config/awf/prompts/<suffix>`
+
+This enables shared prompts at the global level while allowing projects to override them locally:
+
+```yaml
+# Workflow at: ~/myproject/.awf/workflows/review.yaml
+analyze:
+  type: agent
+  provider: claude
+  prompt_file: "{{.awf.prompts_dir}}/code_review.md"
+  on_success: done
+```
+
+Resolution order:
+1. Check `~/myproject/.awf/workflows/prompts/code_review.md` (local override)
+2. Check `~/.config/awf/prompts/code_review.md` (global shared)
 
 ### Template Helper Functions
 

--- a/docs/user-guide/workflow-syntax.md
+++ b/docs/user-guide/workflow-syntax.md
@@ -161,10 +161,35 @@ Script file paths are resolved in this order:
    script_file: scripts/test.sh  # Resolves to <workflow_dir>/scripts/test.sh
    ```
 
-4. **XDG scripts directory** — via template interpolation:
+4. **XDG scripts directory with local override** — via template interpolation with local-before-global resolution:
    ```yaml
-   script_file: "{{.awf.scripts_dir}}/checks/lint.sh"  # ~/.config/awf/scripts/checks/lint.sh
+   script_file: "{{.awf.scripts_dir}}/checks/lint.sh"
+   # Checks in order:
+   # 1. <workflow_dir>/scripts/checks/lint.sh (local override)
+   # 2. ~/.config/awf/scripts/checks/lint.sh (global fallback)
    ```
+
+##### Local-Before-Global Resolution
+
+When using `{{.awf.scripts_dir}}` in `script_file`, AWF prioritizes local project files over global ones:
+
+- **If local file exists** at `<workflow_dir>/scripts/<suffix>` → use it
+- **If local file missing** → fall back to global `~/.config/awf/scripts/<suffix>`
+
+This enables shared scripts at the global level while allowing projects to override them locally:
+
+```yaml
+# Workflow at: ~/myproject/.awf/workflows/deploy.yaml
+steps:
+  deploy:
+    type: step
+    script_file: "{{.awf.scripts_dir}}/deploy.sh"
+    on_success: verify
+```
+
+Resolution order:
+1. Check `~/myproject/.awf/workflows/scripts/deploy.sh` (local override)
+2. Check `~/.config/awf/scripts/deploy.sh` (global shared)
 
 #### Template Interpolation
 

--- a/internal/application/external_file.go
+++ b/internal/application/external_file.go
@@ -14,6 +14,35 @@ import (
 
 const maxExternalFileSize = 1024 * 1024
 
+// resolveLocalOverGlobal prefers a workflow-local file over the global XDG path when the
+// interpolated path falls under scripts_dir or prompts_dir. Returns the original path otherwise.
+func resolveLocalOverGlobal(interpolatedPath, sourceDir string, awfMap map[string]string) string {
+	allowedKeys := []string{"scripts_dir", "prompts_dir"}
+
+	for _, key := range allowedKeys {
+		globalDir, ok := awfMap[key]
+		if !ok || globalDir == "" {
+			continue
+		}
+
+		suffix, hasPrefix := strings.CutPrefix(interpolatedPath, globalDir+string(filepath.Separator))
+		if !hasPrefix {
+			continue
+		}
+
+		// Derive local subdir name from map key: "scripts_dir" → "scripts"
+		// Resolve against parent of sourceDir: .awf/workflows/ → .awf/scripts/
+		localSubdir := strings.TrimSuffix(key, "_dir")
+		localPath := filepath.Join(filepath.Dir(sourceDir), localSubdir, suffix)
+
+		if _, err := os.Stat(localPath); err == nil {
+			return localPath
+		}
+	}
+
+	return interpolatedPath
+}
+
 // loadExternalFile loads file contents with path resolution and 1MB size limit.
 // Shared by loadPromptFile and loadScriptFile.
 func loadExternalFile(
@@ -31,14 +60,14 @@ func loadExternalFile(
 		return "", fmt.Errorf("interpolate file path: %w", err)
 	}
 
-	resolvedPath := interpolatedPath
-	if strings.HasPrefix(interpolatedPath, "~/") {
+	resolvedPath := resolveLocalOverGlobal(interpolatedPath, wf.SourceDir, intCtx.AWF)
+	if strings.HasPrefix(resolvedPath, "~/") {
 		var homeDir string
 		homeDir, err = os.UserHomeDir()
 		if err != nil {
 			return "", fmt.Errorf("expand tilde in file path: %w", err)
 		}
-		resolvedPath = filepath.Join(homeDir, interpolatedPath[2:])
+		resolvedPath = filepath.Join(homeDir, resolvedPath[2:])
 
 		// Convenience: if ~/path doesn't exist in $HOME, try workflow.SourceDir/path instead.
 		// Allows users to write "~/scripts/foo.sh" for workflow-relative files.

--- a/internal/application/external_file_test.go
+++ b/internal/application/external_file_test.go
@@ -373,3 +373,197 @@ func TestLoadExternalFile_InterpolationError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "interpolate")
 }
+
+func TestLoadExternalFile_LocalOverridesGlobalScriptsDir(t *testing.T) {
+	globalDir := t.TempDir()
+	projectDir := t.TempDir()
+	sourceDir := filepath.Join(projectDir, "workflows")
+	require.NoError(t, os.MkdirAll(sourceDir, 0o755))
+
+	globalScriptsDir := filepath.Join(globalDir, "scripts")
+	globalFile := filepath.Join(globalScriptsDir, "deploy.sh")
+	require.NoError(t, os.MkdirAll(globalScriptsDir, 0o755))
+	require.NoError(t, os.WriteFile(globalFile, []byte("global content"), 0o644))
+
+	localFile := filepath.Join(projectDir, "scripts", "deploy.sh")
+	require.NoError(t, os.MkdirAll(filepath.Dir(localFile), 0o755))
+	require.NoError(t, os.WriteFile(localFile, []byte("local content"), 0o644))
+
+	wf := &workflow.Workflow{Name: "test", SourceDir: sourceDir}
+	intCtx := &interpolation.Context{
+		AWF: map[string]string{"scripts_dir": globalScriptsDir},
+	}
+
+	result, err := loadExternalFile(context.Background(), "{{.awf.scripts_dir}}/deploy.sh", wf, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "local content", result, "local script should override global")
+}
+
+func TestLoadExternalFile_FallbackToGlobalScriptsDir(t *testing.T) {
+	globalDir := t.TempDir()
+	projectDir := t.TempDir()
+	sourceDir := filepath.Join(projectDir, "workflows")
+	require.NoError(t, os.MkdirAll(sourceDir, 0o755))
+
+	globalScriptsDir := filepath.Join(globalDir, "scripts")
+	globalFile := filepath.Join(globalScriptsDir, "deploy.sh")
+	require.NoError(t, os.MkdirAll(globalScriptsDir, 0o755))
+	require.NoError(t, os.WriteFile(globalFile, []byte("global content"), 0o644))
+
+	wf := &workflow.Workflow{Name: "test", SourceDir: sourceDir}
+	intCtx := &interpolation.Context{
+		AWF: map[string]string{"scripts_dir": globalScriptsDir},
+	}
+
+	result, err := loadExternalFile(context.Background(), "{{.awf.scripts_dir}}/deploy.sh", wf, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "global content", result, "should fallback to global when no local exists")
+}
+
+func TestLoadExternalFile_LocalOverridesGlobalPromptsDir(t *testing.T) {
+	globalDir := t.TempDir()
+	projectDir := t.TempDir()
+	sourceDir := filepath.Join(projectDir, "workflows")
+	require.NoError(t, os.MkdirAll(sourceDir, 0o755))
+
+	globalPromptsDir := filepath.Join(globalDir, "prompts")
+	globalFile := filepath.Join(globalPromptsDir, "system.md")
+	require.NoError(t, os.MkdirAll(globalPromptsDir, 0o755))
+	require.NoError(t, os.WriteFile(globalFile, []byte("global prompt"), 0o644))
+
+	localFile := filepath.Join(projectDir, "prompts", "system.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(localFile), 0o755))
+	require.NoError(t, os.WriteFile(localFile, []byte("local prompt"), 0o644))
+
+	wf := &workflow.Workflow{Name: "test", SourceDir: sourceDir}
+	intCtx := &interpolation.Context{
+		AWF: map[string]string{"prompts_dir": globalPromptsDir},
+	}
+
+	result, err := loadExternalFile(context.Background(), "{{.awf.prompts_dir}}/system.md", wf, intCtx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "local prompt", result, "local prompt should override global")
+}
+
+func TestResolveLocalOverGlobal(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, projectDir, globalDir string) (interpolatedPath string, awfMap map[string]string)
+		wantPath string // "local" = under projectDir, "unchanged" = same as interpolatedPath
+	}{
+		{
+			name: "local scripts_dir overrides global when local file exists",
+			setup: func(t *testing.T, projectDir, globalDir string) (string, map[string]string) {
+				globalFile := filepath.Join(globalDir, "scripts", "deploy.sh")
+				require.NoError(t, os.MkdirAll(filepath.Dir(globalFile), 0o755))
+				require.NoError(t, os.WriteFile(globalFile, []byte("global"), 0o644))
+
+				localPath := filepath.Join(projectDir, "scripts", "deploy.sh")
+				require.NoError(t, os.MkdirAll(filepath.Dir(localPath), 0o755))
+				require.NoError(t, os.WriteFile(localPath, []byte("local"), 0o644))
+
+				return globalFile, map[string]string{"scripts_dir": filepath.Join(globalDir, "scripts")}
+			},
+			wantPath: "local",
+		},
+		{
+			name: "local prompts_dir overrides global when local file exists",
+			setup: func(t *testing.T, projectDir, globalDir string) (string, map[string]string) {
+				globalFile := filepath.Join(globalDir, "prompts", "greet.md")
+				require.NoError(t, os.MkdirAll(filepath.Dir(globalFile), 0o755))
+				require.NoError(t, os.WriteFile(globalFile, []byte("global"), 0o644))
+
+				localPath := filepath.Join(projectDir, "prompts", "greet.md")
+				require.NoError(t, os.MkdirAll(filepath.Dir(localPath), 0o755))
+				require.NoError(t, os.WriteFile(localPath, []byte("local"), 0o644))
+
+				return globalFile, map[string]string{"prompts_dir": filepath.Join(globalDir, "prompts")}
+			},
+			wantPath: "local",
+		},
+		{
+			name: "fallback to global scripts_dir when no local file",
+			setup: func(t *testing.T, projectDir, globalDir string) (string, map[string]string) {
+				globalFile := filepath.Join(globalDir, "scripts", "deploy.sh")
+				require.NoError(t, os.MkdirAll(filepath.Dir(globalFile), 0o755))
+				require.NoError(t, os.WriteFile(globalFile, []byte("global"), 0o644))
+
+				return globalFile, map[string]string{"scripts_dir": filepath.Join(globalDir, "scripts")}
+			},
+			wantPath: "unchanged",
+		},
+		{
+			name: "absolute non-XDG path is unchanged",
+			setup: func(t *testing.T, projectDir, globalDir string) (string, map[string]string) {
+				otherFile := filepath.Join(globalDir, "other.sh")
+				require.NoError(t, os.WriteFile(otherFile, []byte("other"), 0o644))
+
+				return otherFile, map[string]string{"scripts_dir": filepath.Join(globalDir, "scripts")}
+			},
+			wantPath: "unchanged",
+		},
+		{
+			name: "nested subpath preserves structure in local resolution",
+			setup: func(t *testing.T, projectDir, globalDir string) (string, map[string]string) {
+				globalFile := filepath.Join(globalDir, "scripts", "ci", "build.sh")
+				require.NoError(t, os.MkdirAll(filepath.Dir(globalFile), 0o755))
+				require.NoError(t, os.WriteFile(globalFile, []byte("global"), 0o644))
+
+				localPath := filepath.Join(projectDir, "scripts", "ci", "build.sh")
+				require.NoError(t, os.MkdirAll(filepath.Dir(localPath), 0o755))
+				require.NoError(t, os.WriteFile(localPath, []byte("local"), 0o644))
+
+				return filepath.Join(globalDir, "scripts", "ci", "build.sh"),
+					map[string]string{"scripts_dir": filepath.Join(globalDir, "scripts")}
+			},
+			wantPath: "local",
+		},
+		{
+			name: "empty AWF map returns path unchanged",
+			setup: func(t *testing.T, projectDir, globalDir string) (string, map[string]string) {
+				otherFile := filepath.Join(globalDir, "file.sh")
+				require.NoError(t, os.WriteFile(otherFile, []byte("content"), 0o644))
+
+				return otherFile, map[string]string{}
+			},
+			wantPath: "unchanged",
+		},
+		{
+			name: "nil AWF map returns path unchanged",
+			setup: func(t *testing.T, projectDir, globalDir string) (string, map[string]string) {
+				otherFile := filepath.Join(globalDir, "file.sh")
+				require.NoError(t, os.WriteFile(otherFile, []byte("content"), 0o644))
+
+				return otherFile, nil
+			},
+			wantPath: "unchanged",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projectDir := t.TempDir()
+			globalDir := t.TempDir()
+			// sourceDir simulates .awf/workflows/ — parent is where local scripts/prompts live
+			sourceDir := filepath.Join(projectDir, "workflows")
+			require.NoError(t, os.MkdirAll(sourceDir, 0o755))
+
+			interpolatedPath, awfMap := tt.setup(t, projectDir, globalDir)
+
+			result := resolveLocalOverGlobal(interpolatedPath, sourceDir, awfMap)
+
+			switch tt.wantPath {
+			case "local":
+				assert.NotEqual(t, interpolatedPath, result, "expected local path, got unchanged global path")
+				assert.True(t, strings.HasPrefix(result, projectDir), "expected path under projectDir, got: %s", result)
+				_, statErr := os.Stat(result)
+				assert.NoError(t, statErr, "resolved local path must exist")
+			case "unchanged":
+				assert.Equal(t, interpolatedPath, result, "expected path unchanged")
+			}
+		})
+	}
+}

--- a/tests/integration/cli/cli_test_helpers_test.go
+++ b/tests/integration/cli/cli_test_helpers_test.go
@@ -3,9 +3,12 @@
 package cli_test
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/awf-project/awf/internal/interfaces/cli"
 )
 
 // setupTestDir creates a temporary directory for test isolation.
@@ -56,6 +59,22 @@ func createTestWorkflow(t *testing.T, baseDir, filename, content string) {
 	if err := os.WriteFile(workflowPath, []byte(content), 0o644); err != nil {
 		t.Fatalf("failed to write workflow file: %v", err)
 	}
+}
+
+// runCLI creates a root command, sets the given args, executes it, and returns
+// the combined stdout+stderr output along with any error.
+func runCLI(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+
+	return out.String(), err
 }
 
 // findRepoRoot walks up the directory tree to find the repository root

--- a/tests/integration/cli/run_script_file_test.go
+++ b/tests/integration/cli/run_script_file_test.go
@@ -3,12 +3,10 @@
 package cli_test
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/awf-project/awf/internal/interfaces/cli"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,16 +34,8 @@ states:
 `
 	createTestWorkflow(t, tmpDir, "script-file-basic.yaml", workflowContent)
 
-	cmd := cli.NewRootCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"run", "script-file-basic", "--dry-run"})
-
-	err = cmd.Execute()
+	output, err := runCLI(t, "run", "script-file-basic", "--dry-run")
 	require.NoError(t, err)
-
-	output := out.String()
 	assert.Contains(t, output, "basic script executed", "script should be loaded and executed")
 }
 
@@ -76,16 +66,8 @@ states:
 `
 	createTestWorkflow(t, tmpDir, "relative-path.yaml", workflowContent)
 
-	cmd := cli.NewRootCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"run", "relative-path", "--dry-run"})
-
-	err := cmd.Execute()
+	output, err := runCLI(t, "run", "relative-path", "--dry-run")
 	require.NoError(t, err)
-
-	output := out.String()
 	assert.Contains(t, output, "relative script executed", "should load script from relative path")
 }
 
@@ -118,16 +100,8 @@ states:
 `
 	createTestWorkflow(t, tmpDir, "awf-scripts-dir.yaml", workflowContent)
 
-	cmd := cli.NewRootCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"run", "awf-scripts-dir", "--dry-run"})
-
-	err := cmd.Execute()
+	output, err := runCLI(t, "run", "awf-scripts-dir", "--dry-run")
 	require.NoError(t, err)
-
-	output := out.String()
 	assert.Contains(t, output, "awf scripts dir executed", "should resolve AWF scripts directory template variable")
 }
 
@@ -158,16 +132,8 @@ states:
 `
 	createTestWorkflow(t, tmpDir, "absolute-path.yaml", workflowContent)
 
-	cmd := cli.NewRootCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"run", "absolute-path", "--dry-run"})
-
-	err := cmd.Execute()
+	output, err := runCLI(t, "run", "absolute-path", "--dry-run")
 	require.NoError(t, err)
-
-	output := out.String()
 	assert.Contains(t, output, "absolute path executed", "should load script from absolute path")
 }
 
@@ -203,16 +169,8 @@ states:
 `
 	createTestWorkflow(t, tmpDir, "tilde-expansion.yaml", workflowContent)
 
-	cmd := cli.NewRootCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"run", "tilde-expansion", "--dry-run"})
-
-	err = cmd.Execute()
+	output, err := runCLI(t, "run", "tilde-expansion", "--dry-run")
 	require.NoError(t, err)
-
-	output := out.String()
 	assert.Contains(t, output, "tilde path executed", "should expand tilde to home directory")
 }
 
@@ -243,16 +201,8 @@ states:
 `
 	createTestWorkflow(t, tmpDir, "content-interpolation.yaml", workflowContent)
 
-	cmd := cli.NewRootCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"run", "content-interpolation", "--dry-run", "--input=value=TestData"})
-
-	err = cmd.Execute()
+	output, err := runCLI(t, "run", "content-interpolation", "--dry-run", "--input=value=TestData")
 	require.NoError(t, err)
-
-	output := out.String()
 	assert.Contains(t, output, "Value: TestData", "script content should be interpolated with input value")
 }
 
@@ -283,16 +233,8 @@ states:
 `
 	createTestWorkflow(t, tmpDir, "dry-run-test.yaml", workflowContent)
 
-	cmd := cli.NewRootCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"run", "dry-run-test", "--dry-run"})
-
-	err := cmd.Execute()
+	output, err := runCLI(t, "run", "dry-run-test", "--dry-run")
 	require.NoError(t, err)
-
-	output := out.String()
 	assert.Contains(t, output, "echo \"dry run test\"", "dry run should show resolved script content")
 }
 
@@ -314,16 +256,8 @@ states:
 `
 	createTestWorkflow(t, tmpDir, "missing-file.yaml", workflowContent)
 
-	cmd := cli.NewRootCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"run", "missing-file", "--dry-run"})
-
-	err := cmd.Execute()
+	output, err := runCLI(t, "run", "missing-file", "--dry-run")
 	require.Error(t, err, "should fail with missing file error")
-
-	output := out.String()
 	assert.Contains(t, output, "file not found", "error should mention missing script file")
 	assert.Contains(t, output, "missing.sh", "error should include the file path")
 }
@@ -347,16 +281,8 @@ states:
 `
 	createTestWorkflow(t, tmpDir, "mutual-exclusivity.yaml", workflowContent)
 
-	cmd := cli.NewRootCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"validate", "mutual-exclusivity"})
-
-	err := cmd.Execute()
+	output, err := runCLI(t, "validate", "mutual-exclusivity")
 	require.Error(t, err, "validation should fail when both command and script_file are set")
-
-	output := out.String()
 	assert.Contains(t, output, "mutually exclusive", "error should mention mutual exclusivity")
 }
 
@@ -383,16 +309,8 @@ states:
 `
 	createTestWorkflow(t, tmpDir, "nested-path.yaml", workflowContent)
 
-	cmd := cli.NewRootCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"run", "nested-path", "--dry-run"})
-
-	err = cmd.Execute()
+	output, err := runCLI(t, "run", "nested-path", "--dry-run")
 	require.NoError(t, err)
-
-	output := out.String()
 	assert.Contains(t, output, "local script", "nested script should be loaded and executed")
 }
 
@@ -433,16 +351,53 @@ states:
 `
 	createTestWorkflow(t, tmpDir, "multiple-steps.yaml", workflowContent)
 
-	cmd := cli.NewRootCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"run", "multiple-steps", "--dry-run"})
-
-	err := cmd.Execute()
+	output, err := runCLI(t, "run", "multiple-steps", "--dry-run")
 	require.NoError(t, err)
-
-	output := out.String()
 	assert.Contains(t, output, "step one executed", "first script should be loaded")
 	assert.Contains(t, output, "step two executed", "second script should be loaded")
+}
+
+// TestRunCommand_ScriptFile_LocalOverridesGlobalAWFScriptsDir verifies local scripts take precedence over global XDG scripts
+// AC: When both local and global scripts exist, {{.awf.scripts_dir}} resolves to the local workflow-relative script
+// Regression guard for B005
+func TestRunCommand_ScriptFile_LocalOverridesGlobalAWFScriptsDir(t *testing.T) {
+	tmpDir := setupInitTestDir(t)
+
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	globalScriptsDir := filepath.Join(tmpDir, "awf", "scripts")
+	require.NoError(t, os.MkdirAll(globalScriptsDir, 0o755))
+
+	globalScriptContent := `#!/bin/sh
+echo "GLOBAL SCRIPT"
+`
+	globalScriptPath := filepath.Join(globalScriptsDir, "deploy.sh")
+	require.NoError(t, os.WriteFile(globalScriptPath, []byte(globalScriptContent), 0o755))
+
+	localScriptsDir := filepath.Join(tmpDir, ".awf", "scripts")
+	require.NoError(t, os.MkdirAll(localScriptsDir, 0o755))
+
+	localScriptContent := `#!/bin/sh
+echo "LOCAL SCRIPT"
+`
+	localScriptPath := filepath.Join(localScriptsDir, "deploy.sh")
+	require.NoError(t, os.WriteFile(localScriptPath, []byte(localScriptContent), 0o755))
+
+	workflowContent := `name: local-override-test
+version: "1.0.0"
+states:
+  initial: deploy
+  deploy:
+    type: step
+    script_file: "{{.awf.scripts_dir}}/deploy.sh"
+    on_success: done
+  done:
+    type: terminal
+`
+	createTestWorkflow(t, tmpDir, "local-override-test.yaml", workflowContent)
+
+	output, err := runCLI(t, "run", "local-override-test", "--dry-run")
+	require.NoError(t, err)
+	assert.Contains(t, output, "LOCAL SCRIPT", "local script should take precedence over global XDG script")
+	assert.NotContains(t, output, "GLOBAL SCRIPT", "global script should not be used when local exists")
 }


### PR DESCRIPTION
## Summary

- ec0cffa fix(external-file): prefer local scripts/prompts over global XDG paths

## Changes

```
 CHANGELOG.md                                   |  20 +++
 CLAUDE.md                                      |   8 +
 README.md                                      |   4 +-
 docs/reference/interpolation.md                |  27 ++++
 docs/user-guide/agent-steps.md                 |  30 +++-
 docs/user-guide/workflow-syntax.md             |  29 +++-
 internal/application/external_file.go          |  35 ++++-
 internal/application/external_file_test.go     | 194 +++++++++++++++++++++++++
 tests/integration/cli/cli_test_helpers_test.go |  19 +++
 tests/integration/cli/run_script_file_test.go  | 157 +++++++-------------
 10 files changed, 412 insertions(+), 111 deletions(-)
```

Closes #230


---
Generated with awf commit workflow

