### PR TITLE
fix(conversation): C062 agent state options audit — 7 gap fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **C062**: Agent state options audit — 7 documentation and validation gaps
+  - **Finding 1–2**: Documented `continue_from` and `inject_context` fields in Conversation Configuration table (`workflow-syntax.md`)
+  - **Finding 3**: Fixed `strategy` default value from `sliding_window` to `-` (no context management when omitted)
+  - **Finding 4**: Enumerated all valid strategy values (`sliding_window`, `summarize`, `truncate_middle`) in documentation
+  - **Finding 5**: Documented conversation mode limitation — full history continuity only with `openai_compatible`; CLI providers execute turns independently
+  - **Finding 6**: `ConversationConfig.Validate()` now rejects `continue_from` and `inject_context` with "not yet implemented" errors (previously silently ignored)
+  - **Finding 7**: `ConversationConfig.Validate()` now rejects `summarize` and `truncate_middle` strategies with "not yet implemented; use sliding_window" error
+  - Updated `conversation-multiturn.yaml` and `conversation-window.yaml` fixtures for new validation rules
 - **C061**: Step options audit — 3 documentation/implementation gaps
   - `timeout` field documentation now reflects both integer seconds and Go duration string syntax (`"1m30s"`, `"500ms"`) across step and agent option tables
   - Removed redundant `context.WithTimeout` from `ShellExecutor.Execute` — application layer is now the single timeout owner via `prepareStepExecution`

--- a/docs/user-guide/conversation-steps.md
+++ b/docs/user-guide/conversation-steps.md
@@ -116,7 +116,7 @@ Prevents exceeding model token limits. When exceeded, old turns are dropped usin
 
 Context window strategy when token limit is reached:
 
-- **`sliding_window`** (default) - Drop oldest turns, preserving system prompt and most recent context
+- **`sliding_window`** - Drop oldest turns, preserving system prompt and most recent context. If omitted, no context management is applied.
 
 ```yaml
 strategy: sliding_window
@@ -124,7 +124,7 @@ strategy: sliding_window
 # Drop: Turn 1, Keep: System prompt, Turn 2, Turn 3, Turn 4, Turn 5
 ```
 
-Future strategies: `summarize` (compress old turns), `truncate_middle` (keep first and last turns).
+Future strategies: `summarize` (compress old turns), `truncate_middle` (keep first and last turns). These strategies are validated but not yet implemented — using them will produce a validation error suggesting `sliding_window` instead.
 
 #### stop_condition
 
@@ -240,9 +240,11 @@ stop_condition: "response contains 'sufficient sources' || turn_count >= 10"
 stop_condition: "response contains 'Summary:' || tokens_used > 90000"
 ```
 
-## Injecting Context Mid-Conversation
+## Injecting Context Mid-Conversation (Planned)
 
-Continue a conversation from a previous step:
+> **Not yet implemented** — `continue_from` and `inject_context` are parsed but rejected at validation. See [Limitations](#limitations) for details.
+
+The following example shows the planned behavior for resuming a conversation from a previous step:
 
 ```yaml
 states:
@@ -260,12 +262,12 @@ states:
       max_turns: 5
     on_success: add_requirements
 
-  # Continue previous conversation
+  # Planned: continue previous conversation
   add_requirements:
     type: agent
     provider: claude
     mode: conversation
-    continue_from: refine_code
+    continue_from: refine_code  # Not yet implemented — will error at validation
     prompt: |
       Also consider these requirements:
       {{.inputs.additional_requirements}}
