### PR TITLE
feat(init): add scripts directory to awf init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **C060**: `awf init` now creates `.awf/scripts/` directory with `example.sh`
+  - Local init creates `.awf/scripts/` with `0o755` permissions and an executable `example.sh` demonstrating shebang-based execution
+  - Global init (`--global`) creates `$XDG_CONFIG_HOME/awf/scripts/` alongside the existing prompts directory
+  - `--force` flag overwrites existing example script
+  - Handles partial initialization: creates scripts directory even if prompts already exists
+  - Completes AWF directory convention symmetry with `.awf/workflows/`, `.awf/prompts/`, and `.awf/scripts/`
+
 ### Breaking Changes
 
 - **F070**: Replaced `custom` agent provider with `openai_compatible` provider

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,8 @@ All port interface methods performing blocking operations must accept context.Co
 
 When documenting code duplication across layers in comments, include explicit file path cross-references to prevent maintenance divergence (e.g., `// Note: Parallel definitions in pkg/interpolation/reference.go`)
 
+In global init, create each directory resource independently; never early-exit when one resource already exists (enables recovery from partial initialization failures)
+
 ## Common Pitfalls
 
 - Preserve existing infrastructure layers when adding domain registries; ADR-004 enforces infrastructure plugin registry coexistence for separate lifecycle concerns
@@ -265,6 +267,12 @@ When documenting code duplication across layers in comments, include explicit fi
 Never block on I/O without context support; use goroutine+channel+select with buffered channel (cap 1) to enable graceful cancellation
 
 Always wrap context.Canceled with fmt.Errorf(msg, %w); callers must use errors.Is(err, context.Canceled) for detection instead of type assertion
+
+Extract a generic helper only after 3 similar concrete implementations exist; prefer duplication below that threshold to avoid premature abstraction
+
+Use 0o755 for executable scripts, 0o644 for data files, 0o700 for private temp files; match permissions to file purpose and access expectations
+
+When adding new scaffolded directories to init, replicate existing implementation patterns (e.g., createExampleScript mirrors createExamplePrompt) for consistency
 
 ## Test Conventions
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -18,8 +18,10 @@ This creates the following structure:
 ├── config.yaml        # Project configuration with input templates
 ├── workflows/
 │   └── example.yaml   # Sample workflow
-└── prompts/
-    └── example.md     # Sample prompt template
+├── prompts/
+│   └── example.md     # Sample prompt template
+└── scripts/
+    └── example.sh     # Sample script file
 ```
 
 ## 2. Run the Example Workflow

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -5,7 +5,7 @@
 | Command | Description |
 |---------|-------------|
 | `awf init` | Initialize AWF in current directory |
-| `awf init --global` | Initialize global prompts directory |
+| `awf init --global` | Initialize global prompts and scripts directories |
 | `awf run <workflow>` | Execute a workflow |
 | `awf resume [workflow-id]` | Resume an interrupted workflow |
 | `awf list` | List available workflows |
@@ -60,7 +60,7 @@ awf status $WORKFLOW_ID -f quiet
 
 ## awf init
 
-Initialize AWF in the current directory or global prompts directory.
+Initialize AWF in the current directory or global prompts and scripts directories.
 
 ```bash
 awf init [flags]
@@ -71,7 +71,7 @@ awf init [flags]
 | Flag | Description |
 |------|-------------|
 | `--force` | Overwrite existing configuration files |
-| `--global` | Initialize global prompts directory at `$XDG_CONFIG_HOME/awf/prompts/` |
+| `--global` | Initialize global prompts and scripts directories at `$XDG_CONFIG_HOME/awf/` |
 
 ### Examples
 
@@ -96,6 +96,8 @@ awf init --global
 │   └── example.yaml   # Sample workflow
 ├── prompts/
 │   └── example.md     # Example prompt file
+├── scripts/
+│   └── example.sh     # Example script file (executable)
 ├── templates/         # Reusable workflow templates
 └── storage/
     ├── states/        # State persistence
@@ -108,8 +110,10 @@ See [Project Configuration](configuration.md) for details on `.awf/config.yaml`.
 
 ```
 $XDG_CONFIG_HOME/awf/
-└── prompts/
-    └── example.md     # Example prompt file
+├── prompts/
+│   └── example.md     # Example prompt file
+└── scripts/
+    └── example.sh     # Example script file (executable)
 ```
 
 ---

