### PR TITLE
fix(cli): apply config inputs in interactive and dry-run modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Risk**: Unreplaced references silently evaluate to `0` (expr-lang zero-value semantics)
 
 ### Fixed
+- **B007**: Interactive and dry-run modes now respect `.awf/config.yaml` input defaults
+  - `runInteractive()` and `runDryRun()` now load project config and merge inputs (same pattern as `runWorkflow()`)
+  - Config values are pre-filled, reducing re-prompting for already-configured inputs
+  - CLI flags still override config values (CLI wins)
+  - Fixes regression where interactive input collection always prompted for all required inputs, ignoring config.yaml
+  - Affects: interactive mode (`awf run --interactive`), dry-run mode (`awf run --dry-run`), and config-based input defaults
+
 - **B006**: Shell commands no longer fail on Debian/Ubuntu where `/bin/sh` is `dash`
   - `ShellExecutor` now detects the user's preferred shell via `$SHELL` environment variable at construction time
   - Falls back to `/bin/sh` if `$SHELL` is unset, relative, or points to a non-existent binary
@@ -268,6 +275,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Impact: Enables programmatic error handling in CI/CD pipelines, searchable error documentation, and consistent error messages across output formats
 
 ### Fixed
+- **B007**: Interactive input prompt and dry-run mode now respect `.awf/config.yaml` input defaults
+  - `runInteractive()` and `runDryRun()` now load project config and merge inputs (same pattern as `runWorkflow()`)
+  - Config values are pre-filled, reducing re-prompting for already-configured inputs
+  - CLI flags still override config values (CLI wins)
+  - Fixes regression where interactive input collection always prompted for all required inputs, ignoring config.yaml
+  - Affects: interactive mode (`awf run --interactive`), dry-run mode (`awf run --dry-run`), and config-based input defaults
 - **B006**: Shell commands no longer fail on Debian/Ubuntu where `/bin/sh` is `dash`
   - `ShellExecutor` now detects the user's preferred shell via `$SHELL` environment variable at construction time
   - Falls back to `/bin/sh` if `$SHELL` is unset, relative, or points to a non-existent binary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,83 +221,49 @@ See `CHANGELOG.md` and `docs/code-review-2025-12.md` for details.
 
 ## Architecture Rules
 
-Domain layer packages must restrict dependencies via go-arch-lint rules; domain/operation imports only domain/plugin, domain/ports, and stdlib
-
-Implement domain ports directly on domain types (e.g., OperationRegistry implements ports.OperationProvider) to enable zero-change integration with application services
-
-Use pkg pattern for cross-layer HTTP utilities (pkg/httpx) to avoid infrastructure-to-infrastructure mayDependOn violations; register as commonComponent in go-arch-lint.yml
-
-Implement infrastructure operation providers (e.g., HTTPOperationProvider) with direct domain type implementation to enable zero-change wiring into CompositeOperationProvider
-
-Implement prompt file loading in application layer (ExecutionService); domain layer defines PromptFile field only; infrastructure layer handles YAML mapping
-
-Populate AWF context variables (.awf.config_dir, .awf.cache_dir) in application layer during interpolation setup; use XDG directory standards for consistency
-
-Inject optional dependencies like XDG paths via SetAWFPaths() pattern in application layer; never import infrastructure modules directly from application layer
-
-Restrict local XDG overrides to scripts_dir and prompts_dir only; use allowlist-based matching against AWF map values to prevent unintended path resolution
-
-Synthesize inline on_failure objects into anonymous terminal steps at YAML parse time via normalizeOnFailure() and synthesizeInlineErrorTerminal() in infrastructure layer; domain Step.OnFailure remains string type with zero changes to existing consumers
+- Domain layer packages must restrict dependencies via go-arch-lint rules; domain/operation imports only domain/plugin, domain/ports, and stdlib
+- Implement domain ports directly on domain types (e.g., OperationRegistry implements ports.OperationProvider) to enable zero-change integration with application services
+- Use pkg pattern for cross-layer HTTP utilities (pkg/httpx) to avoid infrastructure-to-infrastructure mayDependOn violations; register as commonComponent in go-arch-lint.yml
+- Implement infrastructure operation providers (e.g., HTTPOperationProvider) with direct domain type implementation to enable zero-change wiring into CompositeOperationProvider
+- Implement prompt file loading in application layer (ExecutionService); domain layer defines PromptFile field only; infrastructure layer handles YAML mapping
+- Populate AWF context variables (.awf.config_dir, .awf.cache_dir) in application layer during interpolation setup; use XDG directory standards for consistency
+- Inject optional dependencies like XDG paths via SetAWFPaths() pattern in application layer; never import infrastructure modules directly from application layer
+- Restrict local XDG overrides to scripts_dir and prompts_dir only; use allowlist-based matching against AWF map values to prevent unintended path resolution
+- Synthesize inline on_failure objects into anonymous terminal steps at YAML parse time via normalizeOnFailure() and synthesizeInlineErrorTerminal() in infrastructure layer; domain Step.OnFailure remains string type with zero changes to existing consumers
 
 ## Common Pitfalls
 