@@ -277,7 +279,7 @@ states:
     type: terminal
 ```
 
-The `continue_from` field loads the conversation history from the previous step and continues with the new prompt.
+When implemented, the `continue_from` field will load the conversation history from the previous step and continue with the new prompt.
 
 ## Examples
 
@@ -521,20 +523,42 @@ error:
 
 **Fixed in**: F051 (See CHANGELOG.md for details)
 
-### Provider Not Supporting Conversation
+### CLI Providers Execute Turns Independently
 
-**Problem**: Agent doesn't maintain history across turns
+**Problem**: Agent doesn't maintain history across turns with CLI providers
 
-**Note**: Conversation mode serializes history in prompts for all providers, but not all CLIs may handle multi-turn naturally. If experiencing issues:
-- Check provider CLI documentation
-- Test with a single-turn agent step as fallback
-- File an issue with provider details
+**Explanation**: CLI-based providers (`claude`, `codex`, `gemini`, `opencode`) execute each conversation turn as an independent process invocation. AWF serializes conversation history into the prompt, but the CLI does not retain session state between turns. This means:
+- Each turn starts a fresh CLI process
+- Context is passed via prompt serialization, not native session continuity
+- Token usage may be higher due to repeated context in each prompt
+
+**Solution**: For workflows requiring full multi-turn conversation with native history continuity, use the `openai_compatible` provider, which sends the complete message history via the Chat Completions API:
+
+```yaml
+refine:
+  type: agent
+  provider: openai_compatible
+  mode: conversation
+  options:
+    base_url: https://api.openai.com/v1
+    model: gpt-4
+  initial_prompt: "Review this code"
+  conversation:
+    max_turns: 10
+    strategy: sliding_window
+  on_success: done
+```
 
 ## Limitations
 
+### Provider Compatibility
+
+Conversation mode with full history continuity is only functional with `openai_compatible`. CLI-based providers (`claude`, `codex`, `gemini`, `opencode`) execute each turn as an independent process — conversation context is serialized into the prompt but the provider does not maintain native session state. This is a known architectural limitation; implementing `--resume` style session continuation for each CLI provider is tracked as a separate feature.
+
 ### Current Implementation
 
-- Only `sliding_window` strategy implemented (dropping oldest turns)
+- Only `sliding_window` strategy implemented (dropping oldest turns); `summarize` and `truncate_middle` are rejected at validation
+- `continue_from` and `inject_context` fields are parsed but not yet implemented; using them produces a validation error
 - Stop conditions limited to string/token/turn expressions
 - No branching conversations (single linear path)
 
@@ -542,8 +566,10 @@ error:
 
 - `summarize` strategy (LLM-based compression of old turns)
 - `truncate_middle` strategy (keep first and last turns)
+- `continue_from` for resuming conversations across steps
+- `inject_context` for adding context mid-conversation
+- CLI provider session continuation via `--resume` flags
 - Conversation branching (explore multiple paths)
-- Pause/resume conversations across workflow runs
 
 ## See Also
 

--- a/docs/user-guide/workflow-syntax.md
+++ b/docs/user-guide/workflow-syntax.md
@@ -440,18 +440,22 @@ refine_code:
 |--------|------|---------|-------------|
 | `max_turns` | int | 10 | Maximum conversation turns |
 | `max_context_tokens` | int | model limit | Token budget for conversation |
-| `strategy` | string | `sliding_window` | Context window strategy |
+| `strategy` | string | `-` | Context window strategy: `sliding_window`, `summarize` (not yet implemented), `truncate_middle` (not yet implemented). Omitting means no context management is applied |
 | `stop_condition` | string | - | Expression to exit early |
+| `continue_from` | string | - | Step name to continue conversation from (not yet implemented) |
+| `inject_context` | string | - | Additional context to inject mid-conversation (not yet implemented) |
 
 ### Available Providers
 
-| Provider | Binary/Endpoint | Description |
-|----------|--------|-------------|
-| `claude` | `claude` CLI | Anthropic Claude CLI |
-| `codex` | `codex` CLI | OpenAI Codex CLI |
-| `gemini` | `gemini` CLI | Google Gemini CLI |
-| `opencode` | `opencode` CLI | OpenCode CLI |
-| `openai_compatible` | HTTP API | Chat Completions API (OpenAI, Ollama, vLLM, Groq) |
+| Provider | Binary/Endpoint | Conversation Support | Description |
+|----------|--------|----------------------|-------------|
+| `claude` | `claude` CLI | Single-turn only | Anthropic Claude CLI |
+| `codex` | `codex` CLI | Single-turn only | OpenAI Codex CLI |
+| `gemini` | `gemini` CLI | Single-turn only | Google Gemini CLI |
+| `opencode` | `opencode` CLI | Single-turn only | OpenCode CLI |
+| `openai_compatible` | HTTP API | Full multi-turn | Chat Completions API (OpenAI, Ollama, vLLM, Groq) |
+
+> **Conversation mode and providers:** Only `openai_compatible` maintains full conversation history across turns via the Chat Completions API. CLI-based providers (`claude`, `codex`, `gemini`, `opencode`) execute each turn as an independent invocation — previous conversation context is serialized into the prompt but the CLI process does not retain session state. For workflows requiring true multi-turn continuity, use `openai_compatible`.
 
 ### Agent Output
 

--- a/internal/domain/workflow/conversation.go
+++ b/internal/domain/workflow/conversation.go
@@ -88,6 +88,13 @@ type ConversationConfig struct {
 // Validate checks if the conversation configuration is valid.
 // The validator parameter is used to check stop condition expression syntax.
 func (c *ConversationConfig) Validate(validator ExpressionCompiler) error {
+	if c.ContinueFrom != "" {
+		return errors.New("continue_from is not yet implemented")
+	}
+	if c.InjectContext != "" {
+		return errors.New("inject_context is not yet implemented")
+	}
+
 	// Validate MaxTurns (0 is allowed and means use default)
 	if c.MaxTurns < 0 {
 		return errors.New("max_turns must be non-negative")
@@ -104,8 +111,10 @@ func (c *ConversationConfig) Validate(validator ExpressionCompiler) error {
 	// Validate Strategy if set
 	if c.Strategy != "" {
 		switch c.Strategy {
-		case StrategySlidingWindow, StrategySummarize, StrategyTruncateMiddle:
+		case StrategySlidingWindow:
 			// Valid strategies
+		case StrategySummarize, StrategyTruncateMiddle:
+			return fmt.Errorf("strategy %q is not yet implemented; use sliding_window", c.Strategy)
 		default:
 			return errors.New("invalid context window strategy")
 		}

--- a/internal/domain/workflow/conversation_test.go
+++ b/internal/domain/workflow/conversation_test.go
@@ -214,7 +214,8 @@ func TestConversationConfig_Validate(t *testing.T) {
 				MaxTurns:     5,
 				ContinueFrom: "previous_conversation",
 			},
-			wantErr: false,
+			wantErr: true,
+			errMsg:  "continue_from is not yet implemented",
 		},
 		{
 			name: "valid with inject_context",
@@ -222,7 +223,8 @@ func TestConversationConfig_Validate(t *testing.T) {
 				MaxTurns:      5,
 				InjectContext: "Additional context here",
 			},
-			wantErr: false,
+			wantErr: true,
+			errMsg:  "inject_context is not yet implemented",
 		},
 		{
 			name: "zero max_turns (uses default)",
@@ -287,14 +289,15 @@ func TestConversationConfig_Validate_Strategies(t *testing.T) {
 		name     string
 		strategy ContextWindowStrategy
 		wantErr  bool
+		errMsg   string
 	}{
-		{"none (default)", StrategyNone, false},
-		{"sliding_window", StrategySlidingWindow, false},
-		{"summarize", StrategySummarize, false},
-		{"truncate_middle", StrategyTruncateMiddle, false},
-		{"empty string", ContextWindowStrategy(""), false},
-		{"invalid", ContextWindowStrategy("invalid"), true},
-		{"typo", ContextWindowStrategy("sliding_windows"), true},
+		{"none (default)", StrategyNone, false, ""},
+		{"sliding_window", StrategySlidingWindow, false, ""},
+		{"summarize", StrategySummarize, true, "not yet implemented"},
+		{"truncate_middle", StrategyTruncateMiddle, true, "not yet implemented"},
+		{"empty string", ContextWindowStrategy(""), false, ""},
+		{"invalid", ContextWindowStrategy("invalid"), true, "invalid"},
+		{"typo", ContextWindowStrategy("sliding_windows"), true, "invalid"},
 	}
 
 	for _, tt := range tests {
@@ -306,6 +309,9 @@ func TestConversationConfig_Validate_Strategies(t *testing.T) {
 			err := config.Validate(nil)
 			if tt.wantErr {
 				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
 			} else {
 				require.NoError(t, err)
 			}

--- a/tests/fixtures/workflows/conversation-invalid-continue-from.yaml
+++ b/tests/fixtures/workflows/conversation-invalid-continue-from.yaml
@@ -1,0 +1,30 @@
+# Feature: C062 — reject continue_from (not yet implemented)
+name: conversation-invalid-continue-from
+version: "1.0.0"
+
+inputs:
+  - name: task
+    type: string
+    required: true
+
+states:
+  initial: chat
+
+  chat:
+    type: agent
+    provider: claude
+    mode: conversation
+    initial_prompt: "{{inputs.task}}"
+    conversation:
+      max_turns: 5
+      continue_from: previous_step
+    on_success: done
+    on_failure: error
+
+  done:
+    type: terminal
+    status: success
+
+  error:
+    type: terminal
+    status: failure

--- a/tests/fixtures/workflows/conversation-invalid-inject-context.yaml
+++ b/tests/fixtures/workflows/conversation-invalid-inject-context.yaml
@@ -1,0 +1,30 @@
+# Feature: C062 — reject inject_context (not yet implemented)
+name: conversation-invalid-inject-context
+version: "1.0.0"
+
+inputs:
+  - name: task
+    type: string
+    required: true
+
+states:
+  initial: chat
+
+  chat:
+    type: agent
+    provider: claude
+    mode: conversation
+    initial_prompt: "{{inputs.task}}"
+    conversation:
+      max_turns: 5
+      inject_context: "extra context for mid-conversation injection"
+    on_success: done
+    on_failure: error
+
+  done:
+    type: terminal
+    status: success
+
+  error:
+    type: terminal
+    status: failure

--- a/tests/fixtures/workflows/conversation-invalid-summarize.yaml
+++ b/tests/fixtures/workflows/conversation-invalid-summarize.yaml
@@ -1,0 +1,30 @@
+# Feature: C062 — reject summarize strategy (not yet implemented)
+name: conversation-invalid-summarize
+version: "1.0.0"
+
+inputs:
+  - name: task
+    type: string
+    required: true
+
+states:
+  initial: chat
+
+  chat:
+    type: agent
+    provider: claude
+    mode: conversation
+    initial_prompt: "{{inputs.task}}"
+    conversation:
+      max_turns: 5
+      strategy: summarize
+    on_success: done
+    on_failure: error
+
+  done:
+    type: terminal
+    status: success
+
+  error:
+    type: terminal
+    status: failure

--- a/tests/fixtures/workflows/conversation-invalid-truncate-middle.yaml
+++ b/tests/fixtures/workflows/conversation-invalid-truncate-middle.yaml
@@ -1,0 +1,30 @@
+# Feature: C062 — reject truncate_middle strategy (not yet implemented)
+name: conversation-invalid-truncate-middle
+version: "1.0.0"
+
+inputs:
+  - name: task
+    type: string
+    required: true
+
+states:
+  initial: chat
+
+  chat:
+    type: agent
+    provider: claude
+    mode: conversation
+    initial_prompt: "{{inputs.task}}"
+    conversation:
+      max_turns: 5
+      strategy: truncate_middle
+    on_success: done
+    on_failure: error
+
+  done:
+    type: terminal
+    status: success
+
+  error:
+    type: terminal
+    status: failure

--- a/tests/fixtures/workflows/conversation-multiturn.yaml
+++ b/tests/fixtures/workflows/conversation-multiturn.yaml
@@ -35,7 +35,6 @@ states:
     type: agent
     provider: claude
     mode: conversation
-    continue_from: first_turn
     prompt: |
       Can you elaborate on that response?
     conversation:

--- a/tests/fixtures/workflows/conversation-window.yaml
+++ b/tests/fixtures/workflows/conversation-window.yaml
@@ -40,7 +40,7 @@ states:
     conversation:
       max_turns: 5
       max_context_tokens: 50000
-      strategy: summarize
+      strategy: sliding_window
     timeout: 60
     on_success: truncate_middle_test
     on_failure: error
@@ -54,7 +54,7 @@ states:
     conversation:
       max_turns: 10
       max_context_tokens: 20000
-      strategy: truncate_middle
+      strategy: sliding_window
     timeout: 60
     on_success: done
     on_failure: error

--- a/tests/integration/execution/error_transition_priority_test.go
+++ b/tests/integration/execution/error_transition_priority_test.go
@@ -168,4 +168,3 @@ states:
 	require.True(t, ok)
 	assert.Contains(t, stepState.Output, "timed out")
 }
-

--- a/tests/integration/features/conversation_test.go
+++ b/tests/integration/features/conversation_test.go
@@ -601,7 +601,6 @@ func TestBackwardsCompatibility_StatelessMode(t *testing.T) {
 	})
 
 	err := cmd.Execute()
-
 	// Then: Agent step fails because no agent registry is configured in CLI test setup
 	// The stateless agent workflow requires a registered provider (claude/gemini/etc.)
 	// which is not available in integration tests without live API access.

--- a/tests/integration/features/conversation_validation_test.go
+++ b/tests/integration/features/conversation_validation_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+
+// Feature: C062
+
+package features_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/awf-project/cli/internal/interfaces/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConversationValidation_RejectsUnimplementedFeatures(t *testing.T) {
+	t.Setenv("AWF_WORKFLOWS_PATH", "../../fixtures/workflows")
+
+	tests := []struct {
+		name         string
+		workflowName string
+		wantErr      string
+	}{
+		{
+			name:         "continue_from_rejected",
+			workflowName: "conversation-invalid-continue-from",
+			wantErr:      "continue_from is not yet implemented",
+		},
+		{
+			name:         "inject_context_rejected",
+			workflowName: "conversation-invalid-inject-context",
+			wantErr:      "inject_context is not yet implemented",
+		},
+		{
+			name:         "summarize_strategy_rejected",
+			workflowName: "conversation-invalid-summarize",
+			wantErr:      "not yet implemented",
+		},
+		{
+			name:         "truncate_middle_strategy_rejected",
+			workflowName: "conversation-invalid-truncate-middle",
+			wantErr:      "not yet implemented",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := cli.NewRootCommand()
+			buf := new(bytes.Buffer)
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			cmd.SetArgs([]string{"validate", tt.workflowName})
+
+			err := cmd.Execute()
+
+			require.Error(t, err)
+			output := buf.String()
+			assert.Contains(t, output, tt.wantErr,
+				"validation output should contain rejection message")
+		})
+	}
+}
+
+func TestConversationValidation_AcceptsValidConfigs(t *testing.T) {
+	t.Setenv("AWF_WORKFLOWS_PATH", "../../fixtures/workflows")
+
+	tests := []struct {
+		name         string
+		workflowName string
+	}{
+		{
+			name:         "sliding_window_strategy",
+			workflowName: "conversation-window",
+		},
+		{
+			name:         "no_strategy",
+			workflowName: "conversation-simple",
+		},
+		{
+			name:         "multiturn_without_continue_from",
+			workflowName: "conversation-multiturn",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := cli.NewRootCommand()
+			buf := new(bytes.Buffer)
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			cmd.SetArgs([]string{"validate", tt.workflowName})
+
+			err := cmd.Execute()
+
+			require.NoError(t, err)
+			assert.Contains(t, buf.String(), "valid")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Addresses 7 audit gaps (C062) in conversation agent configuration: 5 documentation fixes and 2 validation enforcement gaps
- `ConversationConfig.Validate()` now actively rejects `continue_from`, `inject_context`, and unimplemented strategies (`summarize`, `truncate_middle`) with clear "not yet implemented" errors, preventing silent misconfiguration
- Documentation now accurately reflects the architectural limitation that CLI-based providers (`claude`, `codex`, `gemini`, `opencode`) execute each conversation turn independently — only `openai_compatible` supports true multi-turn history continuity

## Changes

### Domain
- `internal/domain/workflow/conversation.go`: Add validation guards rejecting `continue_from`, `inject_context`, and unimplemented strategies (`summarize`, `truncate_middle`) with actionable error messages

### Tests — Unit
- `internal/domain/workflow/conversation_test.go`: Flip `continue_from` and `inject_context` test cases from `wantErr: false` to `wantErr: true`; add `errMsg` assertions to strategy validation table

### Tests — Integration
- `tests/integration/features/conversation_validation_test.go`: New integration test file covering all 4 rejected configs and 3 accepted valid configs via `awf validate`
- `tests/integration/execution/error_transition_priority_test.go`: Remove trailing blank line (cosmetic)
- `tests/integration/features/conversation_test.go`: Remove blank line (cosmetic)

### Fixtures
- `tests/fixtures/workflows/conversation-invalid-continue-from.yaml`: New fixture for validation rejection test
- `tests/fixtures/workflows/conversation-invalid-inject-context.yaml`: New fixture for validation rejection test
- `tests/fixtures/workflows/conversation-invalid-summarize.yaml`: New fixture for validation rejection test
- `tests/fixtures/workflows/conversation-invalid-truncate-middle.yaml`: New fixture for validation rejection test
- `tests/fixtures/workflows/conversation-multiturn.yaml`: Remove `continue_from` field (now fails validation)
- `tests/fixtures/workflows/conversation-window.yaml`: Replace `summarize` and `truncate_middle` strategies with `sliding_window` (now fail validation)

### Documentation
- `docs/user-guide/conversation-steps.md`: Fix strategy default value, clarify unimplemented strategies, rewrite CLI provider limitation section, mark `continue_from`/`inject_context` section as planned
- `docs/user-guide/workflow-syntax.md`: Document `continue_from` and `inject_context` fields, fix strategy default, add "Conversation Support" column to provider table with single-turn/full multi-turn distinction

### Changelog
- `CHANGELOG.md`: Document all 7 C062 findings under `[Unreleased] → Fixed`

## Test plan

- [ ] Run unit tests: `make test-unit` — all conversation domain tests pass
- [ ] Run integration tests: `make test-integration` — `TestConversationValidation_RejectsUnimplementedFeatures` and `TestConversationValidation_AcceptsValidConfigs` pass
- [ ] Validate a fixture using an unimplemented feature: `awf validate conversation-invalid-summarize` — outputs "not yet implemented" error
- [ ] Validate a valid conversation fixture: `awf validate conversation-window` — passes without error

---
Generated with [awf](https://github.com/Pmuzlcky/awf) commit workflow