--- a/internal/interfaces/cli/init.go
+++ b/internal/interfaces/cli/init.go
@@ -14,10 +14,12 @@ const (
 	awfDir            = ".awf"
 	workflowsDir      = "workflows"
 	promptsDir        = "prompts"
+	scriptsDir        = "scripts"
 	configFileName    = ".awf.yaml"
 	projectConfigFile = "config.yaml"
 	exampleFile       = "example.yaml"
 	examplePromptFile = "example.md"
+	exampleScriptFile = "example.sh"
 )
 
 func newInitCommand(cfg *Config) *cobra.Command {
@@ -36,6 +38,8 @@ This creates:
   .awf/workflows/example.yaml  Example workflow file
   .awf/prompts/                Prompt templates directory
   .awf/prompts/example.md      Example prompt file
+  .awf/scripts/                Shell scripts directory
+  .awf/scripts/example.sh      Example script with shebang
 
 State persistence uses XDG directories ($XDG_DATA_HOME/awf/ or ~/.local/share/awf/).
 
@@ -55,7 +59,7 @@ Examples:
 	}
 
 	cmd.Flags().BoolVar(&force, "force", false, "Overwrite existing configuration")
-	cmd.Flags().BoolVar(&global, "global", false, "Initialize global prompts directory")
+	cmd.Flags().BoolVar(&global, "global", false, "Initialize global prompts and scripts directories")
 
 	return cmd
 }