-Preserve existing infrastructure layers when adding domain registries; ADR-004 enforces infrastructure plugin registry coexistence for separate lifecycle concerns
-
-Never duplicate HTTP client logic across notification backends; extract to pkg/httpx with HTTPDoer interface for testability and shared timeout/header handling
-
-Limit HTTP response bodies at operation level (default 1MB via io.LimitReader) with truncated flag; preserve unlimited reads for notify backends by allowing maxBytes=0
-
-Always resolve relative prompt file paths against workflow.SourceDir, not current working directory; enables consistent behavior regardless of CLI invocation location
-
-Enforce 1MB size limit on loaded prompt files via io.LimitReader to prevent accidental memory issues and provide fast failure feedback for misconfigured paths
-
-Never allow both Prompt and PromptFile fields to be set simultaneously; AgentConfig.Validate must enforce XOR constraint with clear error messages
-
-Never allow both Prompt and PromptFile fields to be set simultaneously in agent configuration; enforce XOR constraint in AgentConfig.Validate with clear error message
-
-Always resolve relative prompt file paths against workflow.SourceDir, not current working directory; ensures consistent behavior regardless of CLI invocation location
-
-Enforce 1MB size limit on loaded prompt files via io.LimitReader; prevents accidental memory issues and provides fast failure feedback for misconfigured paths
-
-Always resolve script_file and prompt_file paths against workflow.SourceDir first, then check for local XDG overrides via resolveLocalOverGlobal() before falling back to global XDG paths
-
-Never initialize interpolation context with nil AWF map; always pass initialized empty map to prevent nil dereference in path resolution helpers
-
-Never initialize interpolation context with nil AWF map in loadExternalFile() and related functions; always pass initialized empty map to prevent nil dereference in resolveLocalOverGlobal() and path resolution helpers
-
-Always use interpolateTerminalMessage() in application layer to evaluate template variables in Step.Message at runtime; store message verbatim during parsing to preserve {{var}} syntax until execution time
-
-Extract validation functions with cognitive complexity > 30 into smaller helper functions to maintain readability
-
-Always run reported failing tests directly with -v flag before implementing fixes; error reports may reference stale or incorrect file locations
-
-Pass structs larger than 128 bytes by pointer in function parameters and method receivers to avoid expensive value copying
-
-Never check if maps are nil before calling len(); Go defines len() as zero for nil maps
-
-Combine consecutive function parameters of the same type into single type declaration (e.g., user, errorMsg string instead of user string, errorMsg string)
-
-Avoid package names that conflict with Go standard library packages (plugin, httputil, sql); rename packages to prevent revive var-naming lint violations
-
-Avoid implicit environment dependencies in tests; mock system calls (os.User, shell detection, file permissions) to ensure execution is deterministic regardless of test runner environment
+- Preserve existing infrastructure layers when adding domain registries; ADR-004 enforces infrastructure plugin registry coexistence for separate lifecycle concerns
+- Never duplicate HTTP client logic across notification backends; extract to pkg/httpx with HTTPDoer interface for testability and shared timeout/header handling
+- Limit HTTP response bodies at operation level (default 1MB via io.LimitReader) with truncated flag; preserve unlimited reads for notify backends by allowing maxBytes=0
+- Always resolve relative prompt file paths against workflow.SourceDir, not current working directory; enables consistent behavior regardless of CLI invocation location
+- Enforce 1MB size limit on loaded prompt files via io.LimitReader to prevent accidental memory issues and provide fast failure feedback for misconfigured paths
+- Never allow both Prompt and PromptFile fields to be set simultaneously; AgentConfig.Validate must enforce XOR constraint with clear error messages
+- Never allow both Prompt and PromptFile fields to be set simultaneously in agent configuration; enforce XOR constraint in AgentConfig.Validate with clear error message
+- Always resolve relative prompt file paths against workflow.SourceDir, not current working directory; ensures consistent behavior regardless of CLI invocation location
+- Enforce 1MB size limit on loaded prompt files via io.LimitReader; prevents accidental memory issues and provides fast failure feedback for misconfigured paths
+- Always resolve script_file and prompt_file paths against workflow.SourceDir first, then check for local XDG overrides via resolveLocalOverGlobal() before falling back to global XDG paths
+- Never initialize interpolation context with nil AWF map; always pass initialized empty map to prevent nil dereference in path resolution helpers
+- Never initialize interpolation context with nil AWF map in loadExternalFile() and related functions; always pass initialized empty map to prevent nil dereference in resolveLocalOverGlobal() and path resolution helpers
+- Always use interpolateTerminalMessage() in application layer to evaluate template variables in Step.Message at runtime; store message verbatim during parsing to preserve {{var}} syntax until execution time
+- Extract validation functions with cognitive complexity > 30 into smaller helper functions to maintain readability
+- Always run reported failing tests directly with -v flag before implementing fixes; error reports may reference stale or incorrect file locations
+- Pass structs larger than 128 bytes by pointer in function parameters and method receivers to avoid expensive value copying
+- Never check if maps are nil before calling len(); Go defines len() as zero for nil maps
+- Combine consecutive function parameters of the same type into single type declaration (e.g., user, errorMsg string instead of user string, errorMsg string)
+- Avoid package names that conflict with Go standard library packages (plugin, httputil, sql); rename packages to prevent revive var-naming lint violations
+- Avoid implicit environment dependencies in tests; mock system calls (os.User, shell detection, file permissions) to ensure execution is deterministic regardless of test runner environment
 
 ## Test Conventions
 
-Integration tests use compile-time interface checks (var _ PortInterface = (*Implementation)(nil)) to verify port implementation at build time
-
-Use HTTPDoer interface in pkg/httpx tests to mock HTTP behavior (timeouts, DNS errors, connection failures) without requiring adapters or *http.Client modifications
-
-Write unit tests for prompt file validation, interpolation, and YAML mapping before integration tests; use table-driven tests for path resolution scenarios
-
-Write unit tests for prompt file validation, interpolation, and YAML mapping before integration tests; use table-driven tests for path resolution scenarios
-
-Never use switch statements to populate table-driven test variables; declare all fields in struct literals to prevent silent zero-value failures from missed case names
-
-Write table-driven tests for inline error object parsing (message + status validation) before integration tests; use yamlStep.OnFailure field as 'any' type in test fixtures to validate both string and object forms
-
-Use distinct file naming for unit vs integration tests: *_unit_test.go vs *_test.go; prevents error analysis tools from reporting incorrect file scopes
-
-Never hardcode OS-specific values in test assertions (usernames, paths, shell names); use `os/user.Current()` or mock dependencies for reproducible tests across environments
+- Integration tests use compile-time interface checks (var _ PortInterface = (*Implementation)(nil)) to verify port implementation at build time
+- Use HTTPDoer interface in pkg/httpx tests to mock HTTP behavior (timeouts, DNS errors, connection failures) without requiring adapters or *http.Client modifications
+- Write unit tests for prompt file validation, interpolation, and YAML mapping before integration tests; use table-driven tests for path resolution scenarios
+- Write unit tests for prompt file validation, interpolation, and YAML mapping before integration tests; use table-driven tests for path resolution scenarios
+- Never use switch statements to populate table-driven test variables; declare all fields in struct literals to prevent silent zero-value failures from missed case names
+- Write table-driven tests for inline error object parsing (message + status validation) before integration tests; use yamlStep.OnFailure field as 'any' type in test fixtures to validate both string and object forms
+- Use distinct file naming for unit vs integration tests: *_unit_test.go vs *_test.go; prevents error analysis tools from reporting incorrect file scopes
+- Never hardcode OS-specific values in test assertions (usernames, paths, shell names); use `os/user.Current()` or mock dependencies for reproducible tests across environments
 
 ## Review Standards
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -82,7 +82,7 @@ inputs:
 
 ## Input Pre-population
 
