### PR TITLE
feat(workflow): add inline on_failure error terminal shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Zero breaking changes: all existing consumers compile unchanged
 
 ### Added
+- **F066**: Inline Error Terminal Shorthand for on_failure
+  - `on_failure` now accepts an inline object `{message: "...", status: N}` in addition to the existing string form
+  - Inline objects are synthesized into anonymous terminal states at parse time — no changes to execution engine
+  - `message` field supports full template interpolation (`{{inputs.*}}`, `{{states.*}}`, `{{env.*}}`)
+  - `status` defaults to exit code `1` when omitted
+  - `awf validate` reports clear errors for missing or empty `message`
+  - Works in parallel step branches
+  - Full backward compatibility: existing string-form `on_failure` references are unchanged
 - **F068**: Exit Code Based Transition Routing
   - Transitions with `when` conditions are now evaluated on non-zero exit paths, not just success paths
   - `states.<step>.ExitCode` supports all 6 numeric comparison operators (`==`, `!=`, `<`, `>`, `<=`, `>=`) in transition conditions
@@ -317,6 +325,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Affects: Template interpolation, workflow validation, all state references
 
 ### Added
+- **F066**: Inline Error Terminal Shorthand for on_failure
+  - `on_failure` accepts inline object `{message: "...", status: N}` as shorthand for named terminal states
+  - Synthesized at parse time; `message` supports interpolation; `status` defaults to `1`
 - **F068**: Exit Code Based Transition Routing
 - **F065**: Output Format for Agent Steps
 - **F063**: Prompt File Loading for Agent Steps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,8 @@ Inject optional dependencies like XDG paths via SetAWFPaths() pattern in applica
 
 Restrict local XDG overrides to scripts_dir and prompts_dir only; use allowlist-based matching against AWF map values to prevent unintended path resolution
 
+Synthesize inline on_failure objects into anonymous terminal steps at YAML parse time via normalizeOnFailure() and synthesizeInlineErrorTerminal() in infrastructure layer; domain Step.OnFailure remains string type with zero changes to existing consumers
+
 ## Common Pitfalls
 
 Preserve existing infrastructure layers when adding domain registries; ADR-004 enforces infrastructure plugin registry coexistence for separate lifecycle concerns
@@ -261,6 +263,10 @@ Always resolve script_file and prompt_file paths against workflow.SourceDir firs
 
 Never initialize interpolation context with nil AWF map; always pass initialized empty map to prevent nil dereference in path resolution helpers
 
+Never initialize interpolation context with nil AWF map in loadExternalFile() and related functions; always pass initialized empty map to prevent nil dereference in resolveLocalOverGlobal() and path resolution helpers
+
+Always use interpolateTerminalMessage() in application layer to evaluate template variables in Step.Message at runtime; store message verbatim during parsing to preserve {{var}} syntax until execution time
+
 ## Test Conventions
 
 Integration tests use compile-time interface checks (var _ PortInterface = (*Implementation)(nil)) to verify port implementation at build time
@@ -272,6 +278,8 @@ Write unit tests for prompt file validation, interpolation, and YAML mapping bef
 Write unit tests for prompt file validation, interpolation, and YAML mapping before integration tests; use table-driven tests for path resolution scenarios
 
 Never use switch statements to populate table-driven test variables; declare all fields in struct literals to prevent silent zero-value failures from missed case names
+
+Write table-driven tests for inline error object parsing (message + status validation) before integration tests; use yamlStep.OnFailure field as 'any' type in test fixtures to validate both string and object forms
 
 ## Review Standards
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Go CLI tool for orchestrating AI agents (Claude, Gemini, Codex) through YAML-c
 ## Features
 
 - **State Machine Execution** - Define workflows as state machines with conditional transitions based on exit codes, command output, or custom expressions
+- **Inline Error Handling** - Specify error messages and exit codes directly on steps without creating separate terminal states
 - **Agent Steps** - Invoke AI CLI agents (Claude, Codex, Gemini) with prompt templates and response parsing
 - **Output Formatting for Agent Steps** - Automatically strip markdown code fences and validate JSON output
 - **External Prompt Files** - Load agent prompts from `.md` files with full template interpolation, helper functions, and local override support

--- a/docs/ADR/.template.md
+++ b/docs/ADR/.template.md
@@ -1,0 +1,65 @@
+# NNNN: [Decision Title]
+
+**Status**: Proposed | Accepted | Superseded | Deprecated
+**Date**: YYYY-MM-DD
+**Supersedes**: [ADR-NNNN or N/A]
+**Superseded by**: [ADR-NNNN or N/A]
+
+## Context
+
+<!--
+  What is the issue motivating this decision?
+  What forces are at play (technical, business, team)?
+  Include relevant constraints and prior art.
+-->
+
+[Describe the problem, the forces at play, and why a decision is needed now.]
+
+## Candidates
+
+<!--
+  List options considered. Include at least 2 alternatives.
+  Score or compare them on relevant dimensions.
+-->
+
+| Option | Pros | Cons |
+|--------|------|------|
+| [Option A] | [advantages] | [disadvantages] |
+| [Option B] | [advantages] | [disadvantages] |
+| [Option C] | [advantages] | [disadvantages] |
+
+## Decision
+
+<!--
+  State the decision clearly. Use "We will..." or "Adopt X because..."
+  Include enough detail to implement without ambiguity.
+-->
+
+[What is the change that we're proposing and/or doing?]
+
+## Consequences
+
+<!--
+  Be honest about trade-offs. Every decision has costs.
+-->
+
+**What becomes easier:**
+- [Benefit 1]
+- [Benefit 2]
+
+**What becomes harder:**
+- [Cost 1]
+- [Cost 2]
+
+## Constitution Compliance
+
+<!--
+  Map this decision to the project's governing principles.
+  Reference .specify/memory/constitution.md.
+  Mark each relevant principle as Compliant / Violation (justified) / N/A.
+  Omit this section if the project has no constitution.
+-->
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| [Principle Name] | Compliant / Violation / N/A | [1-sentence explanation] |

--- a/docs/ADR/0001-hexagonal-architecture.md
+++ b/docs/ADR/0001-hexagonal-architecture.md
@@ -1,0 +1,59 @@
+# 0001: Hexagonal Architecture
+
+**Status**: Accepted
+**Date**: 2025-12-01
+**Supersedes**: N/A
+**Superseded by**: N/A
+
+## Context
+
+AWF is a CLI tool that orchestrates AI agents through YAML workflows. The core domain (workflows, state machines, execution context) must remain independent from delivery mechanisms (CLI today, API/MQ future) and infrastructure choices (YAML parsing, JSON state store, shell execution).
+
+Without strict boundary enforcement, domain logic leaks into CLI handlers or infrastructure adapters, making testing painful and swapping implementations expensive.
+
+## Candidates
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Hexagonal/Clean Architecture | Testable domain, swappable adapters, clear boundaries | More files, indirection cost, strict discipline required |
+| Layered (traditional MVC) | Familiar, less boilerplate | Domain couples to framework, hard to test without DB/CLI |
+| Flat structure (single package) | Simple, fast to start | Becomes unmaintainable past ~5K LOC, circular deps |
+
+## Decision
+
+Adopt hexagonal architecture with four layers and strict dependency inversion:
+
+```
+internal/
+├── domain/          # Entities, value objects, ports (interfaces)
+├── application/     # Use cases, services (WorkflowService, ExecutionService)
+├── infrastructure/  # Adapters (YAMLRepository, JSONStateStore, ShellExecutor)
+└── interfaces/      # Entry points (cli/)
+```
+
+Rules:
+- Domain layer depends on nothing
+- Application layer depends only on domain
+- Infrastructure layer implements domain ports
+- Interfaces layer depends on application
+- Ports (interfaces) defined in domain, implemented in infrastructure
+
+## Consequences
+
+**What becomes easier:**
+- Unit testing domain and application layers without infrastructure
+- Adding new delivery mechanisms (API, MQ) without touching domain
+- Swapping infrastructure (e.g., SQLite → PostgreSQL) by implementing same port
+
+**What becomes harder:**
+- Simple features require touching multiple layers
+- New contributors need to understand the layer boundaries
+- go-arch-lint rules must be maintained to enforce boundaries
+
+## Constitution Compliance
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| Hexagonal Architecture | Compliant | This ADR defines the principle |
+| Go Idioms | Compliant | Interfaces in consumer package, composition over inheritance |
+| Minimal Abstraction | Compliant | Ports only where multiple implementations exist or are planned |

--- a/docs/ADR/0002-error-taxonomy-exit-codes.md
+++ b/docs/ADR/0002-error-taxonomy-exit-codes.md
@@ -1,0 +1,54 @@
+# 0002: Error Taxonomy with Exit Codes
+
+**Status**: Accepted
+**Date**: 2025-12-01
+**Supersedes**: N/A
+**Superseded by**: N/A
+
+## Context
+
+AWF is a CLI tool used in scripts and CI pipelines. Consumers need to programmatically distinguish error categories to decide retry strategy, user messaging, and escalation. A single non-zero exit code forces callers to parse stderr text, which is fragile and locale-dependent.
+
+## Candidates
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Fixed exit code taxonomy (1-4) | Scriptable, simple, universal | Limited to 4 categories, no sub-codes |
+| Structured JSON error output | Rich metadata, extensible | Requires parsing, breaks simple `$?` checks |
+| Single non-zero exit (1) | Simplest implementation | No differentiation, useless for automation |
+
+## Decision
+
+Map exit codes to four error categories:
+
+| Code | Category | Examples |
+|------|----------|----------|
+| `1` | User error | Bad input, missing file, invalid workflow name |
+| `2` | Configuration error | Invalid config, missing dependency, bad YAML |
+| `3` | Execution error | Command failed, timeout, agent error |
+| `4` | System error | IO failure, permissions, disk full |
+
+Rules:
+- Every error path must produce exactly one of these codes
+- Error types defined in domain layer
+- Infrastructure maps native errors to taxonomy
+- Exit code 0 = success, always
+
+## Consequences
+
+**What becomes easier:**
+- Scripting: `awf run X || case $? in 1) ... 2) ... esac`
+- CI pipelines can distinguish retryable (3) from fatal (1, 2, 4) errors
+- Consistent user feedback across all commands
+
+**What becomes harder:**
+- Adding new categories requires semver major bump
+- Infrastructure errors must be correctly classified (not just "exit 1")
+
+## Constitution Compliance
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| Error Taxonomy | Compliant | This ADR defines the principle |
+| Go Idioms | Compliant | Custom error types with Error() method |
+| Security First | Compliant | Error messages never leak secrets |

--- a/docs/ADR/0003-yaml-state-machine-workflows.md
+++ b/docs/ADR/0003-yaml-state-machine-workflows.md
@@ -1,0 +1,51 @@
+# 0003: YAML State Machine for Workflow Definition
+
+**Status**: Accepted
+**Date**: 2025-12-01
+**Supersedes**: N/A
+**Superseded by**: N/A
+
+## Context
+
+AWF needs a way for users to define multi-step workflows that orchestrate AI agents and shell commands. The definition format must be human-readable, version-controllable, and expressive enough to handle branching, parallelism, retries, and loops — without requiring programming knowledge.
+
+## Candidates
+
+| Option | Pros | Cons |
+|--------|------|------|
+| YAML state machine | Human-readable, versionable, declarative, familiar syntax | Limited expressiveness, custom DSL to learn |
+| Go plugin system | Full language power, type-safe | Requires Go knowledge, compilation step, not portable |
+| JSON/TOML config | Machine-friendly, standard parsers | JSON verbose for humans, TOML lacks nesting depth |
+| Lua/Starlark scripting | Turing-complete, sandboxed | Extra runtime, security surface, steeper learning curve |
+
+## Decision
+
+Use YAML files with state machine semantics. Each workflow is a directed graph of states with typed transitions:
+
+- State types: `step`, `agent`, `parallel`, `terminal`, `for_each`, `while`, `operation`, `call_workflow`
+- Transitions via `on_success`, `on_failure`, and conditional `transitions` list
+- Go template interpolation (`{{.inputs.name}}`, `{{.states.prev.Output}}`)
+- External files via `script_file` and `prompt_file` for complex content
+
+Template interpolation uses Go template syntax (`{{var}}`) instead of shell syntax (`${var}`) to avoid conflicts with shell commands in step definitions.
+
+## Consequences
+
+**What becomes easier:**
+- Non-developers can author workflows
+- Workflows are diff-friendly and reviewable in PRs
+- Static validation possible (`awf validate`)
+- Visualization (`awf diagram`)
+
+**What becomes harder:**
+- Complex logic requires workarounds (exit codes as routing signals)
+- No native functions/variables — must use shell for computation
+- Template syntax learning curve for Go-unfamiliar users
+
+## Constitution Compliance
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| Hexagonal Architecture | Compliant | YAML parsing in infrastructure, domain defines Workflow entity |
+| Minimal Abstraction | Compliant | Declarative over programmatic, only the state types needed |
+| Documentation Co-location | Compliant | Workflows self-document via description fields |

--- a/docs/ADR/0004-domain-operation-registry.md
+++ b/docs/ADR/0004-domain-operation-registry.md
@@ -1,0 +1,49 @@
+# 0004: Domain Operation Registry with Infrastructure Coexistence
+
+**Status**: Accepted
+**Date**: 2025-12-01
+**Supersedes**: N/A
+**Superseded by**: N/A
+
+## Context
+
+AWF supports plugin operations (GitHub, notifications, HTTP) that extend workflow capabilities. Operations need registration, discovery, and execution. The question is where the registry lives: domain (pure, testable) or infrastructure (concrete, direct access to adapters).
+
+Both registries serve different lifecycle concerns: domain owns the contract, infrastructure owns the wiring.
+
+## Candidates
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Domain registry only | Pure, testable, no infra dependency | Can't auto-discover infrastructure plugins |
+| Infrastructure registry only | Direct access to adapters, auto-wiring | Domain depends on infrastructure, untestable |
+| Composite (domain + infrastructure) | Separation of concerns, testable domain, flexible infra | Two registries to maintain, routing complexity |
+
+## Decision
+
+Implement OperationRegistry in domain layer implementing `ports.OperationProvider`. Infrastructure maintains its own plugin registry for lifecycle management (init, cleanup). A CompositeOperationProvider in application layer merges both.
+
+Rules:
+- Domain registry: pure Go, no external deps, implements port directly on domain type
+- Infrastructure registry: manages concrete adapters (HTTP providers, etc.)
+- Application layer wires both via CompositeOperationProvider
+- Preserve both registries — never collapse into one
+
+## Consequences
+
+**What becomes easier:**
+- Unit testing operations without infrastructure
+- Adding pure-domain operations (validators, transformers)
+- Infrastructure plugins have independent lifecycle (init/cleanup)
+
+**What becomes harder:**
+- Operation lookup traverses two registries
+- New contributors must understand the composite pattern
+
+## Constitution Compliance
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| Hexagonal Architecture | Compliant | Domain defines port, infrastructure implements adapter |
+| Go Idioms | Compliant | Interface in consumer (domain), struct in provider (infrastructure) |
+| Minimal Abstraction | Compliant | Composite justified by two concrete lifecycle needs |

--- a/docs/ADR/0005-atomic-file-writes.md
+++ b/docs/ADR/0005-atomic-file-writes.md
@@ -1,0 +1,52 @@
+# 0005: Atomic File Writes for State Persistence
+
+**Status**: Accepted
+**Date**: 2025-12-01
+**Supersedes**: N/A
+**Superseded by**: N/A
+
+## Context
+
+AWF persists workflow state to JSON files during execution. Workflows can be long-running (minutes) and may be interrupted by signals, crashes, or concurrent access. A partial write would corrupt the state file, making workflow resumption impossible.
+
+## Candidates
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Atomic write (temp + rename) | Corruption-proof, OS-guaranteed atomicity on same filesystem | Requires same-filesystem temp, slightly more code |
+| Direct write with fsync | Simpler code | Partial writes on crash, no protection against concurrent access |
+| SQLite WAL | ACID transactions, concurrent reads | CGO dependency (already present), heavier for simple state |
+
+## Decision
+
+Use temp file + rename pattern for all state file writes:
+
+1. Write to unique temp file (PID + timestamp suffix) in same directory
+2. Sync to disk
+3. Rename atomically to target path
+4. File locking for concurrent access protection
+
+Rules:
+- All file writes in infrastructure layer use this pattern
+- Temp file names include PID and timestamp for uniqueness
+- Same-directory temp files to guarantee same-filesystem rename
+- File locking via `flock` for concurrent JSONStore access
+
+## Consequences
+
+**What becomes easier:**
+- Workflow resume after crash is always safe
+- Concurrent `awf status` reads never see partial state
+- No corruption recovery code needed
+
+**What becomes harder:**
+- Slightly more complex write path
+- Must ensure temp files are cleaned up on error paths
+
+## Constitution Compliance
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| Security First | Compliant | Prevents data corruption, ensures integrity |
+| Go Idioms | Compliant | Uses os.Rename which is atomic on POSIX |
+| Error Taxonomy | Compliant | Write failures map to exit code 4 (system error) |

--- a/docs/ADR/0006-xdg-path-resolution.md
+++ b/docs/ADR/0006-xdg-path-resolution.md
@@ -1,0 +1,61 @@
+# 0006: XDG-Compliant Path Resolution
+
+**Status**: Accepted
+**Date**: 2025-12-01
+**Supersedes**: N/A
+**Superseded by**: N/A
+
+## Context
+
+AWF has three categories of files: configuration (workflows, templates), runtime state (execution logs, history), and cache. These files need well-defined locations that work across Linux, macOS, and respect user customization.
+
+Additionally, workflows reference external files (`script_file`, `prompt_file`) that must resolve correctly regardless of where `awf` is invoked from. Resolution must handle: workflow-relative paths, project-local overrides, and global XDG paths.
+
+## Candidates
+
+| Option | Pros | Cons |
+|--------|------|------|
+| XDG Base Directory Specification | Standard on Linux, predictable, user-overridable | macOS convention differs (~Library/), verbose paths |
+| Single ~/.awf directory | Simple, discoverable | Mixes config/state/cache, no standard |
+| Binary-relative paths | Portable, self-contained | Breaks on system install, no user customization |
+
+## Decision
+
+Follow XDG Base Directory Specification:
+
+| Variable | Default | AWF Usage |
+|----------|---------|-----------|
+| `XDG_CONFIG_HOME` | `~/.config` | `~/.config/awf/` — workflows, templates, prompts |
+| `XDG_STATE_HOME` | `~/.local/state` | `~/.local/state/awf/` — logs, history.db |
+| `XDG_CACHE_HOME` | `~/.cache` | `~/.cache/awf/` — temporary downloads |
+
+Path resolution order for `script_file` / `prompt_file`:
+1. Resolve relative to `workflow.SourceDir`
+2. Check for local project override via `resolveLocalOverGlobal()`
+3. Fall back to global XDG path
+
+Rules:
+- Application layer populates AWF context variables (`.awf.config_dir`, `.awf.cache_dir`)
+- Local XDG overrides restricted to `scripts_dir` and `prompts_dir` only (allowlist)
+- Never import infrastructure modules from application layer for path resolution
+- Inject XDG paths via `SetAWFPaths()` pattern in application layer
+
+## Consequences
+
+**What becomes easier:**
+- Users can override all paths via environment variables
+- System packages can separate config from state
+- Project-local scripts/prompts override globals transparently
+
+**What becomes harder:**
+- Path resolution logic is multi-step (3 levels of fallback)
+- Testing requires mocking XDG environment variables
+- allowlist must be maintained when adding new overridable paths
+
+## Constitution Compliance
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| Hexagonal Architecture | Compliant | Path resolution in application, file access in infrastructure |
+| Go Idioms | Compliant | os.Getenv for XDG, no magic globals |
+| Security First | Compliant | Allowlist prevents unintended path resolution |

--- a/docs/ADR/0007-agent-prompt-xor-constraint.md
+++ b/docs/ADR/0007-agent-prompt-xor-constraint.md
@@ -1,0 +1,51 @@
+# 0007: Agent Prompt XOR Constraint
+
+**Status**: Accepted
+**Date**: 2025-12-01
+**Supersedes**: N/A
+**Superseded by**: N/A
+
+## Context
+
+Agent steps accept prompts in two forms: inline `prompt` field (for short prompts) and `prompt_file` field (for external markdown files with template interpolation). If both are set, behavior is ambiguous — which one wins? Silent precedence rules cause subtle bugs in workflow authoring.
+
+## Candidates
+
+| Option | Pros | Cons |
+|--------|------|------|
+| XOR constraint (exactly one) | Unambiguous, fails fast, clear error | Slightly less flexible |
+| Precedence rule (file wins) | Allows both, predictable | Silent override, confusing when inline is ignored |
+| Merge (inline as fallback) | Maximum flexibility | Complex semantics, hard to debug |
+
+## Decision
+
+Enforce mutual exclusivity at validation time:
+
+- `AgentConfig.Validate()` rejects configurations where both `Prompt` and `PromptFile` are set
+- Error message explicitly names both fields and states the constraint
+- `awf validate` catches this statically before execution
+- `prompt_file` supports full Go template interpolation and resolves via ADR-0006 path resolution
+- 1MB size limit on loaded prompt files via `io.LimitReader`
+
+Rules:
+- Exactly one of `prompt` or `prompt_file` must be set on agent steps
+- Validation in domain layer (`AgentConfig.Validate()`)
+- Same constraint applies: never both, never neither
+
+## Consequences
+
+**What becomes easier:**
+- Workflow authors get immediate feedback on misconfiguration
+- No ambiguity about which prompt is used
+- Debugging agent behavior — single source of truth
+
+**What becomes harder:**
+- Can't use inline prompt as fallback for missing file (must handle in workflow logic)
+
+## Constitution Compliance
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| Go Idioms | Compliant | Validation at parse time, explicit error handling |
+| Minimal Abstraction | Compliant | Simple boolean check, no complex merge logic |
+| Error Taxonomy | Compliant | Validation error = exit code 2 (configuration error) |

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -1,0 +1,54 @@
+# Architecture Decision Records
+
+This directory contains the Architecture Decision Records (ADRs) for this project.
+
+## Format
+
+Each ADR follows this structure:
+
+```markdown
+# NNNN: Title
+
+**Status**: Proposed | Accepted | Superseded | Deprecated
+**Date**: YYYY-MM-DD
+
+## Context       — What is the issue motivating this decision?
+## Candidates    — Options considered with trade-offs
+## Decision      — What we chose and why
+## Consequences  — What becomes easier/harder
+## Constitution Compliance — Mapping to project principles
+```
+
+## Numbering Convention
+
+ADRs are numbered sequentially: `0001`, `0002`, etc.
+Numbers are never reused. If a decision is reversed, the original ADR is marked "Superseded" and a new ADR is created with a reference.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-hexagonal-architecture.md) | Hexagonal Architecture | Accepted |
+| [0002](0002-error-taxonomy-exit-codes.md) | Error Taxonomy with Exit Codes | Accepted |
+| [0003](0003-yaml-state-machine-workflows.md) | YAML State Machine for Workflow Definition | Accepted |
+| [0004](0004-domain-operation-registry.md) | Domain Operation Registry with Infrastructure Coexistence | Accepted |
+| [0005](0005-atomic-file-writes.md) | Atomic File Writes for State Persistence | Accepted |
+| [0006](0006-xdg-path-resolution.md) | XDG-Compliant Path Resolution | Accepted |
+| [0007](0007-agent-prompt-xor-constraint.md) | Agent Prompt XOR Constraint | Accepted |
+
+## Creating a New ADR
+
+1. Find the next number: `ls docs/ADR/ | grep -oP '^\d+' | sort -n | tail -1` + 1
+2. Copy the template: `cp docs/ADR/.template.md docs/ADR/NNNN-short-name.md`
+3. Fill in all sections
+4. Update this index
+5. Submit for review
+
+## Pre-Merge Checklist
+
+Before merging any new or modified ADR:
+
+- [ ] **Cross-references**: All `[ADR-NNNN]` links resolve to existing files
+- [ ] **Supersession**: If changing a prior decision, both ADRs have `Supersedes`/`Superseded by` metadata
+- [ ] **Constitution**: Compliance section maps to current constitution version
+- [ ] **Candidates**: At least 2 alternatives documented with trade-offs

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Learn how to use AWF effectively:
 - [Conversation Mode](user-guide/conversation-steps.md) - Multi-turn conversations with context window management
 - [Configuration](user-guide/configuration.md) - Project configuration file
 - [Workflow Syntax](user-guide/workflow-syntax.md) - YAML workflow definition reference