@@ -83,6 +87,7 @@ func runInit(cmd *cobra.Command, cfg *Config, force bool) error {
 	dirs := []string{
 		filepath.Join(awfPath, workflowsDir),
 		filepath.Join(awfPath, promptsDir),
+		filepath.Join(awfPath, scriptsDir),
 	}
 
 	for _, dir := range dirs {
@@ -120,6 +125,13 @@ func runInit(cmd *cobra.Command, cfg *Config, force bool) error {
 	}
 	formatter.Success(fmt.Sprintf("Created %s", promptPath))
 
+	// Create example script
+	scriptPath := filepath.Join(awfPath, scriptsDir, exampleScriptFile)
+	if err := createExampleScript(scriptPath, force); err != nil {
+		return err
+	}
+	formatter.Success(fmt.Sprintf("Created %s", scriptPath))
+
 	// Next steps
 	formatter.Info("\nNext steps:")
 	formatter.Info("  awf list          - List available workflows")
@@ -137,40 +149,59 @@ func runInitGlobal(cmd *cobra.Command, cfg *Config, force bool) error {
 	})
 
 	globalPromptsDir := xdg.AWFPromptsDir()
+	globalScriptsDir := xdg.AWFScriptsDir()
 
-	// Check if already initialized
-	if !force {
-		if _, err := os.Stat(globalPromptsDir); err == nil {
-			formatter.Info(fmt.Sprintf("Global prompts already initialized in '%s'", globalPromptsDir))
-			formatter.Info("Use --force to reinitialize")
-			return nil
+	_, err := os.Stat(globalPromptsDir)
+	if !force && err == nil {
+		formatter.Info(fmt.Sprintf("Global prompts already initialized in '%s'", globalPromptsDir))
+		formatter.Info("Use --force to reinitialize")
+	} else {
+		// Create global prompts directory
+		if err := os.MkdirAll(globalPromptsDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", globalPromptsDir, err)
 		}
+		formatter.Success(fmt.Sprintf("Created %s", globalPromptsDir))
+
+		// Create example prompt
+		promptPath := filepath.Join(globalPromptsDir, examplePromptFile)
+		if err := createExamplePrompt(promptPath, force); err != nil {
+			return err
+		}
+		formatter.Success(fmt.Sprintf("Created %s", promptPath))
 	}
 
-	// Create global prompts directory
-	if err := os.MkdirAll(globalPromptsDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", globalPromptsDir, err)
+	// Create global scripts directory (independent of prompts state)
+	if err := os.MkdirAll(globalScriptsDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", globalScriptsDir, err)
 	}
-	formatter.Success(fmt.Sprintf("Created %s", globalPromptsDir))
+	formatter.Success(fmt.Sprintf("Created %s", globalScriptsDir))
 
-	// Create example prompt
-	promptPath := filepath.Join(globalPromptsDir, examplePromptFile)
-	if err := createExamplePrompt(promptPath, force); err != nil {
+	// Create example script
+	scriptPath := filepath.Join(globalScriptsDir, exampleScriptFile)
+	if err := createExampleScript(scriptPath, force); err != nil {
 		return err
 	}
-	formatter.Success(fmt.Sprintf("Created %s", promptPath))
+	formatter.Success(fmt.Sprintf("Created %s", scriptPath))
 
 	return nil
 }
 
-func createConfigFile(path string, force bool) error {
+// writeFileUnlessExists writes content to path with the given permissions.
+// If force is false and the file already exists, it skips silently.
+func writeFileUnlessExists(path string, force bool, content string, perm os.FileMode) error {
 	if !force {
 		if _, err := os.Stat(path); err == nil {
-			return nil // File exists, skip
+			return nil
 		}
 	}
+	if err := os.WriteFile(path, []byte(content), perm); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+	return nil
+}
 
-	content := `# AWF Configuration
+func createConfigFile(path string, force bool) error {
+	return writeFileUnlessExists(path, force, `# AWF Configuration
 # https://github.com/awf-project/cli
 
 version: "1"
@@ -180,21 +211,11 @@ log_level: info
 
 # Output format: text, json, table, quiet
 output_format: text
-`
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		return fmt.Errorf("write file: %w", err)
-	}
-	return nil
+`, 0o644)
 }
 
 func createExampleWorkflow(path string, force bool) error {
-	if !force {
-		if _, err := os.Stat(path); err == nil {
-			return nil // File exists, skip
-		}
-	}
-
-	content := `name: example
+	return writeFileUnlessExists(path, force, `name: example
 version: "1.0.0"
 description: Example workflow created by awf init
 
@@ -208,24 +229,11 @@ states:
 
   done:
     type: terminal
-`
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		return fmt.Errorf("write file: %w", err)
-	}
-	return nil
+`, 0o644)
 }
 
-// createProjectConfigFile creates the project configuration file at .awf/config.yaml
-// with a commented inputs: section as a template.
-// This file is used to pre-populate workflow inputs (FR-006).
 func createProjectConfigFile(path string, force bool) error {
-	if !force {
-		if _, err := os.Stat(path); err == nil {
-			return nil // File exists, skip
-		}
-	}
-
-	content := `# AWF Project Configuration
+	return writeFileUnlessExists(path, force, `# AWF Project Configuration
 # https://github.com/awf-project/cli
 #
 # This file provides default values for workflow inputs.
@@ -239,21 +247,27 @@ inputs:
   # project: my-project
   # environment: staging
   # debug: false
-`
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		return fmt.Errorf("write file: %w", err)
-	}
-	return nil
+`, 0o644)
+}
+
+func createExampleScript(path string, force bool) error {
+	return writeFileUnlessExists(path, force, `#!/usr/bin/env bash
+# Example script created by awf init
+# This script demonstrates the script_file feature (B009).
+# Reference it in a workflow step:
+#
+#   states:
+#     run_script:
+#       type: step
+#       script_file: "{{.awf.scripts_dir}}/example.sh"
+#       on_success: done
+
+echo "Hello from AWF script!"
+`, 0o755)
 }
 
 func createExamplePrompt(path string, force bool) error {
-	if !force {
-		if _, err := os.Stat(path); err == nil {
-			return nil // File exists, skip
-		}
-	}
-
-	content := `# Example Prompt
+	return writeFileUnlessExists(path, force, `# Example Prompt
 
 This is an example prompt file created by AWF.
 
@@ -261,24 +275,20 @@ This is an example prompt file created by AWF.
 
 Reference this prompt in workflow inputs using the @prompts/ prefix:
 
-` + "```" + `bash
+`+"```"+`bash
 awf run my-workflow --input prompt=@prompts/example.md
-` + "```" + `
+`+"```"+`
 
 ## Template Variables
 
 You can use template variables in your workflow commands:
 
-- ` + "`{{inputs.prompt}}`" + ` - The content of this file
+- `+"`{{inputs.prompt}}`"+` - The content of this file
 
 ## Tips
 
 - Store reusable AI prompts here (system prompts, task templates)
 - Use .md for markdown or .txt for plain text
 - Organize complex prompts in subdirectories (e.g., ai/agents/)
-`
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		return fmt.Errorf("write file: %w", err)
-	}
-	return nil
+`, 0o644)
 }