-When you run a workflow, AWF automatically merges inputs from the config file with any CLI-provided inputs.
+When you run a workflow, AWF automatically merges inputs from the config file with any CLI-provided inputs. This applies to all execution modes: standard `awf run`, `--interactive`, and `--dry-run`.
 
 ### Priority Order
 
@@ -95,7 +95,7 @@ Config File < CLI Flags
 1. **Config file** (`.awf/config.yaml`): Base defaults
 2. **CLI flags** (`--input`): Override config values
 
-### Example
+### Standard Execution
 
 Given this configuration:
 
@@ -114,6 +114,45 @@ awf run deploy --input env=production
 The workflow receives:
 - `env` = `production` (CLI override wins)
 - `project` = `my-app` (from config)
+
+### Interactive Mode
+
+In interactive mode (`awf run --interactive`), config values reduce prompting:
+
+```bash
+$ awf run deploy --interactive --input env=production
+
+# env is NOT prompted (provided via CLI)
+# project is NOT prompted (in config.yaml)
+# Only missing required inputs are prompted
+```
+
+If the workflow had a third required input not in config or CLI:
+
+```bash
+$ awf run deploy --interactive
+
+# env = "staging" (from config, not prompted)
+# project = "my-app" (from config, not prompted)
+# Only other_required_input is prompted interactively
+
+Enter value for 'other_required_input' (string, required)
+> value
+```
+
+### Dry-Run Mode
+
+In dry-run mode (`awf run --dry-run`), config values are included in the execution plan:
+
+```bash
+$ awf run deploy --dry-run
+
+# Execution plan shows:
+# - env = "staging" (from config)
+# - project = "my-app" (from config)
+```
+
+This allows you to verify that config values are correctly applied without actually executing the workflow.
 
 ---
 
@@ -486,6 +525,7 @@ awf run my-workflow
 ## See Also
 
 - [Commands](commands.md) - CLI command reference
+- [Interactive Input Collection](interactive-inputs.md) - Automatic prompting for missing inputs with config pre-population
 - [Workflow Syntax](workflow-syntax.md) - Workflow YAML syntax
 - [Plugins](plugins.md) - Plugin system and configuration
 - [Audit Trail](audit-trail.md) - Structured audit logging for workflow executions