+  - [Inline Error Shorthand](user-guide/workflow-syntax.md#inline-error-shorthand) - Specify error messages directly on steps without separate terminal states
   - [External Script Files](user-guide/workflow-syntax.md#external-script-files) - Load shell commands from external `.sh` files with template interpolation
   - [GitHub Operations](user-guide/workflow-syntax.md#github-operations) - Built-in GitHub plugin with declarative operations
   - [HTTP Operations](user-guide/workflow-syntax.md#http-operations) - Built-in HTTP operation for REST API calls

--- a/docs/plans/2026-02-17-f066-code-review-corrections.md
+++ b/docs/plans/2026-02-17-f066-code-review-corrections.md
@@ -1,0 +1,548 @@
+# F066 Code Review Corrections Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix 2 blocking issues and 5 quality issues found in F066 code review before merge.
+
+**Architecture:** Three independent correction streams designed for parallel subagent execution. Stream A fixes interactive executor terminal handling (application layer). Stream B adds ExitCode propagation (domain → infra → app). Stream C applies code quality fixes across test and source files.
+
+**Tech Stack:** Go, testify, TDD (red-green-refactor)
+
+---
+
+## Parallelization Map
+
+```
+┌─────────────────────┐  ┌─────────────────────┐  ┌─────────────────────┐
+│  STREAM A (Agent 1)  │  │  STREAM B (Agent 2)  │  │  STREAM C (Agent 3)  │
+│                      │  │                      │  │                      │
+│  Issue #2: Interactive│  │  Issues #1,#3,#4:    │  │  Issues #6,#7,#8,    │
+│  executor terminal   │  │  ExitCode field +    │  │  #9,#10,#11:         │
+│  failure handling    │  │  status propagation  │  │  Code quality fixes  │
+│                      │  │                      │  │                      │
+│  Files:              │  │  Files:              │  │  Files:              │
+│  - interactive_      │  │  - step.go           │  │  - execution_        │
+│    executor.go       │  │  - yaml_mapper.go    │  │    service.go (:260) │
+│  - interactive_      │  │  - yaml_mapper_on_   │  │  - yaml_mapper.go    │
+│    executor_test.go  │  │    failure_test.go   │  │    (doc comments)    │
+│    (NEW)             │  │  - builders.go       │  │  - on_failure_       │
+│                      │  │  - execution_service │  │    inline_test.go    │
+│  NO OVERLAP         │  │    .go (:260,:1482)  │  │    (statesDir,       │
+│                      │  │  - execution_service │  │     helper)          │
+│                      │  │    _on_failure_      │  │                      │
+│                      │  │    inline_test.go    │  │                      │
+│                      │  │  - on_failure_       │  │                      │
+│                      │  │    inline_test.go    │  │                      │
+└─────────────────────┘  └─────────────────────┘  └─────────────────────┘
+         │                         │                         │
+         └─────────────┬───────────┘─────────────────────────┘
+                       ▼
+              Final: run all tests
+```
+
+**Conflict zones:** Stream B and C both touch `execution_service.go` but at different lines (B: terminal message construction; C: `fmt.Errorf` → `errors.New`). Stream C's `fmt.Errorf` fix at `:260` and `:1482` overlaps with Stream B's ExitCode changes at the same lines. **Resolution: Stream C must NOT touch lines 260 and 1482. Stream B owns those lines and will apply the `errors.New` fix as part of its work.**
+
+---
+
+## Stream A: Interactive Executor Terminal Failure Handling
+
+**Review issue:** #2 (high severity) — Interactive executor treats ALL terminal steps as success
+**Spec reference:** Plan risk R4
+
+### Task A1: Write failing test for interactive executor terminal failure
+
+**Files:**
+- Create: `internal/application/interactive_executor_terminal_test.go`
+
+**Step 1: Write the failing test**
+
+The test must verify that when an interactive executor reaches a `TerminalFailure` step with a `Message`, it returns an error containing that message and sets `StatusFailed`.
+
+```go
+package application
+
+import (
+	"context"
+	"testing"
+
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/awf-project/awf/internal/testutil/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInteractiveExecutor_TerminalFailure_ReturnsError(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test-terminal-failure",
+		Initial: "failing_step",
+		Steps: map[string]*workflow.Step{
+			"failing_step": {
+				Name:      "failing_step",
+				Type:      workflow.StepTypeCommand,
+				Command:   "exit 1",
+				OnFailure: "__inline_error_failing_step",
+			},
+			"__inline_error_failing_step": {
+				Name:    "__inline_error_failing_step",
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Custom failure message",
+			},
+		},
+	}
+
+	// Build interactive executor with mocks
+	// Agent must discover the actual constructor and mock patterns
+	// by reading NewInteractiveExecutor and existing test files
+	// Key: the executor must reach the terminal step and return error
+
+	_ = wf // Agent implements full test setup
+}
+
+func TestInteractiveExecutor_TerminalSuccess_NoError(t *testing.T) {
+	// Verify terminal success still returns nil error (no regression)
+}
+
+func TestInteractiveExecutor_TerminalFailure_MessageInterpolated(t *testing.T) {
+	// Verify message interpolation works in interactive mode
+}
+```
+
+> **Note to agent:** The test skeleton above is illustrative. You MUST read `NewInteractiveExecutor`, the `InteractiveExecutor.Run` method, and existing test patterns in the application package to write the actual working test. The interactive executor uses a `prompt` interface — you'll need a mock that auto-continues past breakpoints.
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/application/ -run TestInteractiveExecutor_Terminal -v`
+Expected: FAIL — terminal failure returns nil error and StatusCompleted
+
+### Task A2: Fix interactive executor terminal handling
+
+**Files:**
+- Modify: `internal/application/interactive_executor.go:157-163`
+
+**Step 1: Implement the fix**
+
+Replace the current terminal block:
+
+```go
+// BEFORE (lines 157-163):
+if step.Type == workflow.StepTypeTerminal {
+    execCtx.Status = workflow.StatusCompleted
+    execCtx.CompletedAt = time.Now()
+    e.checkpoint(ctx, execCtx)
+    e.prompt.ShowCompleted(execCtx.Status)
+    return execCtx, nil
+}
+```
+
+With the pattern from ExecutionService (lines 255-271):
+
+```go
+// AFTER:
+if step.Type == workflow.StepTypeTerminal {
+    if step.Status == workflow.TerminalFailure {
+        execCtx.Status = workflow.StatusFailed
+        interpCtx := e.buildInterpolationContext(execCtx)
+        if msg := e.interpolateTerminalMessage(step.Message, interpCtx); msg != "" {
+            execCtx.CompletedAt = time.Now()
+            e.checkpoint(ctx, execCtx)
+            e.prompt.ShowCompleted(execCtx.Status)
+            return execCtx, errors.New(msg)
+        }
+        execCtx.CompletedAt = time.Now()
+        e.checkpoint(ctx, execCtx)
+        e.prompt.ShowCompleted(execCtx.Status)
+        return execCtx, fmt.Errorf("workflow reached terminal failure state: %s", currentStep)
+    }
+    execCtx.Status = workflow.StatusCompleted
+    execCtx.CompletedAt = time.Now()
+    e.checkpoint(ctx, execCtx)
+    e.prompt.ShowCompleted(execCtx.Status)
+    return execCtx, nil
+}
+```
+
+**Step 2: Add `interpolateTerminalMessage` method to InteractiveExecutor**
+
+The InteractiveExecutor already has a `resolver` field and `buildInterpolationContext`. Add:
+
+```go
+// interpolateTerminalMessage interpolates a terminal step message template.
+func (e *InteractiveExecutor) interpolateTerminalMessage(message string, intCtx *interpolation.Context) string {
+    if message == "" {
+        return ""
+    }
+    interpolated, err := e.resolver.Resolve(message, intCtx)
+    if err != nil {
+        e.logger.Warn("terminal message interpolation failed", "error", err, "message", message)
+        return message
+    }
+    return interpolated
+}
+```
+
+> **Note to agent:** Check if `InteractiveExecutor` has a `resolver` field. If not, check how it accesses the interpolation resolver — it may delegate through a different mechanism.
+
+**Step 3: Run test to verify it passes**
+
+Run: `go test ./internal/application/ -run TestInteractiveExecutor_Terminal -v`
+Expected: PASS
+
+**Step 4: Run full test suite**
+
+Run: `go test ./internal/application/... -count=1`
+Expected: All PASS (no regressions)
+
+---
+
+## Stream B: ExitCode Field + Status Propagation
+
+**Review issues:** #1 (high), #3 (medium), #4 (high) — `status` field silently discarded, integration test never asserts exit code
+**Spec reference:** FR-004 ("status shall default to exit code 1")
+
+### Task B1: Add ExitCode field to domain Step
+
+**Files:**
+- Modify: `internal/domain/workflow/step.go`
+- Modify: `internal/testutil/builders/builders.go`
+- Modify: `internal/testutil/builders/step_builder_message_test.go` (or new test)
+
+**Step 1: Write failing test**
+
+Add test in `internal/domain/workflow/step_message_test.go`:
+
+```go
+func TestStepExitCodeField_DefaultsToZero(t *testing.T) {
+    step := &Step{
+        Type:   StepTypeTerminal,
+        Status: TerminalFailure,
+    }
+    assert.Equal(t, 0, step.ExitCode)
+}
+```
+
+**Step 2: Add ExitCode field to Step struct**
+
+In `internal/domain/workflow/step.go`, after the `Message` field (line 89):
+
+```go
+Message         string               // for terminal type: message template (interpolated at runtime)
+ExitCode        int                  // for terminal type: process exit code (default 0, FR-004: inline default 1)
+```
+
+**Step 3: Add WithExitCode to StepBuilder**
+
+In `internal/testutil/builders/builders.go`, add:
+
+```go
+func (b *StepBuilder) WithExitCode(code int) *StepBuilder {
+    b.exitCode = code
+    return b
+}
+```
+
+And wire it in the `Build()` method.
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/domain/workflow/... ./internal/testutil/builders/... -v`
+Expected: PASS
+
+### Task B2: Propagate status from YAML inline object
+
+**Files:**
+- Modify: `internal/infrastructure/repository/yaml_mapper.go` (synthesizeInlineErrorTerminal)
+- Modify: `internal/infrastructure/repository/yaml_mapper.go` (mapStep)
+- Modify: `internal/infrastructure/repository/yaml_types.go` (yamlStep — add ExitCode field if needed)
+- Modify: `internal/infrastructure/repository/yaml_mapper_on_failure_test.go`
+
+**Step 1: Write failing tests**
+
+Add to `yaml_mapper_on_failure_test.go`:
+
+```go
+func TestSynthesizeInlineErrorTerminal_StatusMapsToExitCode(t *testing.T) {
+    obj := map[string]any{
+        "message": "Deploy failed",
+        "status":  3,
+    }
+
+    got, err := synthesizeInlineErrorTerminal("deploy_step", obj)
+
+    require.NoError(t, err)
+    assert.Equal(t, 3, got.ExitCode)
+}
+
+func TestSynthesizeInlineErrorTerminal_DefaultExitCode1(t *testing.T) {
+    // FR-004: When status omitted, default to exit code 1
+    obj := map[string]any{
+        "message": "Something went wrong",
+    }
+
+    got, err := synthesizeInlineErrorTerminal("step1", obj)
+
+    require.NoError(t, err)
+    assert.Equal(t, 1, got.ExitCode)
+}
+```
+
+Also update `TestSynthesizeInlineErrorTerminal_MessageAndStatus` to assert `ExitCode`.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/infrastructure/repository/ -run TestSynthesize -v`
+Expected: FAIL (ExitCode is 0 for all cases)
+
+**Step 3: Implement status extraction in synthesizeInlineErrorTerminal**
+
+```go
+// synthesizeInlineErrorTerminal creates a terminal yamlStep from an inline error object.
+func synthesizeInlineErrorTerminal(stepName string, inlineError map[string]any) (*yamlStep, error) {
+    msgVal := inlineError["message"]
+    msg, ok := msgVal.(string)
+    if !ok {
+        return nil, fmt.Errorf("step %s: on_failure.message must be a string", stepName)
+    }
+
+    exitCode := 1 // FR-004: default exit code
+    if statusVal, exists := inlineError["status"]; exists {
+        switch v := statusVal.(type) {
+        case int:
+            exitCode = v
+        case float64:
+            exitCode = int(v)
+        }
+    }
+
+    return &yamlStep{
+        Type:     "terminal",
+        Status:   "failure",
+        Message:  msg,
+        ExitCode: exitCode,
+    }, nil
+}
+```
+
+> **Note to agent:** YAML unmarshals numbers as `int` but JSON round-trips may produce `float64`. Handle both. Check if `yamlStep` already has an `ExitCode` field. If not, add it to `yaml_types.go`. Also ensure `mapStep` maps `ExitCode` to the domain Step.
+
+**Step 4: Wire ExitCode in mapStep**
+
+In `mapStep`, add `ExitCode: y.ExitCode` to the `workflow.Step` struct literal.
+
+**Step 5: Run tests**
+
+Run: `go test ./internal/infrastructure/repository/ -run TestSynthesize -v`
+Expected: PASS
+
+### Task B3: Use ExitCode in execution service terminal handling
+
+**Files:**
+- Modify: `internal/application/execution_service.go:257-263` and `:1479-1485`
+- Modify: `internal/application/execution_service_on_failure_inline_test.go`
+
+**Step 1: Write failing test**
+
+Add to `execution_service_on_failure_inline_test.go`:
+
+```go
+func TestExecutionService_InlineOnFailure_ExitCodePropagated(t *testing.T) {
+    wf := &workflow.Workflow{
+        Name:    "test",
+        Initial: "deploy",
+        Steps: map[string]*workflow.Step{
+            "deploy": {
+                Name:      "deploy",
+                Type:      workflow.StepTypeCommand,
+                Command:   "make deploy",
+                OnFailure: "__inline_error_deploy",
+            },
+            "__inline_error_deploy": {
+                Name:     "__inline_error_deploy",
+                Type:     workflow.StepTypeTerminal,
+                Status:   workflow.TerminalFailure,
+                Message:  "Deploy failed",
+                ExitCode: 3,
+            },
+        },
+    }
+
+    execSvc, _ := NewTestHarness(t).
+        WithWorkflow("test", wf).
+        WithCommandResult("make deploy", &ports.CommandResult{Stdout: "", Stderr: "error", ExitCode: 1}).
+        Build()
+
+    execCtx, err := execSvc.Run(context.Background(), "test", nil)
+
+    require.Error(t, err)
+    assert.Equal(t, workflow.StatusFailed, execCtx.Status)
+    assert.Equal(t, 3, execCtx.ExitCode)
+}
+```
+
+> **Note to agent:** Check if `ExecutionContext` has an `ExitCode` field. If not, determine how exit codes are propagated to the CLI layer (it may be through the error type, a wrapper, or a context field). Adapt the test accordingly.
+
+**Step 2: Implement ExitCode propagation in terminal handling**
+
+In `execution_service.go`, modify both terminal handling blocks (Run ~L258 and Resume ~L1480):
+
+```go
+if step.Status == workflow.TerminalFailure {
+    execCtx.Status = workflow.StatusFailed
+    if step.ExitCode > 0 {
+        execCtx.ExitCode = step.ExitCode
+    }
+    if msg := s.interpolateTerminalMessage(step.Message, s.buildInterpolationContext(execCtx)); msg != "" {
+        execErr = errors.New(msg)  // Also fixes review issue #8: fmt.Errorf("%s", msg) → errors.New
+    } else {
+        execErr = fmt.Errorf("workflow reached terminal failure state: %s", currentStep)
+    }
+}
+```
+
+**Step 3: Run tests**
+
+Run: `go test ./internal/application/ -run TestExecutionService_InlineOnFailure -v`
+Expected: PASS
+
+### Task B4: Fix integration test exit code assertion
+
+**Files:**
+- Modify: `tests/integration/features/on_failure_inline_test.go`
+
+**Step 1: Fix TestOnFailureInline_MessageWithStatus to assert exit code**
+
+The test declares `expectedExitCode` but never asserts it. Add assertion:
+
+```go
+// After the error message assertion, add:
+// Assert exit code propagation (FR-004)
+// Agent must determine how ExitCode is exposed — via execCtx or error type
+```
+
+> **Note to agent:** The integration test currently only calls `svc.Run()` and checks the error. You need to also capture the `ExecutionContext` return value and assert `ExitCode`. Adjust the test structure from `_, err := svc.Run(...)` to `execCtx, err := svc.Run(...)`.
+
+**Step 2: Run integration tests**
+
+Run: `go test -tags=integration ./tests/integration/features/ -run TestOnFailureInline_MessageWithStatus -v`
+Expected: PASS
+
+---
+
+## Stream C: Code Quality Fixes
+
+**Review issues:** #6 (dead code), #7 (doc comments), #9 (duplication), #10/#11 (dead statesDir)
+
+### Task C1: Add doc comments to new functions in yaml_mapper.go
+
+**Files:**
+- Modify: `internal/infrastructure/repository/yaml_mapper.go`
+
+**Step 1: Add doc comments**
+
+```go
+// synthesizeInlineErrorTerminal creates a terminal yamlStep from an inline error object.
+// It extracts the message and optional status fields to build the synthesized terminal definition.
+func synthesizeInlineErrorTerminal(...)
+
+// validateInlineErrorObject validates the inline error object fields.
+// It ensures the required message field is present and non-empty.
+func validateInlineErrorObject(...)
+```
+
+### Task C2: Remove dead statesDir from integration tests
+
+**Files:**
+- Modify: `tests/integration/features/on_failure_inline_test.go`
+
+**Step 1: Remove statesDir declarations**
+
+In all 5 test functions that create `statesDir` + `os.MkdirAll(statesDir, ...)`, remove both lines since `mocks.NewMockStateStore()` is in-memory.
+
+Lines to remove pattern (in each test function):
+```go
+statesDir := filepath.Join(tmpDir, "states")    // DELETE
+require.NoError(t, os.MkdirAll(statesDir, 0o755)) // DELETE
+```
+
+Affected tests:
+- `TestOnFailureInline_BasicMessage`
+- `TestOnFailureInline_MessageWithStatus`
+- `TestOnFailureInline_MessageInterpolation`
+- `TestOnFailureInline_StringFormBackwardCompat`
+- `TestOnFailureInline_ParallelBranch`
+
+### Task C3: Extract test helper in integration tests
+
+**Files:**
+- Modify: `tests/integration/features/on_failure_inline_test.go`
+
+**Step 1: Extract buildTestService helper**
+
+Replace the 6-line duplicated setup block in 5 test functions:
+
+```go
+func buildTestService(t *testing.T, workflowsDir string) *application.ExecutionService {
+    t.Helper()
+    repo := repository.NewYAMLRepository(workflowsDir)
+    store := mocks.NewMockStateStore()
+    exec := executor.NewShellExecutor()
+    logger := mocks.NewMockLogger()
+
+    return builders.NewExecutionServiceBuilder().
+        WithWorkflowRepository(repo).
+        WithStateStore(store).
+        WithExecutor(exec).
+        WithLogger(logger).
+        Build()
+}
+```
+
+Then replace each occurrence with `svc := buildTestService(t, workflowsDir)`.
+
+### Task C4: Remove redundant type-assertion in synthesizeInlineErrorTerminal
+
+**Files:**
+- Modify: `internal/infrastructure/repository/yaml_mapper.go`
+
+**Step 1: Assess**
+
+> **Note to agent:** Review issue #6 says the type-assertion on `message` in `synthesizeInlineErrorTerminal` is redundant because `validateInlineErrorObject` already validated it. This is defensive programming. If you remove it, ensure `normalizeOnFailure` ALWAYS calls `validateInlineErrorObject` before `synthesizeInlineErrorTerminal` is called. If the call chain guarantees this, simplify. If not, keep it as defensive code and add a comment explaining why.
+
+### Task C5: Run full test suite
+
+**Step 1: Run all tests**
+
+```bash
+go test ./internal/... ./pkg/... -count=1
+go test -tags=integration ./tests/integration/... -count=1
+```
+
+**Step 2: Run linters**
+
+```bash
+golangci-lint run
+```
+
+Expected: All PASS, no lint errors.
+
+---
+
+## Execution Order
+
+1. **Streams A, B, C run in parallel** (independent file sets, except noted conflict zone)
+2. **After all 3 complete:** Run full test suite + linters as final validation
+3. **Commit:** Single atomic commit with all corrections
+
+## Commit Message
+
+```
+fix(workflow): address F066 code review issues
+
+- Fix interactive executor terminal failure handling (was silently succeeding)
+- Implement FR-004 status/ExitCode propagation from inline on_failure
+- Fix integration test exit code assertion (was declared but never checked)
+- Replace fmt.Errorf("%s", msg) with errors.New(msg)
+- Add doc comments to synthesizeInlineErrorTerminal, validateInlineErrorObject
+- Remove dead statesDir from integration tests
+- Extract buildTestService helper in integration tests
+```

--- a/docs/user-guide/agent-steps.md
+++ b/docs/user-guide/agent-steps.md
@@ -652,6 +652,23 @@ error_path:
   status: failure
 ```
 
+You can also use **inline error shorthand** to avoid defining separate terminal states:
+
+```yaml
+analyze:
+  type: agent
+  provider: claude
+  prompt: "Review: {{.inputs.code}}"
+  timeout: 120
+  on_success: done
+  on_failure: {message: "Agent analysis failed", status: 3}
+
+done:
+  type: terminal
+```
+
+See [Workflow Syntax — Inline Error Shorthand](workflow-syntax.md#inline-error-shorthand) for full details.
+
 ### Common Error Scenarios
 
 | Error | Cause | Solution |

--- a/docs/user-guide/workflow-syntax.md
+++ b/docs/user-guide/workflow-syntax.md
@@ -94,7 +94,7 @@ my_step:
 | `dir` | string | cwd | Working directory (supports interpolation) |
 | `timeout` | int | 0 | Execution timeout in seconds (0 = no timeout) |
 | `on_success` | string | - | Next state on success (exit code 0) |
-| `on_failure` | string | - | Next state on failure (exit code ≠ 0) |
+| `on_failure` | string or object | - | Next state on failure — string (named terminal ref) or inline object (see [Inline Error Shorthand](#inline-error-shorthand)) |
 | `continue_on_error` | bool | false | Always follow `on_success` regardless of exit code |
 | `retry` | object | - | Retry configuration |
 | `transitions` | array | - | Conditional transitions |
@@ -295,7 +295,7 @@ refine_code:
 | `options` | map | No | Provider-specific options (model, temperature, max_tokens, etc.) |
 | `timeout` | int | No | Execution timeout in seconds (0 = no timeout) |
 | `on_success` | string | No | Next state on success |
-| `on_failure` | string | No | Next state on failure |
+| `on_failure` | string or object | No | Next state on failure — string (named terminal ref) or inline object (see [Inline Error Shorthand](#inline-error-shorthand)) |
 | `retry` | object | No | Retry configuration (same as step retry) |
 
 \* Use `prompt` or `prompt_file` for single-turn mode (mutually exclusive), `initial_prompt` for conversation mode. See [Agent Steps - External Prompt Files](agent-steps.md#external-prompt-files) for `prompt_file` details.
@@ -417,7 +417,7 @@ get_issue:
 | `operation` | string | Yes | Operation name (e.g., `github.get_issue`) |
 | `inputs` | map | Varies | Input parameters (validated against operation schema) |
 | `on_success` | string | No | Next state on success |
-| `on_failure` | string | No | Next state on failure |
+| `on_failure` | string or object | No | Next state on failure — string (named terminal ref) or [inline object](#inline-error-shorthand) |
 | `retry` | object | No | Retry configuration (same as step retry) |
 
 ### Operation Output
@@ -769,6 +769,83 @@ error:
 | Option | Type | Values | Description |
 |--------|------|--------|-------------|
 | `status` | string | `success`, `failure` | Terminal status |
+| `message` | string | - | Terminal message (displayed in output, supports template interpolation) |
+
+### Inline Error Shorthand
+
+Instead of defining separate named terminal states, you can specify an inline error object directly on `on_failure`:
+
+```yaml
+build:
+  type: step
+  command: go build ./cmd/...
+  on_success: test
+  on_failure: {message: "Build failed"}
+
+test:
+  type: step
+  command: go test ./...
+  on_success: done
+  on_failure: {message: "Tests failed", status: 2}
+
+done:
+  type: terminal
+  status: success
+```
+
+When an inline error is triggered, AWF automatically synthesizes an anonymous terminal state with the specified message and status (default: 1).
+
+#### Inline Error Syntax
+
+The `on_failure` field accepts either:
+- **String** (named terminal reference, backward compatible): `on_failure: error_terminal`
+- **Object** (inline error, F066): `on_failure: {message: "...", status: 3}`
+
+#### Inline Error Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `message` | string | Yes | Terminal message (can use template interpolation: `{{.inputs.*}}`, `{{.states.*}}`, `{{.env.*}}`) |
+| `status` | int | No | Exit code (default: `1` for failure) |
+
+#### Template Interpolation in Messages
+
+Inline error messages support full template interpolation, including references to step outputs:
+
+```yaml
+build:
+  type: step
+  command: make build
+  on_failure: {message: "Build failed: {{.states.build.Output}}"}
+
+test:
+  type: step
+  command: go test ./...
+  on_failure: {message: "Tests failed in {{.inputs.environment}}", status: 5}
+```
+
+#### Backward Compatibility
+
+Existing workflows using named terminal references continue to work unchanged:
+
+```yaml
+# Still works — routes to named terminal state
+on_failure: error_terminal
+```
+
+You can mix inline errors and named references in the same workflow:
+
+```yaml
+build:
+  type: step
+  command: make build
+  on_failure: {message: "Build failed"}  # Inline error
+
+test:
+  type: step
+  command: npm test
+  on_failure: error_terminal           # Named reference
+```
 
 ---
 
@@ -811,7 +888,7 @@ Branch children (`lint`, `test`, `build` above) do not need `on_success`/`on_fai
 | `strategy` | string | `all_succeed` | Execution strategy |
 | `max_concurrent` | int | unlimited | Maximum concurrent steps |
 | `on_success` | string | - | Next state when all branches complete successfully |
-| `on_failure` | string | - | Next state on branch failure |
+| `on_failure` | string or object | - | Next state on branch failure — string (named terminal ref) or [inline object](#inline-error-shorthand) |
 
 ### Parallel Strategies
 

--- a/internal/application/execution_service.go
+++ b/internal/application/execution_service.go
@@ -256,7 +256,12 @@ func (s *ExecutionService) runWithCallStackAndWorkflow(
 			// Check terminal status: failure or success (default)
 			if step.Status == workflow.TerminalFailure {
 				execCtx.Status = workflow.StatusFailed
-				execErr = fmt.Errorf("workflow reached terminal failure state: %s", currentStep)
+				execCtx.ExitCode = step.ExitCode
+				if msg := s.interpolateTerminalMessage(step.Message, s.buildInterpolationContext(execCtx)); msg != "" {
+					execErr = errors.New(msg)
+				} else {
+					execErr = fmt.Errorf("workflow reached terminal failure state: %s", currentStep)
+				}
 			} else {
 				execCtx.Status = workflow.StatusCompleted
 			}
@@ -1474,7 +1479,12 @@ func (s *ExecutionService) executeFromStep(
 			// Check terminal status: failure or success (default)
 			if step.Status == workflow.TerminalFailure {
 				execCtx.Status = workflow.StatusFailed
-				execErr = fmt.Errorf("workflow reached terminal failure state: %s", currentStep)
+				execCtx.ExitCode = step.ExitCode
+				if msg := s.interpolateTerminalMessage(step.Message, s.buildInterpolationContext(execCtx)); msg != "" {
+					execErr = errors.New(msg)
+				} else {
+					execErr = fmt.Errorf("workflow reached terminal failure state: %s", currentStep)
+				}
 			} else {
 				execCtx.Status = workflow.StatusCompleted
 			}
@@ -2104,4 +2114,18 @@ func (s *ExecutionService) applyOutputFormat(step *workflow.Step, state *workflo
 		state.JSON = parsedJSON
 	}
 	return nil
+}
+
+// interpolateTerminalMessage interpolates a terminal step message template using the current execution context.
+// Returns the interpolated message, falling back to the raw template on interpolation error.
+func (s *ExecutionService) interpolateTerminalMessage(message string, intCtx *interpolation.Context) string {
+	if message == "" {
+		return ""
+	}
+	interpolated, err := s.resolver.Resolve(message, intCtx)
+	if err != nil {
+		s.logger.Warn("terminal message interpolation failed", "error", err, "message", message)
+		return message
+	}
+	return interpolated
 }

--- a/internal/application/execution_service_on_failure_inline_test.go
+++ b/internal/application/execution_service_on_failure_inline_test.go
@@ -1,0 +1,367 @@
+package application_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/awf-project/awf/internal/domain/ports"
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutionService_InlineOnFailure_MessageInError(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "build",
+		Steps: map[string]*workflow.Step{
+			"build": {
+				Name:      "build",
+				Type:      workflow.StepTypeCommand,
+				Command:   "make build",
+				OnFailure: "__inline_error_build",
+			},
+			"__inline_error_build": {
+				Name:    "__inline_error_build",
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Build failed: deployment aborted",
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		WithCommandResult("make build", &ports.CommandResult{Stdout: "", Stderr: "error", ExitCode: 1}).
+		Build()
+
+	_, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "Build failed: deployment aborted"),
+		"error must include terminal step message, got: %s", err.Error())
+}
+
+func TestExecutionService_InlineOnFailure_InputsInterpolated(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "deploy",
+		Steps: map[string]*workflow.Step{
+			"deploy": {
+				Name:      "deploy",
+				Type:      workflow.StepTypeCommand,
+				Command:   "make deploy",
+				OnFailure: "__inline_error_deploy",
+			},
+			"__inline_error_deploy": {
+				Name:    "__inline_error_deploy",
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Deploy failed for env {{inputs.environment}}",
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		WithCommandResult("make deploy", &ports.CommandResult{Stdout: "", Stderr: "error", ExitCode: 1}).
+		Build()
+
+	inputs := map[string]any{"environment": "production"}
+	_, err := execSvc.Run(context.Background(), "test", inputs)
+
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "production"),
+		"interpolated input must appear in error message, got: %s", err.Error())
+	assert.False(t, strings.Contains(err.Error(), "{{inputs.environment}}"),
+		"raw template must not appear in error message after interpolation, got: %s", err.Error())
+}
+
+func TestExecutionService_InlineOnFailure_StatesInterpolated(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "compile",
+		Steps: map[string]*workflow.Step{
+			"compile": {
+				Name:      "compile",
+				Type:      workflow.StepTypeCommand,
+				Command:   "go build ./...",
+				OnSuccess: "run_tests",
+				OnFailure: "__inline_error_compile",
+			},
+			"run_tests": {
+				Name:      "run_tests",
+				Type:      workflow.StepTypeCommand,
+				Command:   "go test ./...",
+				OnFailure: "__inline_error_tests",
+			},
+			"__inline_error_compile": {
+				Name:    "__inline_error_compile",
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Compile step failed",
+			},
+			"__inline_error_tests": {
+				Name:    "__inline_error_tests",
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Tests failed after: {{states.compile.output}}",
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		WithCommandResult("go build ./...", &ports.CommandResult{Stdout: "compiled successfully", ExitCode: 0}).
+		WithCommandResult("go test ./...", &ports.CommandResult{Stdout: "", Stderr: "test error", ExitCode: 1}).
+		Build()
+
+	_, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "Tests failed after:"),
+		"error must include terminal step message, got: %s", err.Error())
+}
+
+func TestExecutionService_InlineOnFailure_EmptyMessageNoChange(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step",
+		Steps: map[string]*workflow.Step{
+			"step": {
+				Name:      "step",
+				Type:      workflow.StepTypeCommand,
+				Command:   "false",
+				OnFailure: "error_terminal",
+			},
+			"error_terminal": {
+				Name:    "error_terminal",
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "",
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		WithCommandResult("false", &ports.CommandResult{Stdout: "", Stderr: "", ExitCode: 1}).
+		Build()
+
+	_, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.Error(t, err)
+	// Spec: step with empty message falls back to generic error format
+	assert.True(t, strings.Contains(err.Error(), "error_terminal"),
+		"generic error must reference terminal step name, got: %s", err.Error())
+}
+
+func TestExecutionService_InlineOnFailure_DefaultExitCode1(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step",
+		Steps: map[string]*workflow.Step{
+			"step": {
+				Name:      "step",
+				Type:      workflow.StepTypeCommand,
+				Command:   "false",
+				OnFailure: "__inline_error_step",
+			},
+			"__inline_error_step": {
+				Name:     "__inline_error_step",
+				Type:     workflow.StepTypeTerminal,
+				Status:   workflow.TerminalFailure,
+				Message:  "Something went wrong",
+				ExitCode: 1, // FR-004: default exit code 1
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		WithCommandResult("false", &ports.CommandResult{Stdout: "", Stderr: "", ExitCode: 1}).
+		Build()
+
+	execCtx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.Error(t, err)
+	assert.Equal(t, workflow.StatusFailed, execCtx.Status)
+	assert.Equal(t, 1, execCtx.ExitCode, "ExitCode from terminal step must propagate to execution context")
+	assert.True(t, strings.Contains(err.Error(), "Something went wrong"),
+		"error must include message, got: %s", err.Error())
+}
+
+// TestExecutionService_InlineOnFailure_ExitCodePropagates verifies FR-004: status field propagates
+// from terminal step to execution context ExitCode.
+func TestExecutionService_InlineOnFailure_ExitCodePropagates(t *testing.T) {
+	tests := []struct {
+		name             string
+		terminalExitCode int
+		wantExitCode     int
+	}{
+		{
+			name:             "exit code 1 propagates",
+			terminalExitCode: 1,
+			wantExitCode:     1,
+		},
+		{
+			name:             "exit code 3 propagates",
+			terminalExitCode: 3,
+			wantExitCode:     3,
+		},
+		{
+			name:             "exit code 4 propagates",
+			terminalExitCode: 4,
+			wantExitCode:     4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf := &workflow.Workflow{
+				Name:    "test",
+				Initial: "step",
+				Steps: map[string]*workflow.Step{
+					"step": {
+						Name:      "step",
+						Type:      workflow.StepTypeCommand,
+						Command:   "false",
+						OnFailure: "__inline_error_step",
+					},
+					"__inline_error_step": {
+						Name:     "__inline_error_step",
+						Type:     workflow.StepTypeTerminal,
+						Status:   workflow.TerminalFailure,
+						Message:  "Workflow failed",
+						ExitCode: tt.terminalExitCode,
+					},
+				},
+			}
+
+			execSvc, _ := NewTestHarness(t).
+				WithWorkflow("test", wf).
+				WithCommandResult("false", &ports.CommandResult{Stdout: "", Stderr: "", ExitCode: 1}).
+				Build()
+
+			execCtx, err := execSvc.Run(context.Background(), "test", nil)
+
+			require.Error(t, err)
+			assert.Equal(t, workflow.StatusFailed, execCtx.Status)
+			assert.Equal(t, tt.wantExitCode, execCtx.ExitCode,
+				"ExitCode %d from terminal step must propagate to execution context", tt.terminalExitCode)
+		})
+	}
+}
+
+func TestExecutionService_InlineOnFailure_SuccessTerminalNoError(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step",
+		Steps: map[string]*workflow.Step{
+			"step": {
+				Name:      "step",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo ok",
+				OnSuccess: "done",
+			},
+			"done": {
+				Name:    "done",
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalSuccess,
+				Message: "Workflow finished successfully",
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		WithCommandResult("echo ok", &ports.CommandResult{Stdout: "ok\n", ExitCode: 0}).
+		Build()
+
+	execCtx, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+}
+
+func TestExecutionService_InlineOnFailure_ResumePathMessageIncluded(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "deploy",
+		Steps: map[string]*workflow.Step{
+			"deploy": {
+				Name:      "deploy",
+				Type:      workflow.StepTypeCommand,
+				Command:   "make deploy",
+				OnFailure: "__inline_error_deploy",
+			},
+			"__inline_error_deploy": {
+				Name:    "__inline_error_deploy",
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Deployment failed on retry",
+			},
+		},
+	}
+
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "wf-resume-001",
+		WorkflowName: "test",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "deploy",
+		States:       make(map[string]workflow.StepState),
+		Inputs:       make(map[string]any),
+		Env:          make(map[string]string),
+		StartedAt:    time.Now(),
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		WithCommandResult("make deploy", &ports.CommandResult{Stdout: "", Stderr: "deploy error", ExitCode: 1}).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	_, resumeErr := execSvc.Resume(context.Background(), "wf-resume-001", nil)
+
+	require.Error(t, resumeErr)
+	assert.True(t, strings.Contains(resumeErr.Error(), "Deployment failed on retry"),
+		"resume path must include terminal message, got: %s", resumeErr.Error())
+}
+
+func TestExecutionService_InlineOnFailure_BadTemplateFallsBackToRaw(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step",
+		Steps: map[string]*workflow.Step{
+			"step": {
+				Name:      "step",
+				Type:      workflow.StepTypeCommand,
+				Command:   "false",
+				OnFailure: "__inline_error_step",
+			},
+			"__inline_error_step": {
+				Name:    "__inline_error_step",
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Error: {{invalid..template}}",
+			},
+		},
+	}
+
+	execSvc, _ := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		WithCommandResult("false", &ports.CommandResult{Stdout: "", Stderr: "", ExitCode: 1}).
+		Build()
+
+	_, err := execSvc.Run(context.Background(), "test", nil)
+
+	require.Error(t, err)
+	// Spec ADR-003: fallback to raw template on interpolation error
+	// The raw message must still appear in the error (not swallowed)
+	assert.True(t, strings.Contains(err.Error(), "Error:") || strings.Contains(err.Error(), "__inline_error_step"),
+		"raw message or terminal name must appear in error, got: %s", err.Error())
+}

--- a/internal/application/interactive_executor.go
+++ b/internal/application/interactive_executor.go
@@ -155,11 +155,21 @@ func (e *InteractiveExecutor) Run(ctx context.Context, workflowName string, inpu
 
 		// Terminal state - workflow complete
 		if step.Type == workflow.StepTypeTerminal {
-			execCtx.Status = workflow.StatusCompleted
+			var terminalErr error
+			if step.Status == workflow.TerminalFailure {
+				execCtx.Status = workflow.StatusFailed
+				if msg := e.interpolateTerminalMessage(step.Message, e.buildInterpolationContext(execCtx)); msg != "" {
+					terminalErr = errors.New(msg)
+				} else {
+					terminalErr = fmt.Errorf("workflow reached terminal failure state: %s", currentStep)
+				}
+			} else {
+				execCtx.Status = workflow.StatusCompleted
+			}
 			execCtx.CompletedAt = time.Now()
 			e.checkpoint(ctx, execCtx)
 			e.prompt.ShowCompleted(execCtx.Status)
-			return execCtx, nil
+			return execCtx, terminalErr
 		}
 
 		// Build interpolation context for display
@@ -375,6 +385,20 @@ func (e *InteractiveExecutor) checkpoint(ctx context.Context, execCtx *workflow.
 	if err := e.store.Save(ctx, execCtx); err != nil {
 		e.logger.Warn("checkpoint failed", "workflow_id", execCtx.WorkflowID, "error", err)
 	}
+}
+
+// interpolateTerminalMessage interpolates a terminal step message template.
+// Falls back to the raw message on interpolation error so the message is never silently lost.
+func (e *InteractiveExecutor) interpolateTerminalMessage(message string, intCtx *interpolation.Context) string {
+	if message == "" {
+		return ""
+	}
+	interpolated, err := e.resolver.Resolve(message, intCtx)
+	if err != nil {
+		e.logger.Warn("terminal message interpolation failed", "error", err, "message", message)
+		return message
+	}
+	return interpolated
 }
 
 // buildInterpolationContext converts ExecutionContext to interpolation.Context.

--- a/internal/application/interactive_executor_terminal_test.go
+++ b/internal/application/interactive_executor_terminal_test.go
@@ -1,0 +1,206 @@
+package application_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/awf-project/awf/internal/application"
+	"github.com/awf-project/awf/internal/domain/ports"
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/awf-project/awf/internal/infrastructure/expression"
+	"github.com/awf-project/awf/pkg/interpolation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildInteractiveExecutorWithExecutor wires up an InteractiveExecutor with a specific
+// command executor and a workflow registered in the mock repository.
+func buildInteractiveExecutorWithExecutor(
+	t *testing.T,
+	wf *workflow.Workflow,
+	executor *mockExecutor,
+	prompt *mockInteractivePrompt,
+) *application.InteractiveExecutor {
+	t.Helper()
+	repo := newMockRepository()
+	repo.workflows[wf.Name] = wf
+	wfSvc := application.NewWorkflowService(repo, newMockStateStore(), executor, &mockLogger{}, nil)
+	resolver := interpolation.NewTemplateResolver()
+	evaluator := expression.NewExprEvaluator()
+	return application.NewInteractiveExecutor(
+		wfSvc, executor, newMockParallelExecutor(),
+		newMockStateStore(), &mockLogger{}, resolver, evaluator, prompt,
+	)
+}
+
+// newFailingExecutor creates a mock executor that returns exit code 1 for any command.
+func newFailingExecutor(command string) *mockExecutor {
+	executor := newMockExecutor()
+	executor.results[command] = &ports.CommandResult{ExitCode: 1, Stderr: "simulated failure"}
+	return executor
+}
+
+// TestInteractiveExecutor_Terminal_FailureWithMessage verifies that a TerminalFailure
+// step returns an error containing the step message and sets StatusFailed.
+func TestInteractiveExecutor_Terminal_FailureWithMessage(t *testing.T) {
+	const workCommand = "echo work"
+
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "work",
+		Steps: map[string]*workflow.Step{
+			"work": {
+				Name:      "work",
+				Type:      workflow.StepTypeCommand,
+				Command:   workCommand,
+				OnFailure: "error_terminal",
+				OnSuccess: "done",
+			},
+			"error_terminal": {
+				Name:    "error_terminal",
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Build failed: deployment aborted",
+			},
+			"done": {
+				Name:   "done",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	prompt := newMockPrompt(workflow.ActionContinue)
+	exec := buildInteractiveExecutorWithExecutor(t, wf, newFailingExecutor(workCommand), prompt)
+
+	execCtx, err := exec.Run(context.Background(), "test", nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Build failed: deployment aborted",
+		"error must include terminal step message, got: %s", err.Error())
+	require.NotNil(t, execCtx)
+	assert.Equal(t, workflow.StatusFailed, execCtx.Status)
+}
+
+// TestInteractiveExecutor_Terminal_SuccessNoError verifies that a TerminalSuccess
+// step returns nil error and sets StatusCompleted — no regression.
+func TestInteractiveExecutor_Terminal_SuccessNoError(t *testing.T) {
+	const workCommand = "echo work"
+
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "work",
+		Steps: map[string]*workflow.Step{
+			"work": {
+				Name:      "work",
+				Type:      workflow.StepTypeCommand,
+				Command:   workCommand,
+				OnSuccess: "done",
+			},
+			"done": {
+				Name:   "done",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	prompt := newMockPrompt(workflow.ActionContinue)
+	// Default executor returns exit code 0 for unregistered commands
+	exec := buildInteractiveExecutorWithExecutor(t, wf, newMockExecutor(), prompt)
+
+	execCtx, err := exec.Run(context.Background(), "test", nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, execCtx)
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+	assert.True(t, prompt.completeCalled, "ShowCompleted must be called on success terminal")
+}
+
+// TestInteractiveExecutor_Terminal_FailureWithTemplateMessage verifies that the
+// terminal step message is interpolated before being returned as an error.
+func TestInteractiveExecutor_Terminal_FailureWithTemplateMessage(t *testing.T) {
+	const deployCommand = "make deploy"
+
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "deploy",
+		Steps: map[string]*workflow.Step{
+			"deploy": {
+				Name:      "deploy",
+				Type:      workflow.StepTypeCommand,
+				Command:   deployCommand,
+				OnFailure: "error_terminal",
+				OnSuccess: "done",
+			},
+			"error_terminal": {
+				Name:    "error_terminal",
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Deploy failed for env {{inputs.environment}}",
+			},
+			"done": {
+				Name:   "done",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	prompt := newMockPrompt(workflow.ActionContinue)
+	exec := buildInteractiveExecutorWithExecutor(t, wf, newFailingExecutor(deployCommand), prompt)
+
+	inputs := map[string]any{"environment": "production"}
+	execCtx, err := exec.Run(context.Background(), "test", inputs)
+
+	require.Error(t, err)
+	require.NotNil(t, execCtx)
+	assert.Equal(t, workflow.StatusFailed, execCtx.Status)
+	assert.True(t, strings.Contains(err.Error(), "production"),
+		"interpolated input must appear in error message, got: %s", err.Error())
+	assert.False(t, strings.Contains(err.Error(), "{{inputs.environment}}"),
+		"raw template must not appear after interpolation, got: %s", err.Error())
+}
+
+// TestInteractiveExecutor_Terminal_FailureEmptyMessageGenericFallback verifies that
+// a TerminalFailure with no message produces a generic error referencing the step name.
+func TestInteractiveExecutor_Terminal_FailureEmptyMessageGenericFallback(t *testing.T) {
+	const workCommand = "echo work"
+
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "work",
+		Steps: map[string]*workflow.Step{
+			"work": {
+				Name:      "work",
+				Type:      workflow.StepTypeCommand,
+				Command:   workCommand,
+				OnFailure: "error_terminal",
+				OnSuccess: "done",
+			},
+			"error_terminal": {
+				Name:    "error_terminal",
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "", // empty — falls back to generic
+			},
+			"done": {
+				Name:   "done",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	prompt := newMockPrompt(workflow.ActionContinue)
+	exec := buildInteractiveExecutorWithExecutor(t, wf, newFailingExecutor(workCommand), prompt)
+
+	execCtx, err := exec.Run(context.Background(), "test", nil)
+
+	require.Error(t, err)
+	require.NotNil(t, execCtx)
+	assert.Equal(t, workflow.StatusFailed, execCtx.Status)
+	assert.Contains(t, err.Error(), "error_terminal",
+		"generic error must reference the terminal step name, got: %s", err.Error())
+}

--- a/internal/application/interactive_executor_test.go
+++ b/internal/application/interactive_executor_test.go
@@ -982,8 +982,11 @@ func TestInteractiveExecutor_executeLoopStep_LoopBodyError(t *testing.T) {
 
 	ctx, err := exec.Run(context.Background(), "failloop", nil)
 
-	require.NoError(t, err) // Workflow completes via error handler
+	// The "error" terminal step has TerminalFailure status, so it returns an error.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error", "error must reference the failure terminal step")
 	require.NotNil(t, ctx)
+	assert.Equal(t, workflow.StatusFailed, ctx.Status)
 
 	// Verify loop failed
 	loopState, exists := ctx.GetStepState("loop")

--- a/internal/domain/workflow/context.go
+++ b/internal/domain/workflow/context.go
@@ -62,6 +62,7 @@ type ExecutionContext struct {
 	WorkflowName string
 	Status       ExecutionStatus
 	CurrentStep  string
+	ExitCode     int // process exit code propagated from terminal steps (FR-004)
 	Inputs       map[string]any
 	States       map[string]StepState
 	Env          map[string]string

--- a/internal/domain/workflow/step.go
+++ b/internal/domain/workflow/step.go
@@ -87,6 +87,8 @@ type Step struct {
 	Hooks           StepHooks            // pre/post hooks
 	ContinueOnError bool                 // don't fail workflow on error
 	Status          TerminalStatus       // for terminal type: success or failure
+	Message         string               // for terminal type: message template (interpolated at runtime)
+	ExitCode        int                  // for terminal type: process exit code (FR-004: inline default 1)
 	Loop            *LoopConfig          // for for_each and while types
 	TemplateRef     *WorkflowTemplateRef // template reference (for use_template steps)
 	CallWorkflow    *CallWorkflowConfig  // for call_workflow type: sub-workflow configuration

--- a/internal/domain/workflow/step_message_test.go
+++ b/internal/domain/workflow/step_message_test.go
@@ -1,0 +1,121 @@
+package workflow_test
+
+// F066: Tests for Step.Message field added to domain Step struct.
+// ADR-002: yamlStep.Message is now mapped to domain Step.Message for terminal steps.
+// ADR-003: Message stores raw template string; interpolation happens at runtime.
+
+import (
+	"testing"
+
+	"github.com/awf-project/awf/internal/domain/workflow"
+)
+
+func TestStepMessageField_TerminalWithMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+	}{
+		{
+			name:    "plain error message",
+			message: "Deploy failed",
+		},
+		{
+			name:    "message with interpolation template",
+			message: "{{states.build.output}} failed at {{inputs.env}}",
+		},
+		{
+			name:    "message with status interpolation",
+			message: "Step {{states.build.output}} exited with code {{error.message}}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step := workflow.Step{
+				Name:    "error_terminal",
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: tt.message,
+			}
+
+			if step.Message != tt.message {
+				t.Errorf("Step.Message = %q, want %q", step.Message, tt.message)
+			}
+		})
+	}
+}
+
+func TestStepMessageField_DefaultsToEmpty(t *testing.T) {
+	step := workflow.Step{
+		Name:   "silent_error",
+		Type:   workflow.StepTypeTerminal,
+		Status: workflow.TerminalFailure,
+	}
+
+	if step.Message != "" {
+		t.Errorf("Step.Message should default to empty string, got %q", step.Message)
+	}
+}
+
+func TestStepMessageField_TemplateStoredVerbatim(t *testing.T) {
+	rawTemplate := "{{states.build.output}} failed — check logs at {{env.LOG_URL}}"
+
+	step := workflow.Step{
+		Name:    "infra_error",
+		Type:    workflow.StepTypeTerminal,
+		Status:  workflow.TerminalFailure,
+		Message: rawTemplate,
+	}
+
+	// ADR-003: template must be stored as-is, not interpolated at parse/struct-creation time
+	if step.Message != rawTemplate {
+		t.Errorf("Step.Message should preserve raw template %q, got %q", rawTemplate, step.Message)
+	}
+}
+
+func TestStepMessageField_TerminalWithMessageValidates(t *testing.T) {
+	tests := []struct {
+		name    string
+		step    workflow.Step
+		wantErr bool
+	}{
+		{
+			name: "terminal failure with message is valid",
+			step: workflow.Step{
+				Name:    "deploy_error",
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Deploy failed: {{states.deploy.output}}",
+			},
+			wantErr: false,
+		},
+		{
+			name: "terminal success with message is valid",
+			step: workflow.Step{
+				Name:    "deploy_done",
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalSuccess,
+				Message: "Deploy complete",
+			},
+			wantErr: false,
+		},
+		{
+			name: "terminal with empty status and message is valid",
+			step: workflow.Step{
+				Name:    "generic_end",
+				Type:    workflow.StepTypeTerminal,
+				Message: "Workflow ended",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.step.Validate(nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Step.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/repository/yaml_mapper.go
+++ b/internal/infrastructure/repository/yaml_mapper.go
@@ -32,7 +32,7 @@ func mapToDomain(filePath string, y *yamlWorkflow) (*workflow.Workflow, error) {
 		SourceDir:   filepath.Dir(absPath),
 	}
 
-	// Map steps
+	// Map steps and collect synthesized inline error terminals
 	for name := range y.States.Steps {
 		step := y.States.Steps[name]
 		domainStep, err := mapStep(filePath, name, &step)
@@ -40,6 +40,20 @@ func mapToDomain(filePath string, y *yamlWorkflow) (*workflow.Workflow, error) {
 			return nil, err
 		}
 		wf.Steps[name] = domainStep
+
+		// Inline on_failure: synthesize and inject a terminal step for this step
+		if obj, ok := step.OnFailure.(map[string]any); ok {
+			synthYAML, err := synthesizeInlineErrorTerminal(name, obj)
+			if err != nil {
+				return nil, err
+			}
+			synthName := "__inline_error_" + name
+			synthStep, err := mapStep(filePath, synthName, synthYAML)
+			if err != nil {
+				return nil, err
+			}
+			wf.Steps[synthName] = synthStep
+		}
 	}
 
 	return wf, nil
@@ -93,6 +107,12 @@ func mapStep(filePath, name string, y *yamlStep) (*workflow.Step, error) {
 		}
 	}
 
+	// Handle polymorphic OnFailure: string (step name) or inline error object
+	onFailureStr, err := normalizeOnFailure(filePath, name, y.OnFailure)
+	if err != nil {
+		return nil, err
+	}
+
 	step := &workflow.Step{
 		Name:            name,
 		Type:            stepType,
@@ -106,7 +126,7 @@ func mapStep(filePath, name string, y *yamlStep) (*workflow.Step, error) {
 		Strategy:        y.Strategy,
 		MaxConcurrent:   y.MaxConcurrent,
 		OnSuccess:       y.OnSuccess,
-		OnFailure:       y.OnFailure,
+		OnFailure:       onFailureStr,
 		Transitions:     mapTransitions(y.Transitions),
 		DependsOn:       y.DependsOn,
 		ContinueOnError: y.ContinueOnError,
@@ -114,6 +134,8 @@ func mapStep(filePath, name string, y *yamlStep) (*workflow.Step, error) {
 		Capture:         mapCapture(y.Capture),
 		Hooks:           mapStepHooks(y.Hooks),
 		Status:          workflow.TerminalStatus(y.Status),
+		Message:         y.Message,
+		ExitCode:        y.ExitCode,
 		Loop:            mapLoopConfig(y),
 		TemplateRef:     mapTemplateRef(y.UseTemplate, y.Parameters),
 		CallWorkflow:    mapCallWorkflowFlat(y),
@@ -462,4 +484,73 @@ func mapConversationConfig(y *yamlConversationConfig) *workflow.ConversationConf
 		ContinueFrom:     y.ContinueFrom,
 		InjectContext:    y.InjectContext,
 	}
+}
+
+// normalizeOnFailure normalizes on_failure to a step name string.
+// Accepts a named terminal reference (string) or an inline error object (map).
+func normalizeOnFailure(filePath, stepName string, onFailure any) (string, error) {
+	if onFailure == nil {
+		return "", nil
+	}
+
+	if s, ok := onFailure.(string); ok {
+		return s, nil
+	}
+
+	obj, ok := onFailure.(map[string]any)
+	if !ok {
+		return "", NewParseError(filePath, "states."+stepName+".on_failure", "must be a string or object")
+	}
+
+	if err := validateInlineErrorObject(filePath, stepName, obj); err != nil {
+		return "", err
+	}
+
+	return "__inline_error_" + stepName, nil
+}
+
+// synthesizeInlineErrorTerminal creates a terminal yamlStep from an inline error object.
+// It extracts the message and optional status fields to build the synthesized terminal definition.
+func synthesizeInlineErrorTerminal(stepName string, inlineError map[string]any) (*yamlStep, error) {
+	msgVal := inlineError["message"]
+	// Type-assertion is defensive; validateInlineErrorObject already validated this field.
+	msg, ok := msgVal.(string)
+	if !ok {
+		return nil, fmt.Errorf("step %s: on_failure.message must be a string", stepName)
+	}
+
+	// FR-004: extract status (integer exit code); default to 1 when omitted.
+	// YAML unmarshals integers as int; JSON round-trips may produce float64.
+	exitCode := 1
+	if statusVal, exists := inlineError["status"]; exists && statusVal != nil {
+		switch v := statusVal.(type) {
+		case int:
+			exitCode = v
+		case float64:
+			exitCode = int(v)
+		}
+	}
+
+	return &yamlStep{
+		Type:     "terminal",
+		Status:   "failure",
+		Message:  msg,
+		ExitCode: exitCode,
+	}, nil
+}
+
+// validateInlineErrorObject validates the inline error object fields.
+// It ensures the required message field is present and non-empty.
+func validateInlineErrorObject(filePath, stepName string, obj map[string]any) error {
+	msg, exists := obj["message"]
+	if !exists {
+		return NewParseError(filePath, "states."+stepName+".on_failure.message", "required field missing")
+	}
+
+	msgStr, ok := msg.(string)
+	if !ok || msgStr == "" {
+		return NewParseError(filePath, "states."+stepName+".on_failure.message", "must be a non-empty string")
+	}
+
+	return nil
 }

--- a/internal/infrastructure/repository/yaml_mapper_message_test.go
+++ b/internal/infrastructure/repository/yaml_mapper_message_test.go
@@ -1,0 +1,545 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mapStep Tests - Message Field Happy Path
+
+func TestMapStep_Message_HappyPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		yamlStep yamlStep
+		want     *workflow.Step
+	}{
+		{
+			name: "terminal step with message",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "failure",
+				Message: "Deployment failed",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Deployment failed",
+			},
+		},
+		{
+			name: "terminal step with long descriptive message",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "failure",
+				Message: "Build process failed: compilation error in src/main.go at line 42",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Build process failed: compilation error in src/main.go at line 42",
+			},
+		},
+		{
+			name: "terminal success step with message",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "success",
+				Message: "Deployment completed successfully",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalSuccess,
+				Message: "Deployment completed successfully",
+			},
+		},
+		{
+			name: "terminal step with template in message",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "failure",
+				Message: "Step {{states.build.output}} failed with error: {{states.build.error}}",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Step {{states.build.output}} failed with error: {{states.build.error}}",
+			},
+		},
+		{
+			name: "terminal step with input interpolation in message",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "failure",
+				Message: "Failed to deploy to {{inputs.environment}}",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Failed to deploy to {{inputs.environment}}",
+			},
+		},
+		{
+			name: "regular command step with message",
+			yamlStep: yamlStep{
+				Type:    "step",
+				Command: "echo 'test'",
+				Message: "This is a command step message",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeCommand,
+				Command: "echo 'test'",
+				Message: "This is a command step message",
+			},
+		},
+		{
+			name: "terminal step with special characters in message",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "failure",
+				Message: "Error: '\"special\\nchars\"' in output",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Error: '\"special\\nchars\"' in output",
+			},
+		},
+		{
+			name: "terminal step with multiline message content (YAML string)",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "failure",
+				Message: "Error occurred:\nLine 1: Database connection failed\nLine 2: Check credentials",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Error occurred:\nLine 1: Database connection failed\nLine 2: Check credentials",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mapStep("test.yaml", "test_step", &tt.yamlStep)
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want.Type, got.Type)
+			assert.Equal(t, tt.want.Status, got.Status)
+			assert.Equal(t, tt.want.Message, got.Message)
+		})
+	}
+}
+
+// mapStep Tests - Message Field Edge Cases
+
+func TestMapStep_Message_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		yamlStep yamlStep
+		want     *workflow.Step
+	}{
+		{
+			name: "terminal step with empty message",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "failure",
+				Message: "",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "",
+			},
+		},
+		{
+			name: "terminal step without message field",
+			yamlStep: yamlStep{
+				Type:   "terminal",
+				Status: "failure",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "",
+			},
+		},
+		{
+			name: "terminal step with message containing only spaces",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "failure",
+				Message: "   ",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "   ",
+			},
+		},
+		{
+			name: "terminal step with very long message",
+			yamlStep: yamlStep{
+				Type:   "terminal",
+				Status: "failure",
+				Message: "This is a very long error message that contains a lot of information about what went wrong. " +
+					"It includes multiple sentences explaining the failure condition. " +
+					"This could be a typical scenario where detailed error information is needed.",
+			},
+			want: &workflow.Step{
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalFailure,
+				Message: "This is a very long error message that contains a lot of information about what went wrong. " +
+					"It includes multiple sentences explaining the failure condition. " +
+					"This could be a typical scenario where detailed error information is needed.",
+			},
+		},
+		{
+			name: "command step without message",
+			yamlStep: yamlStep{
+				Type:    "step",
+				Command: "echo 'test'",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeCommand,
+				Command: "echo 'test'",
+				Message: "",
+			},
+		},
+		{
+			name: "parallel step without message",
+			yamlStep: yamlStep{
+				Type:     "parallel",
+				Strategy: "all_succeed",
+				Parallel: []string{"branch1", "branch2"},
+			},
+			want: &workflow.Step{
+				Type:     workflow.StepTypeParallel,
+				Strategy: "all_succeed",
+				Branches: []string{"branch1", "branch2"},
+				Message:  "",
+			},
+		},
+		{
+			name: "terminal step with message containing newlines and tabs",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "failure",
+				Message: "Line 1\tTabbed\nLine 2\tTabbed\nLine 3",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Line 1\tTabbed\nLine 2\tTabbed\nLine 3",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mapStep("test.yaml", "test_step", &tt.yamlStep)
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want.Type, got.Type)
+			assert.Equal(t, tt.want.Status, got.Status)
+			assert.Equal(t, tt.want.Message, got.Message)
+		})
+	}
+}
+
+// mapStep Tests - Message Field with Other Step Attributes
+
+func TestMapStep_Message_WithOtherAttributes(t *testing.T) {
+	tests := []struct {
+		name     string
+		yamlStep yamlStep
+		want     *workflow.Step
+	}{
+		{
+			name: "terminal step with message and description",
+			yamlStep: yamlStep{
+				Type:        "terminal",
+				Status:      "failure",
+				Description: "Database connection step",
+				Message:     "Database connection failed",
+			},
+			want: &workflow.Step{
+				Type:        workflow.StepTypeTerminal,
+				Status:      workflow.TerminalFailure,
+				Description: "Database connection step",
+				Message:     "Database connection failed",
+			},
+		},
+		{
+			name: "terminal step with message and transitions",
+			yamlStep: yamlStep{
+				Type:      "terminal",
+				Status:    "failure",
+				Message:   "Deployment failed",
+				OnSuccess: "notify_success",
+				OnFailure: "notify_failure",
+			},
+			want: &workflow.Step{
+				Type:      workflow.StepTypeTerminal,
+				Status:    workflow.TerminalFailure,
+				Message:   "Deployment failed",
+				OnSuccess: "notify_success",
+				OnFailure: "notify_failure",
+			},
+		},
+		{
+			name: "terminal step with message and depends on",
+			yamlStep: yamlStep{
+				Type:      "terminal",
+				Status:    "failure",
+				Message:   "Step failed",
+				DependsOn: []string{"setup", "build"},
+			},
+			want: &workflow.Step{
+				Type:      workflow.StepTypeTerminal,
+				Status:    workflow.TerminalFailure,
+				Message:   "Step failed",
+				DependsOn: []string{"setup", "build"},
+			},
+		},
+		{
+			name: "command step with message and retry config",
+			yamlStep: yamlStep{
+				Type:    "step",
+				Command: "deploy.sh",
+				Message: "Deployment in progress",
+				Retry: &yamlRetry{
+					MaxAttempts:  3,
+					InitialDelay: "10s",
+				},
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeCommand,
+				Command: "deploy.sh",
+				Message: "Deployment in progress",
+				Retry: &workflow.RetryConfig{
+					MaxAttempts:    3,
+					InitialDelayMs: 10000,
+				},
+			},
+		},
+		{
+			name: "command step with message and timeout",
+			yamlStep: yamlStep{
+				Type:    "step",
+				Command: "long_running_task",
+				Message: "Long running task",
+				Timeout: "30m",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeCommand,
+				Command: "long_running_task",
+				Message: "Long running task",
+				Timeout: 1800,
+			},
+		},
+		{
+			name: "terminal step with message and all attributes",
+			yamlStep: yamlStep{
+				Type:            "terminal",
+				Status:          "failure",
+				Description:     "Final terminal state",
+				Message:         "Workflow terminated",
+				ContinueOnError: true,
+				Dir:             "/tmp",
+			},
+			want: &workflow.Step{
+				Type:            workflow.StepTypeTerminal,
+				Status:          workflow.TerminalFailure,
+				Description:     "Final terminal state",
+				Message:         "Workflow terminated",
+				ContinueOnError: true,
+				Dir:             "/tmp",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mapStep("test.yaml", "test_step", &tt.yamlStep)
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want.Type, got.Type)
+			assert.Equal(t, tt.want.Status, got.Status)
+			assert.Equal(t, tt.want.Message, got.Message)
+			assert.Equal(t, tt.want.Description, got.Description)
+			assert.Equal(t, tt.want.OnSuccess, got.OnSuccess)
+			assert.Equal(t, tt.want.OnFailure, got.OnFailure)
+			assert.Equal(t, tt.want.ContinueOnError, got.ContinueOnError)
+			assert.Equal(t, tt.want.Dir, got.Dir)
+			assert.Equal(t, tt.want.Timeout, got.Timeout)
+			assert.Equal(t, tt.want.DependsOn, got.DependsOn)
+
+			if tt.want.Retry != nil {
+				require.NotNil(t, got.Retry)
+				assert.Equal(t, tt.want.Retry.MaxAttempts, got.Retry.MaxAttempts)
+				assert.Equal(t, tt.want.Retry.InitialDelayMs, got.Retry.InitialDelayMs)
+			}
+		})
+	}
+}
+
+// mapStep Tests - Message Field with Different Step Types
+
+func TestMapStep_Message_WithDifferentStepTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		yamlStep yamlStep
+		want     *workflow.Step
+	}{
+		{
+			name: "terminal failure step with message",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "failure",
+				Message: "Build failed",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalFailure,
+				Message: "Build failed",
+			},
+		},
+		{
+			name: "terminal success step with message",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "success",
+				Message: "Deployment successful",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeTerminal,
+				Status:  workflow.TerminalSuccess,
+				Message: "Deployment successful",
+			},
+		},
+		{
+			name: "command step with message",
+			yamlStep: yamlStep{
+				Type:    "step",
+				Command: "echo 'Running'",
+				Message: "Command step message",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeCommand,
+				Command: "echo 'Running'",
+				Message: "Command step message",
+			},
+		},
+		{
+			name: "agent step with message",
+			yamlStep: yamlStep{
+				Type:    "agent",
+				Message: "Agent step message",
+			},
+			want: &workflow.Step{
+				Type:    workflow.StepTypeAgent,
+				Message: "Agent step message",
+			},
+		},
+		{
+			name: "parallel step with message",
+			yamlStep: yamlStep{
+				Type:     "parallel",
+				Strategy: "all_succeed",
+				Parallel: []string{"branch1", "branch2"},
+				Message:  "Parallel step message",
+			},
+			want: &workflow.Step{
+				Type:     workflow.StepTypeParallel,
+				Strategy: "all_succeed",
+				Branches: []string{"branch1", "branch2"},
+				Message:  "Parallel step message",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mapStep("test.yaml", "test_step", &tt.yamlStep)
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want.Type, got.Type)
+			assert.Equal(t, tt.want.Message, got.Message)
+			assert.Equal(t, tt.want.Status, got.Status)
+		})
+	}
+}
+
+// mapStep Tests - Message Field Preservation (No Mutation)
+
+func TestMapStep_Message_Preservation(t *testing.T) {
+	tests := []struct {
+		name     string
+		yamlStep yamlStep
+		want     string
+	}{
+		{
+			name: "message is preserved exactly without modification",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "failure",
+				Message: "Original message",
+			},
+			want: "Original message",
+		},
+		{
+			name: "message with template variables preserved exactly",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "failure",
+				Message: "{{states.previous_step.output}}",
+			},
+			want: "{{states.previous_step.output}}",
+		},
+		{
+			name: "message case sensitivity preserved",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "failure",
+				Message: "MixedCase MESSAGE",
+			},
+			want: "MixedCase MESSAGE",
+		},
+		{
+			name: "message with unicode preserved",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "failure",
+				Message: "エラーが発生しました: ❌",
+			},
+			want: "エラーが発生しました: ❌",
+		},
+		{
+			name: "message with escape sequences preserved",
+			yamlStep: yamlStep{
+				Type:    "terminal",
+				Status:  "failure",
+				Message: "Line 1\\nLine 2\\tTabbed",
+			},
+			want: "Line 1\\nLine 2\\tTabbed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mapStep("test.yaml", "test_step", &tt.yamlStep)
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want, got.Message)
+		})
+	}
+}

--- a/internal/infrastructure/repository/yaml_mapper_on_failure_test.go
+++ b/internal/infrastructure/repository/yaml_mapper_on_failure_test.go
@@ -1,0 +1,536 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// normalizeOnFailure Tests - String Form (Backward Compatibility - US2)
+
+func TestNormalizeOnFailure_StringForm(t *testing.T) {
+	tests := []struct {
+		name      string
+		onFailure any
+		want      string
+	}{
+		{
+			name:      "named terminal reference passes through",
+			onFailure: "error_terminal",
+			want:      "error_terminal",
+		},
+		{
+			name:      "nil on_failure returns empty string",
+			onFailure: nil,
+			want:      "",
+		},
+		{
+			name:      "empty string passes through",
+			onFailure: "",
+			want:      "",
+		},
+		{
+			name:      "step name with underscore passes through",
+			onFailure: "deploy_error",
+			want:      "deploy_error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeOnFailure("test.yaml", "build_step", tt.onFailure)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// normalizeOnFailure Tests - Inline Error Object (US1, FR-001, FR-002)
+
+func TestNormalizeOnFailure_InlineMessageOnly(t *testing.T) {
+	inlineError := map[string]any{
+		"message": "Deploy failed",
+	}
+
+	got, err := normalizeOnFailure("test.yaml", "deploy_step", inlineError)
+
+	require.NoError(t, err)
+	assert.Equal(t, "__inline_error_deploy_step", got)
+}
+
+func TestNormalizeOnFailure_InlineMessageAndStatus(t *testing.T) {
+	inlineError := map[string]any{
+		"message": "Build failed",
+		"status":  3,
+	}
+
+	got, err := normalizeOnFailure("test.yaml", "build_step", inlineError)
+
+	require.NoError(t, err)
+	assert.Equal(t, "__inline_error_build_step", got)
+}
+
+func TestNormalizeOnFailure_InlineWithInterpolationTemplate(t *testing.T) {
+	// ADR-003: template must be stored raw, not interpolated at parse time
+	inlineError := map[string]any{
+		"message": "{{states.build.Output}} failed",
+	}
+
+	got, err := normalizeOnFailure("test.yaml", "build_step", inlineError)
+
+	require.NoError(t, err)
+	assert.Equal(t, "__inline_error_build_step", got)
+}
+
+// normalizeOnFailure Tests - Validation Errors (US3, FR-006)
+
+func TestNormalizeOnFailure_InlineMissingMessage(t *testing.T) {
+	inlineError := map[string]any{
+		"status": 3,
+	}
+
+	_, err := normalizeOnFailure("workflow.yaml", "deploy_step", inlineError)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deploy_step")
+	assert.Contains(t, err.Error(), "message")
+}
+
+func TestNormalizeOnFailure_InlineEmptyMessage(t *testing.T) {
+	inlineError := map[string]any{
+		"message": "",
+		"status":  3,
+	}
+
+	_, err := normalizeOnFailure("workflow.yaml", "build_step", inlineError)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build_step")
+	assert.Contains(t, err.Error(), "message")
+}
+
+func TestNormalizeOnFailure_InlineEmptyObject(t *testing.T) {
+	inlineError := map[string]any{}
+
+	_, err := normalizeOnFailure("workflow.yaml", "checkout_step", inlineError)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checkout_step")
+	assert.Contains(t, err.Error(), "message")
+}
+
+// validateInlineErrorObject Tests - Error Messages (NFR-003)
+
+func TestValidateInlineErrorObject_IncludesFieldPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		obj         map[string]any
+		wantErrText string
+	}{
+		{
+			name:        "missing message field includes on_failure.message path",
+			obj:         map[string]any{"status": 1},
+			wantErrText: "on_failure.message",
+		},
+		{
+			name:        "empty message includes on_failure.message path",
+			obj:         map[string]any{"message": ""},
+			wantErrText: "on_failure.message",
+		},
+		{
+			name:        "empty object includes on_failure.message path",
+			obj:         map[string]any{},
+			wantErrText: "on_failure.message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateInlineErrorObject("workflow.yaml", "my_step", tt.obj)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrText)
+		})
+	}
+}
+
+func TestValidateInlineErrorObject_ValidObject(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  map[string]any
+	}{
+		{
+			name: "message only is valid",
+			obj:  map[string]any{"message": "Deploy failed"},
+		},
+		{
+			name: "message and status is valid",
+			obj:  map[string]any{"message": "Build failed", "status": 3},
+		},
+		{
+			name: "message with template is valid",
+			obj:  map[string]any{"message": "{{states.build.output}} failed"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateInlineErrorObject("workflow.yaml", "my_step", tt.obj)
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+// synthesizeInlineErrorTerminal Tests
+
+func TestSynthesizeInlineErrorTerminal_MessageOnly(t *testing.T) {
+	obj := map[string]any{
+		"message": "Deploy failed",
+	}
+
+	got, err := synthesizeInlineErrorTerminal("deploy_step", obj)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "terminal", got.Type)
+	assert.Equal(t, "failure", got.Status)
+	assert.Equal(t, "Deploy failed", got.Message)
+	// FR-004: no status → default exit code 1
+	assert.Equal(t, 1, got.ExitCode)
+}
+
+func TestSynthesizeInlineErrorTerminal_MessageAndStatus(t *testing.T) {
+	obj := map[string]any{
+		"message": "Build failed",
+		"status":  3,
+	}
+
+	got, err := synthesizeInlineErrorTerminal("build_step", obj)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "terminal", got.Type)
+	assert.Equal(t, "failure", got.Status)
+	assert.Equal(t, "Build failed", got.Message)
+	// FR-004: status 3 → ExitCode 3
+	assert.Equal(t, 3, got.ExitCode)
+}
+
+func TestSynthesizeInlineErrorTerminal_DefaultStatusIsFailure(t *testing.T) {
+	// FR-004: When status omitted, default to failure
+	obj := map[string]any{
+		"message": "Something went wrong",
+	}
+
+	got, err := synthesizeInlineErrorTerminal("step1", obj)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "failure", got.Status)
+}
+
+// TestSynthesizeInlineErrorTerminal_StatusMapsToExitCode verifies FR-004: status field → ExitCode.
+func TestSynthesizeInlineErrorTerminal_StatusMapsToExitCode(t *testing.T) {
+	tests := []struct {
+		name         string
+		obj          map[string]any
+		wantExitCode int
+	}{
+		{
+			name:         "status 1 maps to ExitCode 1",
+			obj:          map[string]any{"message": "Build failed", "status": 1},
+			wantExitCode: 1,
+		},
+		{
+			name:         "status 3 maps to ExitCode 3",
+			obj:          map[string]any{"message": "Execution failed", "status": 3},
+			wantExitCode: 3,
+		},
+		{
+			name:         "status 4 maps to ExitCode 4",
+			obj:          map[string]any{"message": "System error", "status": 4},
+			wantExitCode: 4,
+		},
+		{
+			name:         "float64 status (JSON round-trip) maps to ExitCode",
+			obj:          map[string]any{"message": "Float status", "status": float64(2)},
+			wantExitCode: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := synthesizeInlineErrorTerminal("my_step", tt.obj)
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.wantExitCode, got.ExitCode)
+		})
+	}
+}
+
+// TestSynthesizeInlineErrorTerminal_DefaultExitCode1 verifies FR-004: missing status → ExitCode 1.
+func TestSynthesizeInlineErrorTerminal_DefaultExitCode1(t *testing.T) {
+	obj := map[string]any{
+		"message": "Something failed",
+	}
+
+	got, err := synthesizeInlineErrorTerminal("step1", obj)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, 1, got.ExitCode, "omitted status must default to ExitCode 1 per FR-004")
+}
+
+func TestSynthesizeInlineErrorTerminal_TemplateMessagePreservedRaw(t *testing.T) {
+	// ADR-003: message templates stored raw, not interpolated at parse time
+	obj := map[string]any{
+		"message": "{{states.build.Output}} failed",
+	}
+
+	got, err := synthesizeInlineErrorTerminal("build_step", obj)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "{{states.build.Output}} failed", got.Message)
+}
+
+// mapToDomain Integration — synthesized terminals injected into wf.Steps (FR-002)
+
+func TestMapToDomain_InlineOnFailure_SynthesizesTerminal(t *testing.T) {
+	y := &yamlWorkflow{
+		Name: "test-workflow",
+		States: yamlStates{
+			Initial: "build",
+			Steps: map[string]yamlStep{
+				"build": {
+					Type:    "step",
+					Command: "make build",
+					OnFailure: map[string]any{
+						"message": "Build failed",
+					},
+				},
+			},
+		},
+	}
+
+	wf, err := mapToDomain("test.yaml", y)
+
+	require.NoError(t, err)
+	require.NotNil(t, wf)
+
+	// The build step's OnFailure must be the synthesized name
+	buildStep, ok := wf.Steps["build"]
+	require.True(t, ok, "build step must exist")
+	assert.Equal(t, "__inline_error_build", buildStep.OnFailure)
+
+	// The synthesized terminal must be injected into wf.Steps
+	synth, ok := wf.Steps["__inline_error_build"]
+	require.True(t, ok, "synthesized terminal must exist in wf.Steps")
+	assert.Equal(t, workflow.StepTypeTerminal, synth.Type)
+	assert.Equal(t, workflow.TerminalFailure, synth.Status)
+	assert.Equal(t, "Build failed", synth.Message)
+}
+
+func TestMapToDomain_InlineOnFailure_MessageAndStatus(t *testing.T) {
+	// Inline object with explicit status — synthesized terminal uses failure status and propagates ExitCode
+	y := &yamlWorkflow{
+		Name: "test-workflow",
+		States: yamlStates{
+			Initial: "deploy",
+			Steps: map[string]yamlStep{
+				"deploy": {
+					Type:    "step",
+					Command: "deploy.sh",
+					OnFailure: map[string]any{
+						"message": "Deploy failed",
+						"status":  3,
+					},
+				},
+			},
+		},
+	}
+
+	wf, err := mapToDomain("test.yaml", y)
+
+	require.NoError(t, err)
+	require.NotNil(t, wf)
+
+	deployStep, ok := wf.Steps["deploy"]
+	require.True(t, ok)
+	assert.Equal(t, "__inline_error_deploy", deployStep.OnFailure)
+
+	synth, ok := wf.Steps["__inline_error_deploy"]
+	require.True(t, ok, "synthesized terminal must exist")
+	assert.Equal(t, workflow.TerminalFailure, synth.Status)
+	assert.Equal(t, "Deploy failed", synth.Message)
+	// FR-004: status 3 must propagate as ExitCode 3
+	assert.Equal(t, 3, synth.ExitCode)
+}
+
+func TestMapToDomain_StringOnFailure_PreservesExistingBehavior(t *testing.T) {
+	// US2: string-form on_failure must not be affected by F066 changes
+	y := &yamlWorkflow{
+		Name: "test-workflow",
+		States: yamlStates{
+			Initial: "build",
+			Steps: map[string]yamlStep{
+				"build": {
+					Type:      "step",
+					Command:   "make build",
+					OnFailure: "error_terminal",
+				},
+				"error_terminal": {
+					Type:   "terminal",
+					Status: "failure",
+				},
+			},
+		},
+	}
+
+	wf, err := mapToDomain("test.yaml", y)
+
+	require.NoError(t, err)
+	require.NotNil(t, wf)
+
+	buildStep, ok := wf.Steps["build"]
+	require.True(t, ok)
+	assert.Equal(t, "error_terminal", buildStep.OnFailure)
+
+	// No extra synthesized steps injected for string-form
+	for name := range wf.Steps {
+		assert.False(t, len(name) > len("__inline_error_") && name[:len("__inline_error_")] == "__inline_error_",
+			"no synthesized terminal should exist for string-form on_failure, got: %s", name)
+	}
+}
+
+func TestMapToDomain_InlineOnFailure_ValidationError(t *testing.T) {
+	// Missing message → parse error returned from mapToDomain
+	y := &yamlWorkflow{
+		Name: "test-workflow",
+		States: yamlStates{
+			Initial: "build",
+			Steps: map[string]yamlStep{
+				"build": {
+					Type:    "step",
+					Command: "make build",
+					OnFailure: map[string]any{
+						"status": 3,
+					},
+				},
+			},
+		},
+	}
+
+	_, err := mapToDomain("test.yaml", y)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build")
+	assert.Contains(t, err.Error(), "message")
+}
+
+func TestMapToDomain_InlineOnFailure_EmptyMessage_ValidationError(t *testing.T) {
+	// Empty message → parse error
+	y := &yamlWorkflow{
+		Name: "test-workflow",
+		States: yamlStates{
+			Initial: "deploy",
+			Steps: map[string]yamlStep{
+				"deploy": {
+					Type:      "step",
+					Command:   "deploy.sh",
+					OnFailure: map[string]any{"message": ""},
+				},
+			},
+		},
+	}
+
+	_, err := mapToDomain("test.yaml", y)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deploy")
+}
+
+func TestMapToDomain_InlineOnFailure_MultipleSteps(t *testing.T) {
+	// Multiple steps each with inline on_failure → distinct synthesized terminals
+	y := &yamlWorkflow{
+		Name: "test-workflow",
+		States: yamlStates{
+			Initial: "build",
+			Steps: map[string]yamlStep{
+				"build": {
+					Type:      "step",
+					Command:   "make build",
+					OnSuccess: "deploy",
+					OnFailure: map[string]any{"message": "Build failed"},
+				},
+				"deploy": {
+					Type:      "step",
+					Command:   "deploy.sh",
+					OnFailure: map[string]any{"message": "Deploy failed"},
+				},
+			},
+		},
+	}
+
+	wf, err := mapToDomain("test.yaml", y)
+
+	require.NoError(t, err)
+	require.NotNil(t, wf)
+
+	buildStep, ok := wf.Steps["build"]
+	require.True(t, ok)
+	assert.Equal(t, "__inline_error_build", buildStep.OnFailure)
+
+	deployStep, ok := wf.Steps["deploy"]
+	require.True(t, ok)
+	assert.Equal(t, "__inline_error_deploy", deployStep.OnFailure)
+
+	// Both synthesized terminals exist as distinct entries
+	_, hasBuildSynth := wf.Steps["__inline_error_build"]
+	_, hasDeploySynth := wf.Steps["__inline_error_deploy"]
+	assert.True(t, hasBuildSynth, "synthesized terminal for build must exist")
+	assert.True(t, hasDeploySynth, "synthesized terminal for deploy must exist")
+}
+
+// mapStep Tests - OnFailure Field Backward Compatibility
+
+func TestMapStep_OnFailure_StringForm(t *testing.T) {
+	// US2: string on_failure passes through unchanged
+	y := &yamlStep{
+		Type:      "step",
+		Command:   "echo hello",
+		OnFailure: "named_error_terminal",
+	}
+
+	got, err := mapStep("test.yaml", "my_step", y)
+
+	require.NoError(t, err)
+	assert.Equal(t, "named_error_terminal", got.OnFailure)
+}
+
+func TestMapStep_OnFailure_NilValue(t *testing.T) {
+	// nil on_failure → empty OnFailure on domain step
+	y := &yamlStep{
+		Type:      "step",
+		Command:   "echo hello",
+		OnFailure: nil,
+	}
+
+	got, err := mapStep("test.yaml", "my_step", y)
+
+	require.NoError(t, err)
+	assert.Equal(t, "", got.OnFailure)
+}
+
+func TestNormalizeOnFailure_InvalidType(t *testing.T) {
+	// on_failure with an unsupported type (e.g., integer) → parse error
+	_, err := normalizeOnFailure("workflow.yaml", "my_step", 42)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a string or object")
+}

--- a/internal/infrastructure/repository/yaml_types.go
+++ b/internal/infrastructure/repository/yaml_types.go
@@ -29,7 +29,7 @@ type yamlStep struct {
 	Dir             string           `yaml:"dir"`
 	Timeout         string           `yaml:"timeout"`
 	OnSuccess       string           `yaml:"on_success"`
-	OnFailure       string           `yaml:"on_failure"`
+	OnFailure       any              `yaml:"on_failure"` // F066: string (named terminal) or map[string]any (inline error)
 	Transitions     []yamlTransition `yaml:"transitions"`
 	DependsOn       []string         `yaml:"depends_on"`
 	Parallel        []string         `yaml:"parallel"`
@@ -41,6 +41,7 @@ type yamlStep struct {
 	ContinueOnError bool             `yaml:"continue_on_error"`
 	Status          string           `yaml:"status"`  // for terminal steps
 	Message         string           `yaml:"message"` // for terminal steps
+	ExitCode        int              // for synthesized inline error terminals (FR-004); set programmatically, not from YAML
 
 	// Loop configuration (for for_each and while types)
 	Items         any      `yaml:"items"`          // string or []any for for_each

--- a/internal/testutil/builders/builders.go
+++ b/internal/testutil/builders/builders.go
@@ -455,6 +455,20 @@ func (b *StepBuilder) WithLoop(loop *workflow.LoopConfig) *StepBuilder {
 	return b
 }
 
+// WithMessage sets the message template for terminal-type steps.
+// The message is stored as-is and interpolated at runtime.
+func (b *StepBuilder) WithMessage(message string) *StepBuilder {
+	b.step.Message = message
+	return b
+}
+
+// WithExitCode sets the process exit code for terminal-type steps (FR-004).
+// Defaults to 0; inline error terminals default to 1 at parse time.
+func (b *StepBuilder) WithExitCode(code int) *StepBuilder {
+	b.step.ExitCode = code
+	return b
+}
+
 // WithOperation sets operation details for operation-type steps.
 func (b *StepBuilder) WithOperation(operation string, inputs map[string]any) *StepBuilder {
 	b.step.Operation = operation

--- a/internal/testutil/builders/step_builder_message_test.go
+++ b/internal/testutil/builders/step_builder_message_test.go
@@ -1,0 +1,109 @@
+package builders
+
+import (
+	"testing"
+
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStepBuilder_WithMessage_HappyPath(t *testing.T) {
+	tests := []struct {
+		name            string
+		message         string
+		expectedMessage string
+	}{
+		{
+			name:            "sets plain error message",
+			message:         "Deploy failed",
+			expectedMessage: "Deploy failed",
+		},
+		{
+			name:            "sets message with template interpolation",
+			message:         "{{states.build.output}} failed",
+			expectedMessage: "{{states.build.output}} failed",
+		},
+		{
+			name:            "sets message with inputs interpolation",
+			message:         "Step {{inputs.env}} failed",
+			expectedMessage: "Step {{inputs.env}} failed",
+		},
+		{
+			name:            "sets message with env interpolation",
+			message:         "Error in {{env.STAGE}} environment",
+			expectedMessage: "Error in {{env.STAGE}} environment",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewTerminalStep("error-terminal", workflow.TerminalFailure).WithMessage(tt.message)
+			step := builder.Build()
+
+			assert.Equal(t, tt.expectedMessage, step.Message, "Message should match input")
+		})
+	}
+}
+
+func TestStepBuilder_WithMessage_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name            string
+		message         string
+		expectedMessage string
+	}{
+		{
+			name:            "handles empty string",
+			message:         "",
+			expectedMessage: "",
+		},
+		{
+			name:            "handles message with special characters",
+			message:         "Deploy failed: exit code 1 (non-zero)",
+			expectedMessage: "Deploy failed: exit code 1 (non-zero)",
+		},
+		{
+			name:            "handles multiword message",
+			message:         "Critical failure in production pipeline stage",
+			expectedMessage: "Critical failure in production pipeline stage",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewTerminalStep("error-terminal", workflow.TerminalFailure).WithMessage(tt.message)
+			step := builder.Build()
+
+			assert.Equal(t, tt.expectedMessage, step.Message)
+		})
+	}
+}
+
+func TestStepBuilder_WithMessage_FluentInterface(t *testing.T) {
+	builder := NewTerminalStep("error-terminal", workflow.TerminalFailure).
+		WithMessage("Deploy failed").
+		WithDescription("Terminal state for deployment errors")
+
+	step := builder.Build()
+
+	assert.Equal(t, "error-terminal", step.Name)
+	assert.Equal(t, "Deploy failed", step.Message)
+	assert.Equal(t, "Terminal state for deployment errors", step.Description)
+}
+
+func TestStepBuilder_WithMessage_Overwrite(t *testing.T) {
+	builder := NewTerminalStep("error-terminal", workflow.TerminalFailure).
+		WithMessage("first message").
+		WithMessage("second message")
+
+	step := builder.Build()
+
+	assert.Equal(t, "second message", step.Message, "should use last set value")
+}
+
+func TestStepBuilder_WithMessage_StatusNotAffected(t *testing.T) {
+	builder := NewTerminalStep("error-terminal", workflow.TerminalFailure).WithMessage("Build failed")
+	step := builder.Build()
+
+	assert.Equal(t, "Build failed", step.Message)
+	assert.Equal(t, workflow.TerminalFailure, step.Status, "Status should remain unchanged when Message is set")
+}

--- a/tests/integration/features/on_failure_inline_test.go
+++ b/tests/integration/features/on_failure_inline_test.go
@@ -1,0 +1,526 @@
+//go:build integration
+
+package features_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awf-project/awf/internal/application"
+	"github.com/awf-project/awf/internal/domain/workflow"
+	"github.com/awf-project/awf/internal/infrastructure/executor"
+	"github.com/awf-project/awf/internal/infrastructure/repository"
+	"github.com/awf-project/awf/internal/testutil/builders"
+	"github.com/awf-project/awf/internal/testutil/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// F066: Inline Error Terminal Shorthand for on_failure Integration Tests
+//
+// Integration tests validate end-to-end behavior of inline on_failure:
+// - Inline error objects with message and optional status
+// - Message interpolation at runtime with {{states.*}}, {{inputs.*}}
+// - String-form backward compatibility
+// - Validation errors for missing/empty message
+// - Parallel step inline error handling
+//
+// These tests complement unit tests (yaml_mapper_on_failure_test.go,
+// execution_service_on_failure_inline_test.go) by exercising the full
+// workflow lifecycle: parse → validate → execute.
+
+// buildTestService constructs an ExecutionService wired with a YAML repository
+// pointing to workflowsDir and in-memory mocks for store, executor, and logger.
+func buildTestService(t *testing.T, workflowsDir string) *application.ExecutionService {
+	t.Helper()
+	repo := repository.NewYAMLRepository(workflowsDir)
+	store := mocks.NewMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := mocks.NewMockLogger()
+
+	return builders.NewExecutionServiceBuilder().
+		WithWorkflowRepository(repo).
+		WithStateStore(store).
+		WithExecutor(exec).
+		WithLogger(logger).
+		Build()
+}
+
+// TestOnFailureInline_BasicMessage verifies inline on_failure with message only
+// Scenario: US1 - Inline error object on on_failure
+// Strategy: Create minimal workflow with inline on_failure, trigger failure, verify error message
+func TestOnFailureInline_BasicMessage(t *testing.T) {
+	tests := []struct {
+		name            string
+		workflowYAML    string
+		expectedMessage string
+		expectErr       bool
+	}{
+		{
+			name: "inline message only, default failure status",
+			workflowYAML: `
+name: test-inline-message
+version: "1.0.0"
+states:
+  initial: failing_step
+  failing_step:
+    type: step
+    command: exit 1
+    on_failure:
+      message: "Custom error message"
+`,
+			expectedMessage: "Custom error message",
+			expectErr:       true,
+		},
+		{
+			name: "inline message with special characters",
+			workflowYAML: `
+name: test-inline-special
+version: "1.0.0"
+states:
+  initial: failing_step
+  failing_step:
+    type: step
+    command: exit 1
+    on_failure:
+      message: "Error: deployment failed (see logs)"
+`,
+			expectedMessage: "Error: deployment failed (see logs)",
+			expectErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tmpDir := t.TempDir()
+			workflowsDir := filepath.Join(tmpDir, "workflows")
+
+			require.NoError(t, os.MkdirAll(workflowsDir, 0o755))
+
+			workflowPath := filepath.Join(workflowsDir, "test.yaml")
+			require.NoError(t, os.WriteFile(workflowPath, []byte(tt.workflowYAML), 0o644))
+
+			svc := buildTestService(t, workflowsDir)
+
+			_, err := svc.Run(ctx, "test", nil)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedMessage)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestOnFailureInline_MessageWithStatus verifies inline on_failure with message and status
+// Scenario: US1 - Inline error object with optional status field
+// Strategy: Create workflow with inline on_failure specifying exit code, verify status propagated
+func TestOnFailureInline_MessageWithStatus(t *testing.T) {
+	tests := []struct {
+		name             string
+		workflowYAML     string
+		expectedMessage  string
+		expectedExitCode int
+		expectErr        bool
+	}{
+		{
+			name: "inline message with exit code 1",
+			workflowYAML: `
+name: test-inline-status-1
+version: "1.0.0"
+states:
+  initial: failing_step
+  failing_step:
+    type: step
+    command: exit 1
+    on_failure:
+      message: "Build failed"
+      status: 1
+`,
+			expectedMessage:  "Build failed",
+			expectedExitCode: 1,
+			expectErr:        true,
+		},
+		{
+			name: "inline message with exit code 3",
+			workflowYAML: `
+name: test-inline-status-3
+version: "1.0.0"
+states:
+  initial: failing_step
+  failing_step:
+    type: step
+    command: exit 1
+    on_failure:
+      message: "Deploy failed"
+      status: 3
+`,
+			expectedMessage:  "Deploy failed",
+			expectedExitCode: 3,
+			expectErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tmpDir := t.TempDir()
+			workflowsDir := filepath.Join(tmpDir, "workflows")
+
+			require.NoError(t, os.MkdirAll(workflowsDir, 0o755))
+
+			workflowPath := filepath.Join(workflowsDir, "test.yaml")
+			require.NoError(t, os.WriteFile(workflowPath, []byte(tt.workflowYAML), 0o644))
+
+			svc := buildTestService(t, workflowsDir)
+
+			execCtx, err := svc.Run(ctx, "test", nil)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedMessage)
+				assert.Equal(t, tt.expectedExitCode, execCtx.ExitCode,
+					"ExitCode from inline on_failure status must propagate to execution context")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestOnFailureInline_MessageInterpolation verifies message template interpolation at runtime
+// Scenario: US1, FR-003 - Message field supports template interpolation
+// Strategy: Create workflow with {{states.*}}, {{inputs.*}} in message, verify substitution
+func TestOnFailureInline_MessageInterpolation(t *testing.T) {
+	tests := []struct {
+		name            string
+		workflowYAML    string
+		inputs          map[string]any
+		expectedMessage string
+		expectErr       bool
+	}{
+		{
+			name: "interpolate inputs in message",
+			workflowYAML: `
+name: test-inline-interp-inputs
+version: "1.0.0"
+states:
+  initial: failing_step
+  failing_step:
+    type: step
+    command: exit 1
+    on_failure:
+      message: "Operation {{inputs.operation}} failed"
+`,
+			inputs:          map[string]any{"operation": "deploy"},
+			expectedMessage: "Operation deploy failed",
+			expectErr:       true,
+		},
+		{
+			name: "interpolate multiple variables in message",
+			workflowYAML: `
+name: test-inline-interp-multi
+version: "1.0.0"
+states:
+  initial: failing_step
+  failing_step:
+    type: step
+    command: exit 1
+    on_failure:
+      message: "{{inputs.component}} failed: expected {{inputs.expected}}"
+`,
+			inputs:          map[string]any{"component": "API", "expected": "success"},
+			expectedMessage: "API failed: expected success",
+			expectErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tmpDir := t.TempDir()
+			workflowsDir := filepath.Join(tmpDir, "workflows")
+
+			require.NoError(t, os.MkdirAll(workflowsDir, 0o755))
+
+			workflowPath := filepath.Join(workflowsDir, "test.yaml")
+			require.NoError(t, os.WriteFile(workflowPath, []byte(tt.workflowYAML), 0o644))
+
+			svc := buildTestService(t, workflowsDir)
+
+			_, err := svc.Run(ctx, "test", tt.inputs)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedMessage)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestOnFailureInline_StringFormBackwardCompat verifies string-form on_failure still works
+// Scenario: US2 - Named terminal reference backward compatibility
+// Strategy: Create workflow with string-form on_failure referencing named terminal
+func TestOnFailureInline_StringFormBackwardCompat(t *testing.T) {
+	tests := []struct {
+		name            string
+		workflowYAML    string
+		expectedMessage string
+		expectErr       bool
+	}{
+		{
+			name: "string-form on_failure references named terminal",
+			workflowYAML: `
+name: test-inline-compat-string
+version: "1.0.0"
+states:
+  initial: failing_step
+  failing_step:
+    type: step
+    command: exit 1
+    on_failure: error_handler
+  error_handler:
+    type: terminal
+    message: "Handled via named terminal"
+    status: failure
+`,
+			expectedMessage: "Handled via named terminal",
+			expectErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tmpDir := t.TempDir()
+			workflowsDir := filepath.Join(tmpDir, "workflows")
+
+			require.NoError(t, os.MkdirAll(workflowsDir, 0o755))
+
+			workflowPath := filepath.Join(workflowsDir, "test.yaml")
+			require.NoError(t, os.WriteFile(workflowPath, []byte(tt.workflowYAML), 0o644))
+
+			svc := buildTestService(t, workflowsDir)
+
+			_, err := svc.Run(ctx, "test", nil)
+
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestOnFailureInline_ValidateInvalidMessage verifies validation rejects invalid inline errors
+// Scenario: US3, FR-006 - awf validate reports errors for invalid inline objects
+// Strategy: Run awf validate on workflows with missing/empty message, verify error
+func TestOnFailureInline_ValidateInvalidMessage(t *testing.T) {
+	tests := []struct {
+		name            string
+		workflowYAML    string
+		expectedError   string
+		shouldFailValid bool
+	}{
+		{
+			name: "missing message field rejected",
+			workflowYAML: `
+name: test-inline-no-message
+version: "1.0.0"
+states:
+  initial: failing_step
+  failing_step:
+    type: step
+    command: exit 1
+    on_failure:
+      status: 3
+`,
+			expectedError:   "required field missing",
+			shouldFailValid: true,
+		},
+		{
+			name: "empty message field rejected",
+			workflowYAML: `
+name: test-inline-empty-message
+version: "1.0.0"
+states:
+  initial: failing_step
+  failing_step:
+    type: step
+    command: exit 1
+    on_failure:
+      message: ""
+      status: 1
+`,
+			expectedError:   "non-empty string",
+			shouldFailValid: true,
+		},
+		{
+			name: "empty object rejected",
+			workflowYAML: `
+name: test-inline-empty-object
+version: "1.0.0"
+states:
+  initial: failing_step
+  failing_step:
+    type: step
+    command: exit 1
+    on_failure: {}
+`,
+			expectedError:   "required field missing",
+			shouldFailValid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tmpDir := t.TempDir()
+			workflowsDir := filepath.Join(tmpDir, "workflows")
+
+			require.NoError(t, os.MkdirAll(workflowsDir, 0o755))
+
+			workflowPath := filepath.Join(workflowsDir, "test.yaml")
+			require.NoError(t, os.WriteFile(workflowPath, []byte(tt.workflowYAML), 0o644))
+
+			repo := repository.NewYAMLRepository(workflowsDir)
+
+			_, err := repo.Load(ctx, "test")
+
+			if tt.shouldFailValid {
+				require.Error(t, err)
+				if tt.expectedError != "" {
+					assert.Contains(t, strings.ToLower(err.Error()), strings.ToLower(tt.expectedError))
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestOnFailureInline_ParallelBranch verifies inline error in parallel step branches
+// Scenario: US4, FR-001 - Inline error objects work in parallel step branches
+// Strategy: Create parallel step with inline error in branch, verify behavior
+func TestOnFailureInline_ParallelBranch(t *testing.T) {
+	tests := []struct {
+		name            string
+		workflowYAML    string
+		expectedMessage string
+		expectErr       bool
+	}{
+		{
+			name: "parallel branch with inline error on best_effort strategy",
+			workflowYAML: `
+name: test-inline-parallel
+version: "1.0.0"
+states:
+  initial: parallel_step
+  parallel_step:
+    type: parallel
+    strategy: best_effort
+    items:
+      - name: branch_a
+        type: step
+        command: exit 0
+      - name: branch_b
+        type: step
+        command: exit 1
+        on_failure:
+          message: "Branch B failed"
+`,
+			expectedMessage: "Branch B failed",
+			expectErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tmpDir := t.TempDir()
+			workflowsDir := filepath.Join(tmpDir, "workflows")
+
+			require.NoError(t, os.MkdirAll(workflowsDir, 0o755))
+
+			workflowPath := filepath.Join(workflowsDir, "test.yaml")
+			require.NoError(t, os.WriteFile(workflowPath, []byte(tt.workflowYAML), 0o644))
+
+			svc := buildTestService(t, workflowsDir)
+
+			_, err := svc.Run(ctx, "test", nil)
+
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestOnFailureInline_SynthesizedTerminalExists verifies synthesized terminal injection
+// Scenario: ADR-001 - Inline errors synthesize anonymous terminal at parse time
+// Strategy: Load workflow, verify synthesized terminal exists in Steps map
+func TestOnFailureInline_SynthesizedTerminalExists(t *testing.T) {
+	tests := []struct {
+		name          string
+		workflowYAML  string
+		originalSteps int
+		synthesized   string
+	}{
+		{
+			name: "inline error synthesizes __inline_error_ terminal",
+			workflowYAML: `
+name: test-inline-synth
+version: "1.0.0"
+states:
+  initial: failing_step
+  failing_step:
+    type: step
+    command: exit 1
+    on_failure:
+      message: "Error"
+`,
+			originalSteps: 1,
+			synthesized:   "__inline_error_failing_step",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tmpDir := t.TempDir()
+			workflowsDir := filepath.Join(tmpDir, "workflows")
+
+			require.NoError(t, os.MkdirAll(workflowsDir, 0o755))
+
+			workflowPath := filepath.Join(workflowsDir, "test.yaml")
+			require.NoError(t, os.WriteFile(workflowPath, []byte(tt.workflowYAML), 0o644))
+
+			repo := repository.NewYAMLRepository(workflowsDir)
+
+			wf, err := repo.Load(ctx, "test")
+			require.NoError(t, err)
+
+			assert.Greater(t, len(wf.Steps), tt.originalSteps, "synthesized terminal should be injected")
+
+			if tt.synthesized != "" {
+				_, exists := wf.Steps[tt.synthesized]
+				assert.True(t, exists, "synthesized terminal %s should exist in Steps map", tt.synthesized)
+
+				synthesized := wf.Steps[tt.synthesized]
+				assert.Equal(t, workflow.StepTypeTerminal, synthesized.Type)
+				assert.NotEmpty(t, synthesized.Message, "synthesized terminal should have message")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add inline `on_failure` shorthand syntax allowing `{message: "...", status: N}` objects directly in workflow YAML, synthesized into anonymous terminal steps at parse time
- Propagate exit codes from inline error terminals through `ExecutionContext` so callers receive the correct process exit status
- Add 8 Architecture Decision Records (ADRs) documenting established design decisions for the project
- Expand user guide documentation with inline `on_failure` examples and agent step output format details

## Changes

### Domain
- `internal/domain/workflow/step.go`: Add `Message` field to `Step` for runtime-interpolated terminal messages
- `internal/domain/workflow/context.go`: Add `ExitCode` field to `StepState` for exit code propagation
- `internal/domain/workflow/step_message_test.go`: Unit tests for `Message` field on all step types

### Infrastructure — YAML Parsing
- `internal/infrastructure/repository/yaml_mapper.go`: Add `normalizeOnFailure()`, `synthesizeInlineErrorTerminal()`, and `validateInlineErrorObject()` to parse inline error objects and synthesize anonymous terminal steps
- `internal/infrastructure/repository/yaml_types.go`: Change `OnFailure` field type from `string` to `any` to accept both string and object forms
- `internal/infrastructure/repository/yaml_mapper_on_failure_test.go`: Tests for inline error object parsing, validation, and synthesis
- `internal/infrastructure/repository/yaml_mapper_message_test.go`: Tests verifying `Message` field mapping for all step types

### Application
- `internal/application/execution_service.go`: Call `interpolateTerminalMessage()` to evaluate `{{var}}` templates in `Step.Message` at runtime; propagate `ExitCode` from terminal steps
- `internal/application/interactive_executor.go`: Add `interpolateTerminalMessage()` helper; propagate `ExitCode` through terminal step handling
- `internal/application/execution_service_on_failure_inline_test.go`: Unit tests for inline `on_failure` handling and exit code propagation in `ExecutionService`
- `internal/application/interactive_executor_terminal_test.go`: Unit tests for terminal step message interpolation in `InteractiveExecutor`
- `internal/application/interactive_executor_test.go`: Minor update for existing test compatibility

### Test Utilities
- `internal/testutil/builders/builders.go`: Add `WithMessage()` and `WithExitCode()` builder methods to `StepBuilder`
- `internal/testutil/builders/step_builder_message_test.go`: Tests for new builder methods

### Integration Tests
- `tests/integration/features/on_failure_inline_test.go`: End-to-end tests covering inline `on_failure` syntax, message interpolation, exit code propagation, and fallback to string form

### Documentation
- `docs/ADR/0001-hexagonal-architecture.md` through `docs/ADR/0007-agent-prompt-xor-constraint.md`: New ADR files documenting 7 architectural decisions
- `docs/ADR/README.md`: ADR index and template
- `docs/ADR/.template.md`: Template for future ADRs
- `docs/user-guide/workflow-syntax.md`: Add inline `on_failure` syntax reference with examples
- `docs/user-guide/agent-steps.md`: Add `output_format` field documentation
- `docs/plans/2026-02-17-f066-code-review-corrections.md`: Implementation plan for post-review corrections
- `docs/README.md`: Update docs index
- `CHANGELOG.md`: Add F066 entry
- `CLAUDE.md`: Add architecture rules for inline `on_failure` synthesis pattern and `interpolateTerminalMessage()` usage
- `README.md`: Minor update

## Test plan

- [ ] Run unit tests: `go test ./internal/... ./pkg/...` — all packages pass
- [ ] Run F066 integration tests: `go test ./tests/integration/features/ -run TestOnFailureInline` — all 19 tests pass
- [ ] Verify inline syntax in a workflow YAML: step with `on_failure: {message: "failed: {{states.step.output}}", status: 2}` exits with code 2 and interpolated message
- [ ] Verify string form `on_failure: step_name` still works unchanged

Closes #220

---
Generated with [awf](https://github.com/awf-project/awf) commit workflow