--- a/internal/interfaces/cli/init_test.go
+++ b/internal/interfaces/cli/init_test.go
@@ -1169,6 +1169,227 @@ func parseYAML(data []byte, v interface{}) error {
 	return yaml.Unmarshal(data, v)
 }
 
+// TestInitCommand_ScriptsDirectory tests that awf init creates .awf/scripts/ directory.
+func TestInitCommand_ScriptsDirectory(t *testing.T) {
+	t.Run("creates .awf/scripts directory", func(t *testing.T) {
+		tmpDir := setupInitTestDir(t)
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		scriptsDir := filepath.Join(tmpDir, ".awf", "scripts")
+		info, err := os.Stat(scriptsDir)
+		require.NoError(t, err, ".awf/scripts should be created")
+		assert.True(t, info.IsDir())
+	})
+
+	t.Run("creates example.sh in scripts directory", func(t *testing.T) {
+		tmpDir := setupInitTestDir(t)
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		scriptPath := filepath.Join(tmpDir, ".awf", "scripts", "example.sh")
+		_, err = os.Stat(scriptPath)
+		require.NoError(t, err, ".awf/scripts/example.sh should be created")
+
+		content, err := os.ReadFile(scriptPath)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "#!/usr/bin/env bash",
+			"example script must have shebang line")
+	})
+
+	t.Run("example.sh has executable permissions", func(t *testing.T) {
+		tmpDir := setupInitTestDir(t)
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		scriptPath := filepath.Join(tmpDir, ".awf", "scripts", "example.sh")
+		info, err := os.Stat(scriptPath)
+		require.NoError(t, err)
+
+		mode := info.Mode().Perm()
+		assert.True(t, mode&0o100 != 0, "example.sh must be executable by owner (0o755)")
+	})
+
+	t.Run("--force overwrites existing example.sh", func(t *testing.T) {
+		tmpDir := setupInitTestDir(t)
+
+		awfScriptsDir := filepath.Join(tmpDir, ".awf", "scripts")
+		require.NoError(t, os.MkdirAll(awfScriptsDir, 0o755))
+		oldContent := "# old script\n"
+		require.NoError(t, os.WriteFile(
+			filepath.Join(awfScriptsDir, "example.sh"),
+			[]byte(oldContent),
+			0o755,
+		))
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init", "--force"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(filepath.Join(awfScriptsDir, "example.sh"))
+		require.NoError(t, err)
+		assert.NotContains(t, string(content), "# old script",
+			"--force must overwrite existing example.sh")
+		assert.Contains(t, string(content), "#!/usr/bin/env bash",
+			"overwritten script must have shebang")
+	})
+
+	t.Run("help text mentions scripts directory", func(t *testing.T) {
+		cmd := cli.NewRootCommand()
+		initCmd, _, err := cmd.Find([]string{"init"})
+		require.NoError(t, err)
+
+		longDesc := initCmd.Long
+		assert.Contains(t, longDesc, ".awf/scripts/",
+			"help text should document .awf/scripts/ creation")
+	})
+}
+
+// TestInitCommand_GlobalFlag_ScriptsDirectory tests that awf init --global creates
+// the global scripts directory alongside the global prompts directory.
+func TestInitCommand_GlobalFlag_ScriptsDirectory(t *testing.T) {
+	t.Run("--global creates scripts directory in XDG_CONFIG_HOME", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init", "--global"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		globalScriptsDir := filepath.Join(tmpDir, "awf", "scripts")
+		info, statErr := os.Stat(globalScriptsDir)
+		require.NoError(t, statErr, "global scripts directory should be created at $XDG_CONFIG_HOME/awf/scripts")
+		assert.True(t, info.IsDir())
+	})
+
+	t.Run("--global creates example.sh in global scripts directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init", "--global"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		exampleScript := filepath.Join(tmpDir, "awf", "scripts", "example.sh")
+		_, statErr := os.Stat(exampleScript)
+		require.NoError(t, statErr, "example.sh should be created in global scripts directory")
+
+		content, err := os.ReadFile(exampleScript)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "#!/usr/bin/env bash",
+			"global example.sh must have shebang line")
+	})
+
+	t.Run("--global --force overwrites existing global example.sh", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		scriptsDir := filepath.Join(tmpDir, "awf", "scripts")
+		require.NoError(t, os.MkdirAll(scriptsDir, 0o755))
+		oldContent := "# old global script\n"
+		require.NoError(t, os.WriteFile(
+			filepath.Join(scriptsDir, "example.sh"),
+			[]byte(oldContent),
+			0o755,
+		))
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init", "--global", "--force"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(filepath.Join(scriptsDir, "example.sh"))
+		require.NoError(t, err)
+		assert.NotContains(t, string(content), "# old global script",
+			"--force must overwrite existing global example.sh")
+		assert.Contains(t, string(content), "#!/usr/bin/env bash",
+			"overwritten global script must have shebang")
+	})
+
+	t.Run("--global creates scripts dir when prompts already initialized", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		// Simulate partial state: prompts dir exists but scripts does not
+		promptsDir := filepath.Join(tmpDir, "awf", "prompts")
+		require.NoError(t, os.MkdirAll(promptsDir, 0o755))
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init", "--global"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		// Scripts dir must be created even though prompts dir already existed
+		globalScriptsDir := filepath.Join(tmpDir, "awf", "scripts")
+		info, statErr := os.Stat(globalScriptsDir)
+		require.NoError(t, statErr, "scripts dir should be created when prompts already existed")
+		assert.True(t, info.IsDir())
+	})
+
+	t.Run("--global flag description mentions scripts", func(t *testing.T) {
+		cmd := cli.NewRootCommand()
+		initCmd, _, err := cmd.Find([]string{"init"})
+		require.NoError(t, err)
+
+		globalFlag := initCmd.Flags().Lookup("global")
+		require.NotNil(t, globalFlag, "--global flag should exist")
+		assert.Contains(t, globalFlag.Usage, "scripts",
+			"--global flag usage should mention scripts")
+	})
+}
+
 // TestInitCommand_GlobalFlag_ExamplePromptPermissions verifies file permissions.
 func TestInitCommand_GlobalFlag_ExamplePromptPermissions(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/tests/integration/cli/init_test.go
+++ b/tests/integration/cli/init_test.go
@@ -233,6 +233,56 @@ func TestInitCommand(t *testing.T) {
 		assert.NotContains(t, longDesc, "storage/logs")
 		assert.Contains(t, longDesc, "XDG directories")
 	})