--- a/docs/user-guide/interactive-inputs.md
+++ b/docs/user-guide/interactive-inputs.md
@@ -301,6 +301,67 @@ Always provide inputs explicitly in CI/CD:
   run: awf run deploy --input environment=prod --input version=${{ github.ref_name }}
 ```
 
+## Configuration File Integration
+
+Interactive input collection automatically merges values from `.awf/config.yaml`, reducing re-prompting for pre-configured inputs.
+
+### How Config Values are Used
+
+When running a workflow with interactive input collection:
+
+1. **Config values are loaded** from `.awf/config.yaml` under the `inputs:` key
+2. **Config values are pre-filled** for required inputs that are defined there
+3. **Only missing inputs are prompted** — inputs already in config or CLI flags are skipped
+4. **CLI flags take priority** over config values (if provided, CLI wins)
+
+### Example with Config
+
+**Workflow definition:**
+```yaml
+name: deploy
+inputs:
+  - name: api_key
+    type: string
+    required: true
+    description: API key for authentication
+  - name: environment
+    type: string
+    required: true
+    description: Target environment
+```
+
+**Config file (`.awf/config.yaml`):**
+```yaml
+inputs:
+  api_key: "sk-test-123"  # Pre-configured
+```
+
+**Interactive execution:**
+```bash
+$ awf run deploy
+
+# api_key is NOT prompted (already in config)
+# Only environment is prompted
+Enter value for 'environment' (string, required)
+Description: Target environment
+> prod
+✓ Accepted
+
+Deploying...
+✓ Workflow completed successfully
+```
+
+**CLI override:**
+```bash
+$ awf run deploy --input api_key=sk-cli-456
+
+# api_key from CLI flag (overrides config)
+# Only environment is prompted
+Enter value for 'environment' (string, required)
+> prod
+✓ Accepted
+```
+
 ## Mixed Inputs
 
 ### Combining Flags and Prompts
@@ -561,5 +622,6 @@ description: |
 ## See Also
 
 - [Commands Reference](commands.md) - All AWF CLI commands
+- [Project Configuration](configuration.md) - Config file setup and input pre-population
 - [Workflow Syntax](workflow-syntax.md) - Input definitions and validation
 - [Input Validation Reference](../reference/validation.md) - Validation rules reference

--- a/internal/interfaces/cli/run.go
+++ b/internal/interfaces/cli/run.go
@@ -444,6 +444,15 @@ func runDryRun(cmd *cobra.Command, cfg *Config, workflowName string, inputFlags 
 	resolver := interpolation.NewTemplateResolver()
 	exprEvaluator := infraexpression.NewExprEvaluator()
 
+	// Load project config from .awf/config.yaml
+	projectCfg, err := loadProjectConfig(logger)
+	if err != nil {
+		return fmt.Errorf("config error: %w", err)
+	}
+
+	// Merge config inputs with CLI inputs (CLI wins)
+	inputs = mergeInputs(projectCfg.Inputs, inputs)
+
 	// Create services
 	exprValidator := infraexpression.NewExprValidator()
 	wfSvc := application.NewWorkflowService(repo, stateStore, shellExecutor, logger, exprValidator)
@@ -513,6 +522,15 @@ func runInteractive(cmd *cobra.Command, cfg *Config, workflowName string, inputF
 	}
 	resolver := interpolation.NewTemplateResolver()
 	exprEvaluator := infraexpression.NewExprEvaluator()
+
+	// Load project config from .awf/config.yaml
+	projectCfg, err := loadProjectConfig(logger)
+	if err != nil {
+		return fmt.Errorf("config error: %w", err)
+	}
+
+	// Merge config inputs with CLI inputs (CLI wins)
+	inputs = mergeInputs(projectCfg.Inputs, inputs)
 
 	// Create services
 	exprValidator := infraexpression.NewExprValidator()
@@ -1027,38 +1045,17 @@ func ParseMockFlags(flags []string) (map[string]string, error) {
 }
 
 // loadProjectConfig loads the project configuration from .awf/config.yaml.
-// Returns empty config if file doesn't exist (not an error).
-// Returns error for invalid YAML or file read errors.
-//
-// The logger is used to emit warnings for unknown config keys.
-func loadProjectConfig(logger ports.Logger) (*config.ProjectConfig, error) {
-	_ = logger // Reserved for future warning logging (unknown keys)
-
+// Returns empty config if the file doesn't exist.
+func loadProjectConfig(_ ports.Logger) (*config.ProjectConfig, error) {
 	configPath := xdg.LocalConfigPath()
-	loader := config.NewYAMLConfigLoader(configPath)
-
-	return loader.Load()
+	return config.NewYAMLConfigLoader(configPath).Load()
 }
 
-// hasMissingRequiredInputs checks if workflow has any required inputs that are not
-// present in the provided inputs map.
-//
-// This helper is used to determine if interactive input collection is needed.
-//
-// Parameters:
-//   - wf: Workflow definition
-//   - inputs: Input values already provided
-//
-// Returns:
-//   - true if any required input is missing
-//   - false if all required inputs are present
+// hasMissingRequiredInputs reports whether any required workflow input is absent from inputs.
 func hasMissingRequiredInputs(wf *workflow.Workflow, inputs map[string]any) bool {
-	// Handle nil workflow or inputs
-	if wf == nil || wf.Inputs == nil {
+	if wf == nil {
 		return false
 	}
-
-	// Check each required input
 	for _, input := range wf.Inputs {
 		if input.Required {
 			if _, exists := inputs[input.Name]; !exists {
@@ -1066,26 +1063,14 @@ func hasMissingRequiredInputs(wf *workflow.Workflow, inputs map[string]any) bool
 			}
 		}
 	}
-
 	return false
 }
 
-// mergeInputs merges config file inputs with CLI flag inputs.
-// CLI inputs take precedence over config inputs (CLI always wins).
-// Returns a new map containing all merged inputs.
-//
-// Merge priority (highest wins):
-//
-//	CLI flags (--input key=value) > Config file (.awf/config.yaml)
+// mergeInputs returns configInputs merged with cliInputs. CLI wins on conflict.
 func mergeInputs(configInputs, cliInputs map[string]any) map[string]any {
 	result := make(map[string]any)
-
-	// Copy config inputs first (lower priority)
 	maps.Copy(result, configInputs)
-
-	// Apply CLI inputs (higher priority, overwrites config)
 	maps.Copy(result, cliInputs)
-
 	return result
 }
 

--- a/internal/interfaces/cli/run_dry_run_config_test.go
+++ b/internal/interfaces/cli/run_dry_run_config_test.go
@@ -1,0 +1,203 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awf-project/cli/internal/interfaces/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeConfigFile(t *testing.T, tmpDir string, inputs map[string]string) string {
+	t.Helper()
+	awfDir := filepath.Join(tmpDir, ".awf")
+	require.NoError(t, os.MkdirAll(awfDir, 0o755))
+
+	var sb strings.Builder
+	sb.WriteString("inputs:\n")
+	for k, v := range inputs {
+		sb.WriteString("  " + k + ": \"" + v + "\"\n")
+	}
+	configPath := filepath.Join(awfDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(sb.String()), 0o644))
+	return configPath
+}
+
+// dryRunWorkflow is a minimal workflow with two required inputs.
+const dryRunWorkflow = `name: dry-run-config-test
+description: Test config input merging in dry-run
+inputs:
+  - name: api_key
+    type: string
+    required: true
+    description: API key
+  - name: model
+    type: string
+    required: true
+    description: Model name
+states:
+  initial: run
+  run:
+    type: step
+    command: echo "{{.inputs.api_key}} {{.inputs.model}}"
+    on_success: done
+  done:
+    type: terminal
+    status: success
+`
+
+// TestRunDryRun_ConfigInputsPreFillPlan verifies that inputs from config.yaml appear
+// in the dry-run plan when not supplied via CLI.
+func TestRunDryRun_ConfigInputsPreFillPlan(t *testing.T) {
+	tmpDir := setupTestDir(t)
+
+	configPath := writeConfigFile(t, tmpDir, map[string]string{
+		"api_key": "sk-from-config",
+	})
+	t.Setenv("AWF_CONFIG_PATH", configPath)
+	createTestWorkflow(t, tmpDir, "dry-run-config-test.yaml", dryRunWorkflow)
+
+	cmd := cli.NewRootCommand()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{
+		"--storage=" + tmpDir,
+		"run", "dry-run-config-test",
+		"--dry-run",
+		"--input", "model=gpt-4",
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "dry-run should succeed when api_key is provided by config.yaml")
+
+	output := buf.String()
+	assert.Contains(t, output, "sk-from-config", "dry-run plan must include api_key value from config.yaml")
+	assert.Contains(t, output, "gpt-4", "dry-run plan must include model value from CLI --input")
+}
+
+// TestRunDryRun_CLIInputsOverrideConfig verifies that CLI --input values take precedence
+// over config.yaml values when the same key is provided in both.
+func TestRunDryRun_CLIInputsOverrideConfig(t *testing.T) {
+	tmpDir := setupTestDir(t)
+
+	configPath := writeConfigFile(t, tmpDir, map[string]string{
+		"api_key": "sk-config",
+		"model":   "gpt-config",
+	})
+	t.Setenv("AWF_CONFIG_PATH", configPath)
+	createTestWorkflow(t, tmpDir, "dry-run-config-test.yaml", dryRunWorkflow)
+
+	cmd := cli.NewRootCommand()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{
+		"--storage=" + tmpDir,
+		"run", "dry-run-config-test",
+		"--dry-run",
+		"--input", "api_key=sk-cli",
+		"--input", "model=gpt-cli",
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "dry-run should succeed")
+
+	output := buf.String()
+	assert.Contains(t, output, "sk-cli", "CLI api_key must override config.yaml value")
+	assert.Contains(t, output, "gpt-cli", "CLI model must override config.yaml value")
+	assert.NotContains(t, output, "sk-config", "config api_key must not appear when CLI overrides it")
+	assert.NotContains(t, output, "gpt-config", "config model must not appear when CLI overrides it")
+}
+
+// TestRunDryRun_BothInputsFromConfig verifies that when all required inputs are supplied
+// by config.yaml, dry-run succeeds without any --input flags.
+func TestRunDryRun_BothInputsFromConfig(t *testing.T) {
+	tmpDir := setupTestDir(t)
+
+	configPath := writeConfigFile(t, tmpDir, map[string]string{
+		"api_key": "sk-test",
+		"model":   "gpt-4",
+	})
+	t.Setenv("AWF_CONFIG_PATH", configPath)
+	createTestWorkflow(t, tmpDir, "dry-run-config-test.yaml", dryRunWorkflow)
+
+	cmd := cli.NewRootCommand()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{
+		"--storage=" + tmpDir,
+		"run", "dry-run-config-test",
+		"--dry-run",
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "dry-run should succeed when all inputs are provided by config.yaml")
+
+	output := buf.String()
+	assert.Contains(t, output, "sk-test", "api_key from config.yaml must appear in dry-run plan")
+	assert.Contains(t, output, "gpt-4", "model from config.yaml must appear in dry-run plan")
+}
+
+// TestRunDryRun_NoConfigFile_NormalDryRun verifies that dry-run works normally when no
+// config.yaml exists and all inputs are provided via --input flags (no regression).
+func TestRunDryRun_NoConfigFile_NormalDryRun(t *testing.T) {
+	tmpDir := setupTestDir(t)
+
+	// Point to a config path that does not exist (triggers "file not found" path → empty config)
+	t.Setenv("AWF_CONFIG_PATH", filepath.Join(tmpDir, ".awf", "config.yaml"))
+	createTestWorkflow(t, tmpDir, "dry-run-config-test.yaml", dryRunWorkflow)
+
+	cmd := cli.NewRootCommand()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{
+		"--storage=" + tmpDir,
+		"run", "dry-run-config-test",
+		"--dry-run",
+		"--input", "api_key=sk-cli",
+		"--input", "model=gpt-4",
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "dry-run should succeed when no config.yaml exists but all inputs are via --input")
+
+	output := buf.String()
+	assert.Contains(t, output, "sk-cli", "api_key from --input must appear in dry-run plan")
+	assert.Contains(t, output, "gpt-4", "model from --input must appear in dry-run plan")
+}
+
+// TestRunDryRun_InvalidConfig_ReturnsConfigError verifies that a malformed config.yaml
+// causes dry-run to fail with a "config error:" prefix.
+func TestRunDryRun_InvalidConfig_ReturnsConfigError(t *testing.T) {
+	tmpDir := setupTestDir(t)
+
+	awfDir := filepath.Join(tmpDir, ".awf")
+	require.NoError(t, os.MkdirAll(awfDir, 0o755))
+	configPath := filepath.Join(awfDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("inputs: [\ninvalid yaml:::\n"), 0o644))
+	t.Setenv("AWF_CONFIG_PATH", configPath)
+	createTestWorkflow(t, tmpDir, "dry-run-config-test.yaml", dryRunWorkflow)
+
+	cmd := cli.NewRootCommand()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{
+		"--storage=" + tmpDir,
+		"run", "dry-run-config-test",
+		"--dry-run",
+		"--input", "api_key=sk-cli",
+		"--input", "model=gpt-4",
+	})
+
+	err := cmd.Execute()
+	require.Error(t, err, "dry-run should fail with invalid config.yaml")
+	assert.Contains(t, err.Error(), "config error", "error should be prefixed with 'config error'")
+}

--- a/internal/interfaces/cli/run_interactive_config_test.go
+++ b/internal/interfaces/cli/run_interactive_config_test.go
@@ -1,0 +1,208 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awf-project/cli/internal/interfaces/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// interactiveConfigWorkflow is a minimal workflow with two required inputs.
+// The echo step outputs key=value pairs so tests can assert which values were used.
+const interactiveConfigWorkflow = `name: interactive-config-test
+description: Test config input merging in interactive mode
+inputs:
+  - name: api_key
+    type: string
+    required: true
+    description: API key
+  - name: model
+    type: string
+    required: true
+    description: Model name
+states:
+  initial: run
+  run:
+    type: step
+    command: echo "api_key={{inputs.api_key}} model={{inputs.model}}"
+    on_success: done
+  done:
+    type: terminal
+    status: success
+`
+
+// TestRunInteractive_ConfigInputsPreFillExecution verifies that an input pre-filled in
+// config.yaml is not prompted for and its value is used during interactive execution.
+func TestRunInteractive_ConfigInputsPreFillExecution(t *testing.T) {
+	tmpDir := setupTestDir(t)
+
+	configPath := writeConfigFile(t, tmpDir, map[string]string{
+		"api_key": "sk-from-config",
+	})
+	t.Setenv("AWF_CONFIG_PATH", configPath)
+	createTestWorkflow(t, tmpDir, "interactive-config-test.yaml", interactiveConfigWorkflow)
+
+	// "c\n" continues through the interactive step; model is provided via --input.
+	// api_key must come from config.yaml without prompting.
+	stdin := strings.NewReader("c\n")
+
+	cmd := cli.NewRootCommand()
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetIn(stdin)
+	cmd.SetArgs([]string{
+		"--storage=" + tmpDir,
+		"run", "interactive-config-test",
+		"--interactive",
+		"--input", "model=gpt-4",
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "interactive run should succeed when api_key is pre-filled by config.yaml")
+
+	output := stdout.String()
+	assert.Contains(t, output, "sk-from-config", "api_key value from config.yaml must appear in output")
+	assert.Contains(t, output, "gpt-4", "model value from --input must appear in output")
+}
+
+// TestRunInteractive_CLIInputsOverrideConfig verifies that CLI --input values take
+// precedence over config.yaml values when the same key appears in both.
+func TestRunInteractive_CLIInputsOverrideConfig(t *testing.T) {
+	tmpDir := setupTestDir(t)
+
+	configPath := writeConfigFile(t, tmpDir, map[string]string{
+		"api_key": "sk-config",
+		"model":   "gpt-config",
+	})
+	t.Setenv("AWF_CONFIG_PATH", configPath)
+	createTestWorkflow(t, tmpDir, "interactive-config-test.yaml", interactiveConfigWorkflow)
+
+	stdin := strings.NewReader("c\n")
+
+	cmd := cli.NewRootCommand()
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetIn(stdin)
+	cmd.SetArgs([]string{
+		"--storage=" + tmpDir,
+		"run", "interactive-config-test",
+		"--interactive",
+		"--input", "api_key=sk-cli",
+		"--input", "model=gpt-cli",
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "interactive run should succeed")
+
+	output := stdout.String()
+	assert.Contains(t, output, "sk-cli", "CLI api_key must override config.yaml value")
+	assert.Contains(t, output, "gpt-cli", "CLI model must override config.yaml value")
+	assert.NotContains(t, output, "sk-config", "config api_key must not appear when CLI overrides it")
+	assert.NotContains(t, output, "gpt-config", "config model must not appear when CLI overrides it")
+}
+
+// TestRunInteractive_BothInputsFromConfig verifies that when all required inputs are
+// supplied by config.yaml, interactive mode runs without any --input flags or prompts.
+func TestRunInteractive_BothInputsFromConfig(t *testing.T) {
+	tmpDir := setupTestDir(t)
+
+	configPath := writeConfigFile(t, tmpDir, map[string]string{
+		"api_key": "sk-test",
+		"model":   "gpt-4",
+	})
+	t.Setenv("AWF_CONFIG_PATH", configPath)
+	createTestWorkflow(t, tmpDir, "interactive-config-test.yaml", interactiveConfigWorkflow)
+
+	stdin := strings.NewReader("c\n")
+
+	cmd := cli.NewRootCommand()
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetIn(stdin)
+	cmd.SetArgs([]string{
+		"--storage=" + tmpDir,
+		"run", "interactive-config-test",
+		"--interactive",
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "interactive run should succeed when all inputs are provided by config.yaml")
+
+	output := stdout.String()
+	assert.Contains(t, output, "sk-test", "api_key from config.yaml must appear in output")
+	assert.Contains(t, output, "gpt-4", "model from config.yaml must appear in output")
+}
+
+// TestRunInteractive_NoConfigFile_NoRegression verifies that interactive mode works
+// normally when no config.yaml exists and all inputs are provided via --input flags.
+func TestRunInteractive_NoConfigFile_NoRegression(t *testing.T) {
+	tmpDir := setupTestDir(t)
+
+	// Point to a config path that does not exist → loadProjectConfig returns empty config
+	t.Setenv("AWF_CONFIG_PATH", filepath.Join(tmpDir, ".awf", "config.yaml"))
+	createTestWorkflow(t, tmpDir, "interactive-config-test.yaml", interactiveConfigWorkflow)
+
+	stdin := strings.NewReader("c\n")
+
+	cmd := cli.NewRootCommand()
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetIn(stdin)
+	cmd.SetArgs([]string{
+		"--storage=" + tmpDir,
+		"run", "interactive-config-test",
+		"--interactive",
+		"--input", "api_key=sk-cli",
+		"--input", "model=gpt-4",
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "interactive run should succeed when no config.yaml but all inputs via --input")
+
+	output := stdout.String()
+	assert.Contains(t, output, "sk-cli", "api_key from --input must appear in output")
+	assert.Contains(t, output, "gpt-4", "model from --input must appear in output")
+}
+
+// TestRunInteractive_InvalidConfig_ReturnsConfigError verifies that a malformed
+// config.yaml causes interactive mode to fail with a "config error:" prefix.
+func TestRunInteractive_InvalidConfig_ReturnsConfigError(t *testing.T) {
+	tmpDir := setupTestDir(t)
+
+	awfDir := filepath.Join(tmpDir, ".awf")
+	require.NoError(t, os.MkdirAll(awfDir, 0o755))
+	configPath := filepath.Join(awfDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("inputs: [\ninvalid yaml:::\n"), 0o644))
+	t.Setenv("AWF_CONFIG_PATH", configPath)
+	createTestWorkflow(t, tmpDir, "interactive-config-test.yaml", interactiveConfigWorkflow)
+
+	cmd := cli.NewRootCommand()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetIn(strings.NewReader(""))
+	cmd.SetArgs([]string{
+		"--storage=" + tmpDir,
+		"run", "interactive-config-test",
+		"--interactive",
+		"--input", "api_key=sk-cli",
+		"--input", "model=gpt-4",
+	})
+
+	err := cmd.Execute()
+	require.Error(t, err, "interactive run should fail with invalid config.yaml")
+	assert.Contains(t, err.Error(), "config error", "error must be prefixed with 'config error'")
+}

--- a/tests/fixtures/workflows/config-interactive-test.yaml
+++ b/tests/fixtures/workflows/config-interactive-test.yaml
@@ -1,0 +1,33 @@
+name: config-interactive-test
+description: Test workflow for config.yaml input pre-filling with interactive and dry-run modes
+
+inputs:
+  - name: api_key
+    type: string
+    required: true
+    description: API key required for the workflow
+
+  - name: model
+    type: string
+    required: true
+    description: Model name required for the workflow
+
+states:
+  initial: echo_inputs
+
+  echo_inputs:
+    type: step
+    description: Echo both required inputs
+    command: echo "api_key={{.inputs.api_key}} model={{.inputs.model}}"
+    on_success: done
+    on_failure: error
+
+  done:
+    type: terminal
+    status: success
+    message: "Workflow completed"
+
+  error:
+    type: terminal
+    status: failure
+    message: "Workflow failed"

--- a/tests/integration/features/b007_config_interactive_test.go
+++ b/tests/integration/features/b007_config_interactive_test.go
@@ -1,0 +1,247 @@
+//go:build integration
+
+// Bug: B007
+package features_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awf-project/cli/internal/interfaces/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ╔══════════════════════════════════════════════════════════════════════════╗
+// ║ B007: Interactive Input Prompt Ignores config.yaml Values                ║
+// ╠══════════════════════════════════════════════════════════════════════════╣
+// ║ Tests verify that config.yaml inputs are merged before interactive and   ║
+// ║ dry-run execution, so pre-configured values are not prompted again.      ║
+// ║   - US1: Config inputs pre-fill interactive mode (--interactive)         ║
+// ║   - US2: Config inputs pre-fill dry-run mode (--dry-run)                 ║
+// ╚══════════════════════════════════════════════════════════════════════════╝
+
+// setupB007Env creates a tmpDir with .awf/ and returns the absolute path to
+// the fixture workflows directory. Must be called before os.Chdir so the
+// relative fixture path resolves correctly.
+func setupB007Env(t *testing.T) (tmpDir, fixturesDir string) {
+	t.Helper()
+
+	// Resolve fixture path before any chdir
+	abs, err := filepath.Abs("../../fixtures/workflows")
+	require.NoError(t, err)
+	fixturesDir = abs
+
+	tmpDir = t.TempDir()
+	awfDir := filepath.Join(tmpDir, ".awf")
+	require.NoError(t, os.MkdirAll(awfDir, 0o755))
+	return tmpDir, fixturesDir
+}
+
+func writeB007Config(t *testing.T, tmpDir string, inputs map[string]string) {
+	t.Helper()
+	var sb strings.Builder
+	sb.WriteString("inputs:\n")
+	for k, v := range inputs {
+		sb.WriteString("  " + k + ": \"" + v + "\"\n")
+	}
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpDir, ".awf", "config.yaml"),
+		[]byte(sb.String()),
+		0o644,
+	))
+}
+
+// US1-AC1: Config pre-fills api_key; interactive mode should not prompt for it.
+//
+// Given: config.yaml has api_key pre-filled
+// When: awf run --interactive without --input api_key
+// Then: workflow echoes api_key from config (not empty)
+func TestB007_ConfigPrefillsInteractiveMode_Integration(t *testing.T) {
+	tmpDir, fixturesDir := setupB007Env(t)
+	writeB007Config(t, tmpDir, map[string]string{"api_key": "sk-test"})
+
+	originalDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer os.Chdir(originalDir)
+
+	t.Setenv("AWF_WORKFLOWS_PATH", fixturesDir)
+
+	// Only model provided via CLI; api_key should come from config.
+	// "c\n" continues through the single echo step.
+	stdin := strings.NewReader("c\n")
+
+	cmd := cli.NewRootCommand()
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetIn(stdin)
+	cmd.SetArgs([]string{
+		"run", "config-interactive-test",
+		"--interactive",
+		"--input", "model=gpt-4",
+		"--storage", tmpDir,
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "workflow should complete when api_key is pre-filled by config")
+
+	output := stdout.String()
+	assert.Contains(t, output, "api_key=sk-test", "api_key should be pre-filled from config.yaml")
+	assert.Contains(t, output, "model=gpt-4", "model should come from --input flag")
+}
+
+// US1-AC2: CLI flag overrides config value in interactive mode.
+//
+// Given: config.yaml has api_key=sk-config
+// When: awf run --interactive --input api_key=sk-cli
+// Then: api_key=sk-cli (CLI wins over config)
+func TestB007_CLIOverridesConfigInInteractiveMode_Integration(t *testing.T) {
+	tmpDir, fixturesDir := setupB007Env(t)
+	writeB007Config(t, tmpDir, map[string]string{"api_key": "sk-config"})
+
+	originalDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer os.Chdir(originalDir)
+
+	t.Setenv("AWF_WORKFLOWS_PATH", fixturesDir)
+
+	stdin := strings.NewReader("c\n")
+
+	cmd := cli.NewRootCommand()
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetIn(stdin)
+	cmd.SetArgs([]string{
+		"run", "config-interactive-test",
+		"--interactive",
+		"--input", "api_key=sk-cli",
+		"--input", "model=gpt-4",
+		"--storage", tmpDir,
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "workflow should complete with CLI override")
+
+	output := stdout.String()
+	assert.Contains(t, output, "api_key=sk-cli", "CLI --input should override config.yaml value")
+	assert.NotContains(t, output, "sk-config", "config value must not appear when CLI overrides it")
+}
+
+// US1-AC3: Both inputs from config; interactive mode needs only step confirmations.
+//
+// Given: config.yaml has both api_key and model
+// When: awf run --interactive with no --input flags
+// Then: workflow echoes both values from config
+func TestB007_BothInputsFromConfig_Interactive_Integration(t *testing.T) {
+	tmpDir, fixturesDir := setupB007Env(t)
+	writeB007Config(t, tmpDir, map[string]string{
+		"api_key": "sk-test",
+		"model":   "gpt-4",
+	})
+
+	originalDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer os.Chdir(originalDir)
+
+	t.Setenv("AWF_WORKFLOWS_PATH", fixturesDir)
+
+	stdin := strings.NewReader("c\n")
+
+	cmd := cli.NewRootCommand()
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetIn(stdin)
+	cmd.SetArgs([]string{
+		"run", "config-interactive-test",
+		"--interactive",
+		"--storage", tmpDir,
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "workflow should complete when both inputs are in config")
+
+	output := stdout.String()
+	assert.Contains(t, output, "api_key=sk-test", "api_key should come from config")
+	assert.Contains(t, output, "model=gpt-4", "model should come from config")
+}
+
+// US2-AC1: Config pre-fills api_key in dry-run; plan should show config value.
+//
+// Given: config.yaml has api_key pre-filled
+// When: awf run --dry-run without --input api_key
+// Then: dry-run plan shows api_key from config
+func TestB007_ConfigPrefillsDryRun_Integration(t *testing.T) {
+	tmpDir, fixturesDir := setupB007Env(t)
+	writeB007Config(t, tmpDir, map[string]string{"api_key": "sk-test"})
+
+	originalDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer os.Chdir(originalDir)
+
+	t.Setenv("AWF_WORKFLOWS_PATH", fixturesDir)
+
+	cmd := cli.NewRootCommand()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{
+		"run", "config-interactive-test",
+		"--dry-run",
+		"--input", "model=gpt-4",
+		"--storage", tmpDir,
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "dry-run should succeed when api_key is pre-filled by config")
+
+	output := buf.String()
+	assert.Contains(t, output, "sk-test", "dry-run plan should include api_key value from config.yaml")
+}
+
+// US2-AC2: No config file; all inputs via CLI (no regression).
+//
+// Given: no config.yaml exists
+// When: awf run --interactive with both inputs via --input flags
+// Then: workflow runs normally using CLI values
+func TestB007_NoConfigAllInputsViaCLI_NoRegression_Integration(t *testing.T) {
+	tmpDir, fixturesDir := setupB007Env(t)
+	// No .awf/config.yaml written
+
+	originalDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer os.Chdir(originalDir)
+
+	t.Setenv("AWF_WORKFLOWS_PATH", fixturesDir)
+
+	stdin := strings.NewReader("c\n")
+
+	cmd := cli.NewRootCommand()
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetIn(stdin)
+	cmd.SetArgs([]string{
+		"run", "config-interactive-test",
+		"--interactive",
+		"--input", "api_key=sk-test",
+		"--input", "model=gpt-4",
+		"--storage", tmpDir,
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "workflow should work without config.yaml when all inputs provided via CLI")
+
+	output := stdout.String()
+	assert.Contains(t, output, "api_key=sk-test", "api_key from --input should be used")
+	assert.Contains(t, output, "model=gpt-4", "model from --input should be used")
+}


### PR DESCRIPTION
## Summary

- `runInteractive()` and `runDryRun()` were ignoring `.awf/config.yaml` input defaults, always prompting for all required inputs regardless of pre-configured values — this fix applies the same `loadProjectConfig()` + `mergeInputs()` pattern already used in `runWorkflow()`
- Config-sourced values now pre-fill inputs in both interactive and dry-run modes, so only genuinely missing inputs are prompted; CLI flags still win over config values
- Integration and unit test suites added to lock in the correct behavior and prevent regression across all three execution modes

## Changes

### Fix
- `internal/interfaces/cli/run.go`: Call `loadProjectConfig()` and `mergeInputs()` in `runInteractive()` and `runDryRun()` before input collection/display; mirrors existing pattern in `runWorkflow()`

### Tests
- `internal/interfaces/cli/run_dry_run_config_test.go`: Unit tests for config pre-fill, CLI override, and no-config regression in dry-run mode
- `internal/interfaces/cli/run_interactive_config_test.go`: Unit tests for config pre-fill, CLI override, and no-config regression in interactive mode
- `tests/fixtures/workflows/config-interactive-test.yaml`: Workflow fixture with multiple typed inputs used across test scenarios
- `tests/integration/features/b007_config_interactive_test.go`: Integration tests covering config pre-fill, CLI override, dry-run, and no-config scenarios end-to-end

### Documentation
- `docs/user-guide/configuration.md`: Document that input pre-population applies to `--interactive` and `--dry-run` modes; add mode-specific examples
- `docs/user-guide/interactive-inputs.md`: Add "Configuration File Integration" section explaining merge order and prompting behavior
- `CHANGELOG.md`: Record B007 fix in unreleased and version sections

### Housekeeping
- `CLAUDE.md`: Reformat multi-paragraph bullet lists to use proper list syntax (no content change)

## Test plan

- [ ] `go test ./internal/interfaces/cli/... -run TestDryRunConfig` passes
- [ ] `go test ./internal/interfaces/cli/... -run TestInteractiveConfig` passes
- [ ] `go test ./tests/integration/... -run TestB007` passes
- [ ] Run `awf run <workflow> --dry-run` in a project with `.awf/config.yaml` and verify config values appear in the plan without prompting

Closes #243

---
Generated with [awf](https://github.com/Pмузlcky/awf) commit workflow