+
+	t.Run("creates .awf/scripts directory", func(t *testing.T) {
+		tmpDir := setupInitTestDir(t)
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		scriptsDir := filepath.Join(tmpDir, ".awf", "scripts")
+		info, err := os.Stat(scriptsDir)
+		require.NoError(t, err)
+		assert.True(t, info.IsDir())
+	})
+
+	t.Run("creates example script file", func(t *testing.T) {
+		tmpDir := setupInitTestDir(t)
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		exampleScript := filepath.Join(tmpDir, ".awf", "scripts", "example.sh")
+		_, err = os.Stat(exampleScript)
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(exampleScript)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "#!/usr/bin/env bash")
+	})
+
+	t.Run("help text mentions scripts directory", func(t *testing.T) {
+		cmd := cli.NewRootCommand()
+		initCmd, _, err := cmd.Find([]string{"init"})
+		require.NoError(t, err)
+
+		longDesc := initCmd.Long
+		assert.Contains(t, longDesc, ".awf/scripts/")
+	})
 }
 
 // TestInitCommand_HelpText_GlobalFlag tests that the init command help text
@@ -1169,6 +1219,258 @@ func TestInitCommand_ProjectConfigFile_Permissions(t *testing.T) {
 // parseYAML is a helper for YAML parsing in tests.
 func parseYAML(data []byte, v interface{}) error {
 	return yaml.Unmarshal(data, v)
+}
+
+// TestInitCommand_ScriptsDirectory verifies that awf init creates the scripts directory
+// and example.sh with correct content and permissions.
+func TestInitCommand_ScriptsDirectory(t *testing.T) {
+	t.Run("scripts directory has 0o755 permissions", func(t *testing.T) {
+		tmpDir := setupInitTestDir(t)
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		scriptsDir := filepath.Join(tmpDir, ".awf", "scripts")
+		info, err := os.Stat(scriptsDir)
+		require.NoError(t, err)
+		mode := info.Mode().Perm()
+		assert.True(t, mode&0o755 == 0o755, "scripts directory should have 0o755 permissions")
+	})
+
+	t.Run("example.sh has shebang line", func(t *testing.T) {
+		tmpDir := setupInitTestDir(t)
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		exampleScript := filepath.Join(tmpDir, ".awf", "scripts", "example.sh")
+		content, err := os.ReadFile(exampleScript)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "#!/usr/bin/env bash")
+		assert.Contains(t, string(content), "echo")
+	})
+
+	t.Run("example.sh has 0o755 permissions", func(t *testing.T) {
+		tmpDir := setupInitTestDir(t)
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		exampleScript := filepath.Join(tmpDir, ".awf", "scripts", "example.sh")
+		info, err := os.Stat(exampleScript)
+		require.NoError(t, err)
+		mode := info.Mode().Perm()
+		assert.True(t, mode&0o100 != 0, "example.sh should be executable by owner")
+	})
+
+	t.Run("--force overwrites example.sh", func(t *testing.T) {
+		tmpDir := setupInitTestDir(t)
+
+		// Pre-create scripts directory with custom content
+		scriptsDir := filepath.Join(tmpDir, ".awf", "scripts")
+		require.NoError(t, os.MkdirAll(scriptsDir, 0o755))
+		oldScript := filepath.Join(scriptsDir, "example.sh")
+		require.NoError(t, os.WriteFile(oldScript, []byte("#!/bin/sh\nold content"), 0o755))
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init", "--force"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(oldScript)
+		require.NoError(t, err)
+		assert.NotContains(t, string(content), "old content")
+		assert.Contains(t, string(content), "#!/usr/bin/env bash")
+	})
+
+	t.Run("skips example.sh if already exists without force", func(t *testing.T) {
+		tmpDir := setupInitTestDir(t)
+
+		// First run to create structure
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		// Overwrite with custom content
+		exampleScript := filepath.Join(tmpDir, ".awf", "scripts", "example.sh")
+		customContent := "#!/bin/sh\nmy custom script"
+		require.NoError(t, os.WriteFile(exampleScript, []byte(customContent), 0o755))
+
+		// Run init again with --force on .awf (which does early-exit without force)
+		// The direct way: pre-create scripts dir with custom script, then run without force
+		// Since init early-exits when .awf exists without --force, we test with --force
+		// but scripts already exists — force still overwrites
+		cmd2 := cli.NewRootCommand()
+		cmd2.SetArgs([]string{"init", "--force"})
+
+		var out2 bytes.Buffer
+		cmd2.SetOut(&out2)
+		cmd2.SetErr(&out2)
+
+		err = cmd2.Execute()
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(exampleScript)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "#!/usr/bin/env bash",
+			"--force should restore standard example.sh")
+	})
+}
+
+// TestInitCommand_GlobalFlag_CreatesScriptsDirectory verifies that awf init --global
+// creates the global scripts directory and example.sh.
+func TestInitCommand_GlobalFlag_CreatesScriptsDirectory(t *testing.T) {
+	t.Run("--global creates scripts directory in XDG_CONFIG_HOME", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init", "--global"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		globalScriptsDir := filepath.Join(tmpDir, "awf", "scripts")
+		info, statErr := os.Stat(globalScriptsDir)
+		require.NoError(t, statErr, "global scripts directory should be created at $XDG_CONFIG_HOME/awf/scripts")
+		assert.True(t, info.IsDir())
+	})
+
+	t.Run("--global creates example.sh in scripts directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init", "--global"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		exampleScript := filepath.Join(tmpDir, "awf", "scripts", "example.sh")
+		_, statErr := os.Stat(exampleScript)
+		require.NoError(t, statErr, "example.sh should be created in global scripts directory")
+
+		content, err := os.ReadFile(exampleScript)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "#!/usr/bin/env bash")
+	})
+
+	t.Run("--global creates scripts directory even when prompts already exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		// Pre-create only the prompts directory (partial initialization state)
+		promptsDir := filepath.Join(tmpDir, "awf", "prompts")
+		require.NoError(t, os.MkdirAll(promptsDir, 0o755))
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init", "--global"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		globalScriptsDir := filepath.Join(tmpDir, "awf", "scripts")
+		info, statErr := os.Stat(globalScriptsDir)
+		require.NoError(t, statErr, "scripts directory should be created even when prompts already exists")
+		assert.True(t, info.IsDir())
+	})
+
+	t.Run("--global --force overwrites global example.sh", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		// Pre-create scripts directory with custom content
+		scriptsDir := filepath.Join(tmpDir, "awf", "scripts")
+		require.NoError(t, os.MkdirAll(scriptsDir, 0o755))
+		oldScript := filepath.Join(scriptsDir, "example.sh")
+		require.NoError(t, os.WriteFile(oldScript, []byte("#!/bin/sh\nold global script"), 0o755))
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init", "--global", "--force"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(oldScript)
+		require.NoError(t, err)
+		assert.NotContains(t, string(content), "old global script")
+		assert.Contains(t, string(content), "#!/usr/bin/env bash")
+	})
+
+	t.Run("--global skips example.sh if already exists without force", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+		// Pre-create scripts directory with custom script
+		scriptsDir := filepath.Join(tmpDir, "awf", "scripts")
+		require.NoError(t, os.MkdirAll(scriptsDir, 0o755))
+		customScript := filepath.Join(scriptsDir, "example.sh")
+		customContent := "#!/bin/sh\nmy custom global script"
+		require.NoError(t, os.WriteFile(customScript, []byte(customContent), 0o755))
+
+		cmd := cli.NewRootCommand()
+		cmd.SetArgs([]string{"init", "--global"})
+
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(customScript)
+		require.NoError(t, err)
+		assert.Equal(t, customContent, string(content),
+			"existing example.sh should be preserved without --force")
+	})
 }
 
 // TestInitCommand_GlobalFlag_ExamplePromptPermissions verifies file permissions.


### PR DESCRIPTION
## Summary

- `awf init` now scaffolds a `.awf/scripts/` directory with an executable `example.sh` (shebang + `0o755`), completing the symmetry with `workflows/` and `prompts/`
- `awf init --global` creates `$XDG_CONFIG_HOME/awf/scripts/` independently of the prompts directory, fixing partial initialization states where only prompts existed
- Refactored file-writing helpers into a single `writeFileUnlessExists()` function, eliminating repeated stat+write patterns across `createConfigFile`, `createExampleWorkflow`, `createProjectConfigFile`, and `createExamplePrompt`
- `exampleScriptFile` constant extracted; `--global` flag description and all documentation updated to reflect both prompts and scripts directories

## Changes

### Implementation
- `internal/interfaces/cli/init.go`: Added `scriptsDir` and `exampleScriptFile` constants; added `createExampleScript()` helper (shebang content, `0o755`); extracted `writeFileUnlessExists()` to deduplicate 4 file-write helpers; refactored `runInitGlobal()` to create scripts and prompts directories independently (no early-exit on partial state); updated `--global` flag usage string

### Tests
- `internal/interfaces/cli/init_test.go`: Added `TestInitCommand_ScriptsDirectory` (5 cases: dir created, `example.sh` content/permissions, `--force` overwrite, help text) and `TestInitCommand_GlobalFlag_ScriptsDirectory` (5 cases: XDG path, content, partial-state recovery, `--force`, flag description)
- `tests/integration/cli/init_test.go`: Added `TestInitCommand_ScriptsDirectory` and `TestInitCommand_GlobalFlag_CreatesScriptsDirectory` integration suites covering permissions, shebang, `--force`, skip-without-force, and partial-init scenarios; extended `TestInitCommand` with 3 additional cases

### Documentation
- `CHANGELOG.md`: Added C060 entry under `[Unreleased] → Added`
- `docs/getting-started/quickstart.md`: Updated directory tree to include `scripts/example.sh`
- `docs/user-guide/commands.md`: Updated `--global` flag description and directory trees for both local and global init
- `CLAUDE.md`: Captured three new architecture rules (independent directory creation, file permission conventions, init scaffolding pattern)

## Test plan

- [ ] `make test-unit` passes with all new `TestInitCommand_ScriptsDirectory` and `TestInitCommand_GlobalFlag_ScriptsDirectory` cases
- [ ] `make test-integration` passes for `tests/integration/cli/init_test.go`
- [ ] `awf init` in a fresh directory creates `.awf/scripts/example.sh` with `chmod +x` and a `#!/usr/bin/env bash` shebang
- [ ] `XDG_CONFIG_HOME=/tmp/test awf init --global` with pre-existing prompts dir still creates `scripts/` (partial-state recovery)

Closes #252

---
Generated with [awf](https://github.com/awf-project/cli) commit workflow

