### PR TITLE
fix(retry): C064 retry configuration audit — 7 gap fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **C064**: Retry configuration audit — 7 documentation-vs-implementation gap fixes
+  - **Finding 1 (Critical)**: Guard `CalculateDelay` against `maxDelay=0` silently nullifying all retry delays — omitting `max_delay` no longer caps delays to zero
+  - **Finding 2 (High)**: Default `multiplier` to 2.0 when omitted in YAML (was 0.0, degrading exponential backoff to constant delays)
+  - **Finding 3 (Medium)**: Replaced deprecated `initial_delay_ms` with `initial_delay` duration strings in 3 doc files (`workflow-syntax.md`, `examples.md`, `plugins.md`)
+  - **Finding 4 (Medium)**: Fixed `conversation-error.yaml` fixture using non-existent `delay:` field (renamed to `initial_delay:`)
+  - **Finding 5 (Low)**: Surface duration parse errors in `mapRetry()` instead of silently defaulting to 0ms — invalid `initial_delay` / `max_delay` values now produce parse errors
+  - **Finding 6 (Low)**: Added `RetryConfig.Validate()` covering `max_attempts >= 1`, valid backoff strategy, `jitter ∈ [0.0, 1.0]`, `multiplier >= 0`; wired into `Step.Validate()`
+  - **Finding 7 (Info)**: Added missing `Jitter` and `RetryableExitCodes` fields to `DryRunRetry` struct and mapping in `dry_run_executor.go`
+  - New unit and integration tests for maxDelay guard, multiplier default, duration error propagation, retry validation, and dry-run field mapping
 - **C063**: Loop options audit — 6 documentation-vs-implementation discrepancies
   - **Finding 1**: Replaced ~56 lowercase loop variable references (`loop.item`, `loop.index`) with PascalCase (`loop.Item`, `loop.Index`) across 4 doc files (`workflow-syntax.md`, `loop.md`, `interpolation.md`, `examples.md`)
   - **Finding 1 — Code**: Added missing `index1` and `parent` keys to `makeLoopAccessor` function-call map in `template_resolver.go`; `parent` uses recursive `serializeLoopData` with nil guard

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,8 @@ Own timeout responsibility in application layer via context.WithTimeout; infrast
 
 Evaluate step transitions before fallback behaviors; transitions take priority over OnSuccess, OnFailure, and ContinueOnError (ADR-001)
 
+Use pointer types (*T) for optional config fields in infrastructure types; apply defaults during mapping to distinguish omitted from explicit zero values
+
 ## Common Pitfalls
 
 - Preserve existing infrastructure layers when adding domain registries; ADR-004 enforces infrastructure plugin registry coexistence for separate lifecycle concerns
@@ -279,6 +281,8 @@ Apply identical error handling patterns across similar functions; handleNonZeroE
 When removing redundant infrastructure code, document the architectural ownership pattern; explain which layer assumed responsibility and why the field was removed
 
 Always apply code deletions before writing tests that validate the deletion effect; tests may pass against overridden behavior instead of the intended code path
+
+Wrap YAML/JSON mapping errors (duration parse, type conversion) in domain error types; surface failures immediately to prevent silent defaults
 
 ## Test Conventions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ Learn how to use AWF effectively:
   - [GitHub Operations](user-guide/workflow-syntax.md#github-operations) - Built-in GitHub plugin with declarative operations
   - [HTTP Operations](user-guide/workflow-syntax.md#http-operations) - Built-in HTTP operation for REST API calls
   - [Notification Operations](user-guide/workflow-syntax.md#notification-operations) - Built-in notification plugin with desktop and webhook backends
+- [Retry Configuration](user-guide/retry.md) - Automatic retry with backoff strategies, delay capping, and exit code filtering
 - [Templates](user-guide/templates.md) - Reusable workflow templates
 - [Plugins](user-guide/plugins.md) - Extend AWF with custom operations
 - [Audit Trail](user-guide/audit-trail.md) - Structured execution audit log with JSONL output

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -347,7 +347,7 @@ states:
     retry:
       max_attempts: 3
       backoff: exponential
-      initial_delay_ms: 1000
+      initial_delay: 1s
     on_success: done
     on_failure: error
 

--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -110,7 +110,7 @@ create_resource:
   retry:
     max_attempts: 3
     backoff: exponential
-    initial_delay_ms: 1000
+    initial_delay: 1s
   on_success: success
   on_failure: error
 ```

--- a/docs/user-guide/retry.md
+++ b/docs/user-guide/retry.md
@@ -1,0 +1,418 @@
+---
+title: "Retry Configuration Guide"
+---
+
+Automatically retry failed steps with configurable backoff strategies and exit code filtering.
+
+## Overview
+
+AWF provides built-in retry functionality for steps and agent calls. When a step fails, you can configure AWF to automatically retry with exponential, linear, or constant backoff delays.
+
+**Common use cases:**
+- Transient network errors (429, 502, 503 responses)
+- Intermittent service failures
+- Rate-limited API calls
+- Flaky shell commands
+
+## Basic Retry
+
+The simplest retry configuration retries a step multiple times with default settings:
+
+```yaml
+states:
+  initial: fetch_data
+
+  fetch_data:
+    type: step
+    command: curl https://api.example.com/data
+    retry:
+      max_attempts: 3  # Try 3 times total (default: 1 = no retry)
+    on_success: done
+
+  done:
+    type: terminal
+    status: success
+```
+
+With this configuration:
+1. `curl` executes
+2. If it fails (non-zero exit), AWF retries up to 2 more times
+3. Each retry executes immediately (no delay)
+4. If all 3 attempts fail, the step is considered failed
+
+## Adding Delays
+
+Use `initial_delay` to add a delay before the first retry:
+
+```yaml
+fetch_data:
+  type: step
+  command: curl https://api.example.com/data
+  retry:
+    max_attempts: 3
+    initial_delay: 1s      # Wait 1 second before first retry
+    backoff: constant      # Always wait 1 second between attempts
+  on_success: done
+```
+
+**Duration format** accepts Go duration strings:
+- `100ms` — milliseconds
+- `1s` — 1 second
+- `30s` — 30 seconds
+- `1m30s` — 1.5 minutes
+
+## Backoff Strategies
+
+### Constant Backoff
+
+Retry with a fixed delay:
+
+```yaml
+retry:
+  max_attempts: 5
+  initial_delay: 2s
+  backoff: constant
+```
+
+Delays: `2s`, `2s`, `2s`, `2s` (always the same)
+
+### Linear Backoff
+
+Delay increases linearly with each attempt:
+
+```yaml
+retry:
+  max_attempts: 5
+  initial_delay: 1s
+  backoff: linear
+```
+
+Delays: `1s`, `2s`, `3s`, `4s` (multiplied by attempt number)
+
+### Exponential Backoff
+
+Delay increases exponentially (recommended for most use cases):
+
+```yaml
+retry:
+  max_attempts: 5
+  initial_delay: 1s
+  backoff: exponential
+  multiplier: 2        # Double the delay each time (default: 2.0)
+```
+
+Delays: `1s`, `2s`, `4s`, `8s` (multiplied by 2 each time)
+
+**Using a different multiplier:**
+
+```yaml
+retry:
+  max_attempts: 5
+  initial_delay: 500ms
+  backoff: exponential
+  multiplier: 1.5      # Increase delay by 50% each time
+```
+
+Delays: `500ms`, `750ms`, `1.125s`, `1.687s`
+
+## Capping Maximum Delay
+
+Prevent delays from growing too large with `max_delay`:
+
+```yaml
+retry:
+  max_attempts: 10
+  initial_delay: 1s
+  backoff: exponential
+  multiplier: 2
+  max_delay: 30s       # Never wait longer than 30 seconds
+```
+
+This configuration:
+- Starts with 1 second delays
+- Doubles each time: 2s, 4s, 8s, 16s, **30s** (capped), **30s**, **30s**, **30s**, **30s**
+
+**Important:** Always specify `max_delay` to prevent excessively long delays in production.
+
+## Filtering Retryable Exit Codes
+
+By default, AWF retries on any non-zero exit code. Use `retryable_exit_codes` to retry only specific failures:
+
+```yaml
+deploy:
+  type: step
+  command: ./deploy.sh
+  retry:
+    max_attempts: 3
+    initial_delay: 5s
+    backoff: exponential
+    retryable_exit_codes: [1, 22]  # Only retry on exit codes 1 and 22
+  on_success: verify
+```
+
+With this configuration:
+- Exit code `1` (transient error) → retry
+- Exit code `22` (connection error) → retry
+- Exit code `5` (invalid config) → fail immediately, don't retry
+
+**Empty array** (the default) retries all non-zero codes:
+
+```yaml
+retry:
+  max_attempts: 3
+  retryable_exit_codes: []        # Retry on any non-zero exit
+```
+
+## Agent Step Retry
+
+Retry agent steps the same way you retry command steps:
+
+```yaml
+analyze:
+  type: agent
+  provider: claude
+  prompt: "Analyze: {{.inputs.code}}"
+  timeout: 120
+  retry:
+    max_attempts: 3
+    initial_delay: 2s
+    backoff: exponential
+  on_success: done
+```
+
+## HTTP Operation Retry
+
+For HTTP operations (REST API calls), AWF retries based on status codes:
+
+```yaml
+api_call:
+  type: operation
+  operation: http.request
+  inputs:
+    method: POST
+    url: https://api.example.com/process
+    body: "{{.inputs.data}}"
+    retryable_status_codes: [429, 502, 503]  # Retry on rate limit or server error
+  retry:
+    max_attempts: 5
+    initial_delay: 1s
+    backoff: exponential
+    multiplier: 2
+    max_delay: 60s
+  on_success: next
+```
+
+## Complete Example: Reliable API Integration
+
+This example shows a robust API integration with retry, error handling, and logging:
+
+```yaml
+name: reliable-api
+version: "1.0.0"
+
+inputs:
+  - name: endpoint
+    type: string
+    required: true
+    default: "https://api.example.com"
+
+states:
+  initial: fetch_with_retry
+
+  fetch_with_retry:
+    type: operation
+    operation: http.request
+    inputs:
+      method: GET
+      url: "{{.inputs.endpoint}}/data"
+      timeout: 30
+      retryable_status_codes: [429, 502, 503, 504]
+    retry:
+      max_attempts: 5
+      initial_delay: 1s
+      backoff: exponential
+      multiplier: 2
+      max_delay: 32s
+    on_success: process
+    on_failure:
+      message: "API call failed after 5 attempts: {{.error.message}}"
+      status: 3
+
+  process:
+    type: agent
+    provider: claude
+    prompt: "Process this JSON: {{.states.fetch_with_retry.output}}"
+    retry:
+      max_attempts: 2
+      initial_delay: 2s
+      backoff: constant
+    on_success: done
+
+  done:
+    type: terminal
+    status: success
+```
+
+## Validation Rules
+
+AWF validates retry configurations to catch mistakes early:
+
+| Rule | Error |
+|------|-------|
+| `max_attempts < 1` | `max_attempts must be at least 1` |
+| `initial_delay` invalid | `invalid initial_delay: expected duration string` |
+| `max_delay` invalid | `invalid max_delay: expected duration string` |
+| Unknown `backoff` | `invalid backoff strategy: use constant, linear, or exponential` |
+| `jitter` outside [0, 1] | `jitter must be between 0.0 and 1.0` |
+| `multiplier < 0` | `multiplier must be non-negative` |
+
+Example error:
+
+```
+$ awf run my-workflow
+ERROR validating workflow: step 'fetch': invalid max_attempts: 0
+```
+
+## Common Patterns
+
+### Circuit Breaker (Give Up After Repeated Failures)
+
+Use step transitions to skip retries after a threshold:
+
+```yaml
+deploy:
+  type: step
+  command: ./deploy.sh
+  retry:
+    max_attempts: 3
+    initial_delay: 5s
+    backoff: exponential
+  on_success: verify
+  on_failure: alert_ops
+
+alert_ops:
+  type: terminal
+  message: "Deployment failed after 3 attempts. Manual intervention required."
+  status: 2
+```
+
+### Jitter (Randomize Delays to Avoid Thundering Herd)
+
+For distributed systems where many clients retry simultaneously, add randomization:
+
+```yaml
+retry:
+  max_attempts: 5
+  initial_delay: 1s
+  backoff: exponential
+  multiplier: 2
+  jitter: 0.5              # Add ±50% randomness to each delay
+```
+
+This prevents multiple clients from retrying at exactly the same time, which can overwhelm the service.
+
+### Escalating Delays
+
+For critical operations, increase delays over multiple retries:
+
+```yaml
+critical_task:
+  type: step
+  command: ./critical-operation.sh
+  retry:
+    max_attempts: 10
+    initial_delay: 500ms
+    backoff: exponential
+    multiplier: 1.5
+    max_delay: 5m           # Cap at 5 minutes
+  on_success: done
+```
+
+With `multiplier: 1.5`:
+1. 500ms
+2. 750ms
+3. 1.125s
+4. 1.687s
+5. 2.531s
+... eventually capped at 5m
+
+## Troubleshooting
+
+### Retries Not Happening
+
+**Problem:** Your step never retries even though it fails.
+
+**Causes:**
+1. `max_attempts` not specified (defaults to 1 = no retry)
+2. Exit code not in `retryable_exit_codes` list
+
+**Solution:**
+```yaml
+# Add explicit retry configuration
+retry:
+  max_attempts: 3
+  initial_delay: 1s
+```
+
+### Delays Too Long
+
+**Problem:** Retries take forever.
+
+**Causes:**
+1. `max_delay` not specified on exponential backoff
+2. `max_attempts` set too high
+
+**Solution:**
+```yaml
+retry:
+  max_attempts: 5          # Reasonable limit
+  initial_delay: 1s
+  backoff: exponential
+  max_delay: 30s           # Always cap exponential backoff
+```
+
+### Some Failures Not Retrying
+
+**Problem:** Step fails on certain errors but doesn't retry.
+
+**Causes:**
+1. Exit code not in `retryable_exit_codes` list
+2. `retryable_exit_codes` too restrictive
+
+**Solution:**
+```yaml
+# Check which exit code your command produces
+$ ./my-script.sh; echo "Exit code: $?"
+
+# Then add it to retryable_exit_codes
+retry:
+  retryable_exit_codes: [1, 22, 35]
+```
+
+## Reference
+
+### Retry Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_attempts` | int | 1 | Maximum number of attempts (1 = no retry) |
+| `initial_delay` | duration | 0 | Delay before first retry |
+| `max_delay` | duration | unlimited | Maximum delay between retries |
+| `backoff` | string | `constant` | Strategy: `constant`, `linear`, `exponential` |
+| `multiplier` | float | 2.0 | Multiplier for exponential backoff |
+| `jitter` | float | 0.0 | Randomness factor (0.0-1.0) |
+| `retryable_exit_codes` | array | all | Exit codes to retry (empty = all non-zero) |
+
+### Backoff Formulas
+
+| Strategy | Formula |
+|----------|---------|
+| Constant | `initial_delay` |
+| Linear | `initial_delay × attempt_number` |
+| Exponential | `initial_delay × multiplier^(attempt_number-1)` |
+
+## See Also
+
+- [Workflow Syntax Reference](workflow-syntax.md#retry) — Complete YAML syntax
+- [Agent Steps Guide](agent-steps.md) — Retry for AI operations
+- [HTTP Operations](plugins.md#http-request) — Retry for REST APIs

--- a/docs/user-guide/workflow-syntax.md
+++ b/docs/user-guide/workflow-syntax.md
@@ -835,7 +835,7 @@ create_resource:
   retry:
     max_attempts: 3
     backoff: exponential
-    initial_delay_ms: 2000
+    initial_delay: 2s
   on_success: done
   on_failure: error
 ```
@@ -1394,13 +1394,15 @@ flaky_api_call:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `max_attempts` | int | 1 | Maximum attempts (1 = no retry) |
+| `max_attempts` | int | 1 | Maximum attempts (must be >= 1) |
 | `initial_delay` | duration | 0 | Delay before first retry |
-| `max_delay` | duration | - | Maximum delay cap |
+| `max_delay` | duration | - | Maximum delay cap (omit for uncapped delays) |
 | `backoff` | string | `constant` | Strategy: `constant`, `linear`, `exponential` |
-| `multiplier` | float | 2 | Multiplier for exponential backoff |
-| `jitter` | float | 0 | Random jitter factor 0.0-1.0 |
+| `multiplier` | float | 2 | Multiplier for exponential backoff (must be >= 0) |
+| `jitter` | float | 0 | Random jitter factor (must be between 0.0 and 1.0) |
 | `retryable_exit_codes` | array | all | Exit codes to retry (empty = all non-zero) |
+
+Duration values accept Go duration strings (`100ms`, `1s`, `2m30s`) or plain integers (milliseconds). Invalid duration values produce a parse error at workflow load time.
 
 ### Backoff Strategies
 

--- a/internal/application/dry_run_executor.go
+++ b/internal/application/dry_run_executor.go
@@ -192,11 +192,13 @@ func (e *DryRunExecutor) buildStepPlan(ctx context.Context, step *workflow.Step,
 
 	if step.Retry != nil {
 		dryRunStep.Retry = &workflow.DryRunRetry{
-			MaxAttempts:    step.Retry.MaxAttempts,
-			InitialDelayMs: step.Retry.InitialDelayMs,
-			MaxDelayMs:     step.Retry.MaxDelayMs,
-			Backoff:        step.Retry.Backoff,
-			Multiplier:     step.Retry.Multiplier,
+			MaxAttempts:        step.Retry.MaxAttempts,
+			InitialDelayMs:     step.Retry.InitialDelayMs,
+			MaxDelayMs:         step.Retry.MaxDelayMs,
+			Backoff:            step.Retry.Backoff,
+			Multiplier:         step.Retry.Multiplier,
+			Jitter:             step.Retry.Jitter,
+			RetryableExitCodes: step.Retry.RetryableExitCodes,
 		}
 	}
 

--- a/internal/application/dry_run_executor_test.go
+++ b/internal/application/dry_run_executor_test.go
@@ -427,6 +427,105 @@ func TestDryRunExecutor_Execute_RetryConfig(t *testing.T) {
 	assert.Equal(t, "exponential", flakyStep.Retry.Backoff)
 }
 
+func TestDryRunExecutor_Execute_RetryConfig_JitterAndExitCodes(t *testing.T) {
+	tests := []struct {
+		name               string
+		retry              workflow.RetryConfig
+		wantJitter         float64
+		wantExitCodes      []int
+		wantExitCodesIsNil bool
+	}{
+		{
+			name: "jitter mapped with nil exit codes",
+			retry: workflow.RetryConfig{
+				MaxAttempts: 3, InitialDelayMs: 100, MaxDelayMs: 1000,
+				Backoff: "exponential", Multiplier: 2.0, Jitter: 0.5,
+			},
+			wantJitter:         0.5,
+			wantExitCodesIsNil: true,
+		},
+		{
+			name: "exit codes mapped with jitter",
+			retry: workflow.RetryConfig{
+				MaxAttempts: 3, InitialDelayMs: 100, MaxDelayMs: 1000,
+				Backoff: "linear", Multiplier: 1.5, Jitter: 0.2,
+				RetryableExitCodes: []int{1, 2, 3},
+			},
+			wantJitter:    0.2,
+			wantExitCodes: []int{1, 2, 3},
+		},
+		{
+			name: "zero jitter preserved",
+			retry: workflow.RetryConfig{
+				MaxAttempts: 2, InitialDelayMs: 50, MaxDelayMs: 500,
+				Backoff: "constant", Jitter: 0.0,
+			},
+			wantJitter:         0.0,
+			wantExitCodesIsNil: true,
+		},
+		{
+			name: "empty exit codes preserved",
+			retry: workflow.RetryConfig{
+				MaxAttempts: 2, InitialDelayMs: 100, MaxDelayMs: 500,
+				Backoff: "exponential", Multiplier: 2.0, Jitter: 0.3,
+				RetryableExitCodes: []int{},
+			},
+			wantJitter:    0.3,
+			wantExitCodes: []int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wfName := "retry-" + tt.name
+			repo := newMockRepository()
+			repo.workflows[wfName] = &workflow.Workflow{
+				Name:    wfName,
+				Initial: "flaky",
+				Steps: map[string]*workflow.Step{
+					"flaky": {
+						Name: "flaky", Type: workflow.StepTypeCommand, Command: "flaky-command",
+						Retry: &tt.retry, OnSuccess: "done", OnFailure: "error",
+					},
+					"done":  {Name: "done", Type: workflow.StepTypeTerminal},
+					"error": {Name: "error", Type: workflow.StepTypeTerminal},
+				},
+			}
+
+			wfSvc := application.NewWorkflowService(repo, newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+			resolver := interpolation.NewTemplateResolver()
+			evaluator := mocks.NewMockExpressionEvaluator()
+			exec := application.NewDryRunExecutor(wfSvc, resolver, evaluator, &mockLogger{})
+
+			plan, err := exec.Execute(context.Background(), wfName, nil)
+			require.NoError(t, err)
+
+			var flakyStep *workflow.DryRunStep
+			for i := range plan.Steps {
+				if plan.Steps[i].Name == "flaky" {
+					flakyStep = &plan.Steps[i]
+					break
+				}
+			}
+			require.NotNil(t, flakyStep)
+			require.NotNil(t, flakyStep.Retry)
+
+			assert.Equal(t, tt.retry.MaxAttempts, flakyStep.Retry.MaxAttempts)
+			assert.Equal(t, tt.retry.InitialDelayMs, flakyStep.Retry.InitialDelayMs)
+			assert.Equal(t, tt.retry.MaxDelayMs, flakyStep.Retry.MaxDelayMs)
+			assert.Equal(t, tt.retry.Backoff, flakyStep.Retry.Backoff)
+			assert.Equal(t, tt.retry.Multiplier, flakyStep.Retry.Multiplier)
+			assert.Equal(t, tt.wantJitter, flakyStep.Retry.Jitter)
+
+			if tt.wantExitCodesIsNil {
+				assert.Nil(t, flakyStep.Retry.RetryableExitCodes)
+			} else {
+				assert.Equal(t, tt.wantExitCodes, flakyStep.Retry.RetryableExitCodes)
+			}
+		})
+	}
+}
+
 func TestDryRunExecutor_Execute_CaptureConfig(t *testing.T) {
 	// Test that capture configuration is captured
 	repo := newMockRepository()
@@ -974,16 +1073,6 @@ func TestDryRunExecutor_Execute_AllStepTypes(t *testing.T) {
 		})
 	}
 }
-
-// Component T003 implements comprehensive tests for DryRunExecutor setter methods.
-// Tests follow TDD patterns (RED/GREEN/REFACTOR) and cover happy path, edge cases,
-// and error conditions for SetTemplateService method.
-//
-// Strategy:
-// - Happy path: Valid template service is set and used during Execute
-// - Edge case: Nil template service is accepted (template expansion is optional)
-// - Replacement: Existing template service can be replaced with new one
-// - Integration: Template service affects workflow execution behavior
 
 // TestDryRunExecutor_SetTemplateService_Valid verifies that SetTemplateService
 // correctly sets a valid template service and that it's used during Execute.

--- a/internal/domain/workflow/dry_run.go
+++ b/internal/domain/workflow/dry_run.go
@@ -52,11 +52,13 @@ type DryRunTransition struct {
 }
 
 type DryRunRetry struct {
-	MaxAttempts    int
-	InitialDelayMs int
-	MaxDelayMs     int
-	Backoff        string
-	Multiplier     float64
+	MaxAttempts        int
+	InitialDelayMs     int
+	MaxDelayMs         int
+	Backoff            string
+	Multiplier         float64
+	Jitter             float64
+	RetryableExitCodes []int
 }
 
 type DryRunCapture struct {

--- a/internal/domain/workflow/step.go
+++ b/internal/domain/workflow/step.go
@@ -3,6 +3,8 @@ package workflow
 import (
 	"errors"
 	"fmt"
+
+	"github.com/awf-project/cli/pkg/retry"
 )
 
 // StepType defines the type of workflow step.
@@ -54,6 +56,27 @@ type RetryConfig struct {
 	Multiplier         float64 // for exponential backoff
 	Jitter             float64 // ± randomization (0.0-1.0)
 	RetryableExitCodes []int   // exit codes to retry on
+}
+
+// Validate checks if the retry configuration values are within valid ranges.
+func (r *RetryConfig) Validate() error {
+	if r.MaxAttempts < 1 {
+		return errors.New("max_attempts must be >= 1")
+	}
+
+	if r.Backoff != "" && !retry.Strategy(r.Backoff).Valid() {
+		return errors.New("invalid backoff strategy")
+	}
+
+	if r.Jitter < 0.0 || r.Jitter > 1.0 {
+		return errors.New("jitter must be between 0.0 and 1.0")
+	}
+
+	if r.Multiplier < 0 {
+		return errors.New("multiplier must be >= 0")
+	}
+
+	return nil
 }
 
 // CaptureConfig defines output capture behavior.
@@ -169,6 +192,13 @@ func (s *Step) Validate(validator ExpressionCompiler) error {
 		}
 	default:
 		return errors.New("unknown step type")
+	}
+
+	// Validate retry configuration if present
+	if s.Retry != nil {
+		if err := s.Retry.Validate(); err != nil {
+			return fmt.Errorf("retry config: %w", err)
+		}
 	}
 
 	// Validate transition expressions (only if validator is provided)

--- a/internal/domain/workflow/step_command_test.go
+++ b/internal/domain/workflow/step_command_test.go
@@ -7,6 +7,7 @@ package workflow_test
 //        retry config, capture config, dir field, new fields, and terminal status
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/awf-project/cli/internal/domain/workflow"
@@ -188,6 +189,72 @@ func TestRetryConfig(t *testing.T) {
 			t.Errorf("expected 3 retryable codes, got %d", len(retry.RetryableExitCodes))
 		}
 	})
+}
+
+func TestRetryConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  workflow.RetryConfig
+		wantErr string
+	}{
+		{
+			name:    "valid config",
+			config:  workflow.RetryConfig{MaxAttempts: 3, Backoff: "exponential", Multiplier: 2.0, Jitter: 0.5},
+			wantErr: "",
+		},
+		{
+			name:    "valid empty backoff",
+			config:  workflow.RetryConfig{MaxAttempts: 1},
+			wantErr: "",
+		},
+		{
+			name:    "max_attempts zero",
+			config:  workflow.RetryConfig{MaxAttempts: 0},
+			wantErr: "max_attempts must be >= 1",
+		},
+		{
+			name:    "max_attempts negative",
+			config:  workflow.RetryConfig{MaxAttempts: -1},
+			wantErr: "max_attempts must be >= 1",
+		},
+		{
+			name:    "invalid strategy",
+			config:  workflow.RetryConfig{MaxAttempts: 3, Backoff: "random"},
+			wantErr: "invalid backoff strategy",
+		},
+		{
+			name:    "jitter too high",
+			config:  workflow.RetryConfig{MaxAttempts: 3, Jitter: 1.5},
+			wantErr: "jitter must be between 0.0 and 1.0",
+		},
+		{
+			name:    "jitter negative",
+			config:  workflow.RetryConfig{MaxAttempts: 3, Jitter: -0.1},
+			wantErr: "jitter must be between 0.0 and 1.0",
+		},
+		{
+			name:    "multiplier negative",
+			config:  workflow.RetryConfig{MaxAttempts: 3, Multiplier: -1.0},
+			wantErr: "multiplier must be >= 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected no error, got %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+			}
+		})
+	}
 }
 
 func TestCaptureConfig(t *testing.T) {

--- a/internal/domain/workflow/step_retry_test.go
+++ b/internal/domain/workflow/step_retry_test.go
@@ -1,0 +1,285 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  RetryConfig
+		wantErr bool
+		errMsg  string
+	}{
+		// Happy path: max_attempts valid
+		{
+			name: "valid max_attempts minimum value",
+			config: RetryConfig{
+				MaxAttempts: 1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid max_attempts typical value",
+			config: RetryConfig{
+				MaxAttempts: 5,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid max_attempts high value",
+			config: RetryConfig{
+				MaxAttempts: 100,
+			},
+			wantErr: false,
+		},
+
+		// Happy path: backoff strategy valid
+		{
+			name: "valid backoff constant strategy",
+			config: RetryConfig{
+				MaxAttempts: 3,
+				Backoff:     "constant",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid backoff linear strategy",
+			config: RetryConfig{
+				MaxAttempts: 3,
+				Backoff:     "linear",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid backoff exponential strategy",
+			config: RetryConfig{
+				MaxAttempts: 3,
+				Backoff:     "exponential",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid backoff empty strategy defaults",
+			config: RetryConfig{
+				MaxAttempts: 3,
+				Backoff:     "",
+			},
+			wantErr: false,
+		},
+
+		// Happy path: jitter valid
+		{
+			name: "valid jitter minimum value",
+			config: RetryConfig{
+				MaxAttempts: 2,
+				Jitter:      0.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid jitter maximum value",
+			config: RetryConfig{
+				MaxAttempts: 2,
+				Jitter:      1.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid jitter mid-range value",
+			config: RetryConfig{
+				MaxAttempts: 2,
+				Jitter:      0.5,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid jitter small positive value",
+			config: RetryConfig{
+				MaxAttempts: 2,
+				Jitter:      0.1,
+			},
+			wantErr: false,
+		},
+
+		// Happy path: multiplier valid
+		{
+			name: "valid multiplier zero value",
+			config: RetryConfig{
+				MaxAttempts: 2,
+				Multiplier:  0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid multiplier positive value",
+			config: RetryConfig{
+				MaxAttempts: 2,
+				Multiplier:  2.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid multiplier fractional value",
+			config: RetryConfig{
+				MaxAttempts: 2,
+				Multiplier:  1.5,
+			},
+			wantErr: false,
+		},
+
+		// Happy path: combined valid config
+		{
+			name: "valid complete retry config",
+			config: RetryConfig{
+				MaxAttempts:        3,
+				InitialDelayMs:     100,
+				MaxDelayMs:         5000,
+				Backoff:            "exponential",
+				Multiplier:         2.0,
+				Jitter:             0.2,
+				RetryableExitCodes: []int{1, 2, 3},
+			},
+			wantErr: false,
+		},
+
+		// Error paths: max_attempts invalid
+		{
+			name: "error max_attempts zero",
+			config: RetryConfig{
+				MaxAttempts: 0,
+			},
+			wantErr: true,
+			errMsg:  "max_attempts must be >= 1",
+		},
+		{
+			name: "error max_attempts negative",
+			config: RetryConfig{
+				MaxAttempts: -1,
+			},
+			wantErr: true,
+			errMsg:  "max_attempts must be >= 1",
+		},
+		{
+			name: "error max_attempts large negative",
+			config: RetryConfig{
+				MaxAttempts: -100,
+			},
+			wantErr: true,
+			errMsg:  "max_attempts must be >= 1",
+		},
+
+		// Error paths: backoff strategy invalid
+		{
+			name: "error backoff invalid strategy",
+			config: RetryConfig{
+				MaxAttempts: 2,
+				Backoff:     "fibonacci",
+			},
+			wantErr: true,
+			errMsg:  "invalid backoff strategy",
+		},
+		{
+			name: "error backoff misspelled strategy",
+			config: RetryConfig{
+				MaxAttempts: 2,
+				Backoff:     "exponental", //nolint:misspell // intentionally misspelled to test validation rejection
+			},
+			wantErr: true,
+			errMsg:  "invalid backoff strategy",
+		},
+		{
+			name: "error backoff random string",
+			config: RetryConfig{
+				MaxAttempts: 2,
+				Backoff:     "unknown",
+			},
+			wantErr: true,
+			errMsg:  "invalid backoff strategy",
+		},
+
+		// Error paths: jitter invalid
+		{
+			name: "error jitter negative",
+			config: RetryConfig{
+				MaxAttempts: 2,
+				Jitter:      -0.1,
+			},
+			wantErr: true,
+			errMsg:  "jitter must be between 0.0 and 1.0",
+		},
+		{
+			name: "error jitter exceeds maximum",
+			config: RetryConfig{
+				MaxAttempts: 2,
+				Jitter:      1.1,
+			},
+			wantErr: true,
+			errMsg:  "jitter must be between 0.0 and 1.0",
+		},
+		{
+			name: "error jitter far exceeds maximum",
+			config: RetryConfig{
+				MaxAttempts: 2,
+				Jitter:      5.0,
+			},
+			wantErr: true,
+			errMsg:  "jitter must be between 0.0 and 1.0",
+		},
+
+		// Error paths: multiplier invalid
+		{
+			name: "error multiplier negative",
+			config: RetryConfig{
+				MaxAttempts: 2,
+				Multiplier:  -0.5,
+			},
+			wantErr: true,
+			errMsg:  "multiplier must be >= 0",
+		},
+		{
+			name: "error multiplier large negative",
+			config: RetryConfig{
+				MaxAttempts: 2,
+				Multiplier:  -10.0,
+			},
+			wantErr: true,
+			errMsg:  "multiplier must be >= 0",
+		},
+
+		// Error paths: multiple violations (only first is reported)
+		{
+			name: "error max_attempts and jitter both invalid",
+			config: RetryConfig{
+				MaxAttempts: 0,
+				Jitter:      1.5,
+			},
+			wantErr: true,
+			errMsg:  "max_attempts must be >= 1",
+		},
+		{
+			name: "error max_attempts and multiplier both invalid",
+			config: RetryConfig{
+				MaxAttempts: -1,
+				Multiplier:  -1.0,
+			},
+			wantErr: true,
+			errMsg:  "max_attempts must be >= 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, tt.errMsg, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/repository/yaml_mapper.go
+++ b/internal/infrastructure/repository/yaml_mapper.go
@@ -130,7 +130,6 @@ func mapStep(filePath, name string, y *yamlStep) (*workflow.Step, error) {
 		Transitions:     mapTransitions(y.Transitions),
 		DependsOn:       y.DependsOn,
 		ContinueOnError: y.ContinueOnError,
-		Retry:           mapRetry(y.Retry),
 		Capture:         mapCapture(y.Capture),
 		Hooks:           mapStepHooks(y.Hooks),
 		Status:          workflow.TerminalStatus(y.Status),
@@ -141,6 +140,13 @@ func mapStep(filePath, name string, y *yamlStep) (*workflow.Step, error) {
 		CallWorkflow:    mapCallWorkflowFlat(y),
 		Agent:           mapAgentConfigFlat(y),
 	}
+
+	// Parse retry
+	retry, err := mapRetry(y.Retry)
+	if err != nil {
+		return nil, NewParseError(filePath, "states."+name+".retry", err.Error())
+	}
+	step.Retry = retry
 
 	// Parse timeout
 	if y.Timeout != "" {
@@ -179,23 +185,33 @@ func parseStepType(s string) (workflow.StepType, error) {
 }
 
 // mapRetry converts yamlRetry to domain RetryConfig.
-func mapRetry(y *yamlRetry) *workflow.RetryConfig {
+func mapRetry(y *yamlRetry) (*workflow.RetryConfig, error) {
 	if y == nil {
-		return nil
+		return nil, nil
 	}
 
 	initialDelayMs := 0
 	if y.InitialDelay != "" {
-		if d, err := parseDuration(y.InitialDelay); err == nil {
-			initialDelayMs = int(d.Milliseconds())
+		d, err := parseDuration(y.InitialDelay)
+		if err != nil {
+			return nil, fmt.Errorf("initial_delay: %w", err)
 		}
+		initialDelayMs = int(d.Milliseconds())
 	}
 
 	maxDelayMs := 0
 	if y.MaxDelay != "" {
-		if d, err := parseDuration(y.MaxDelay); err == nil {
-			maxDelayMs = int(d.Milliseconds())
+		d, err := parseDuration(y.MaxDelay)
+		if err != nil {
+			return nil, fmt.Errorf("max_delay: %w", err)
 		}
+		maxDelayMs = int(d.Milliseconds())
+	}
+
+	// Default multiplier to 2.0 when omitted (nil pointer means field was not set).
+	multiplier := 2.0
+	if y.Multiplier != nil {
+		multiplier = *y.Multiplier
 	}
 
 	return &workflow.RetryConfig{
@@ -203,10 +219,10 @@ func mapRetry(y *yamlRetry) *workflow.RetryConfig {
 		InitialDelayMs:     initialDelayMs,
 		MaxDelayMs:         maxDelayMs,
 		Backoff:            y.Backoff,
-		Multiplier:         y.Multiplier,
+		Multiplier:         multiplier,
 		Jitter:             y.Jitter,
 		RetryableExitCodes: y.RetryableExitCodes,
-	}
+	}, nil
 }
 
 // mapCapture converts yamlCapture to domain CaptureConfig.

--- a/internal/infrastructure/repository/yaml_mapper_test.go
+++ b/internal/infrastructure/repository/yaml_mapper_test.go
@@ -464,8 +464,8 @@ func TestMapStep_AgentStep(t *testing.T) {
 					MaxAttempts:  3,
 					InitialDelay: "1s",
 					MaxDelay:     "10s",
-					Backoff:      "2.0",
-					Multiplier:   2.0,
+					Backoff:      "exponential",
+					Multiplier:   func() *float64 { v := 2.0; return &v }(),
 				},
 			},
 			wantStep: func(t *testing.T, step *workflow.Step) {
@@ -1392,4 +1392,330 @@ func TestMapConversationConfig_StrategyMapping(t *testing.T) {
 			assert.Equal(t, tt.domainStrategy, got.Strategy)
 		})
 	}
+}
+
+// mapRetry Tests
+
+func TestMapRetry_NilInput(t *testing.T) {
+	got, err := mapRetry(nil)
+
+	assert.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestMapRetry_HappyPath(t *testing.T) {
+	tests := []struct {
+		name string
+		y    *yamlRetry
+		want *workflow.RetryConfig
+	}{
+		{
+			name: "all fields specified with multiplier",
+			y: &yamlRetry{
+				MaxAttempts:        3,
+				InitialDelay:       "100ms",
+				MaxDelay:           "5s",
+				Backoff:            "exponential",
+				Multiplier:         ptr(2.5),
+				Jitter:             0.1,
+				RetryableExitCodes: []int{1, 2},
+			},
+			want: &workflow.RetryConfig{
+				MaxAttempts:        3,
+				InitialDelayMs:     100,
+				MaxDelayMs:         5000,
+				Backoff:            "exponential",
+				Multiplier:         2.5,
+				Jitter:             0.1,
+				RetryableExitCodes: []int{1, 2},
+			},
+		},
+		{
+			name: "multiplier omitted defaults to 2.0",
+			y: &yamlRetry{
+				MaxAttempts:  2,
+				InitialDelay: "50ms",
+				MaxDelay:     "2s",
+				Backoff:      "linear",
+				Multiplier:   nil,
+				Jitter:       0.05,
+			},
+			want: &workflow.RetryConfig{
+				MaxAttempts:    2,
+				InitialDelayMs: 50,
+				MaxDelayMs:     2000,
+				Backoff:        "linear",
+				Multiplier:     2.0,
+				Jitter:         0.05,
+			},
+		},
+		{
+			name: "durations in go format",
+			y: &yamlRetry{
+				MaxAttempts:  2,
+				InitialDelay: "1s",
+				MaxDelay:     "10s",
+				Backoff:      "constant",
+			},
+			want: &workflow.RetryConfig{
+				MaxAttempts:    2,
+				InitialDelayMs: 1000,
+				MaxDelayMs:     10000,
+				Backoff:        "constant",
+				Multiplier:     2.0,
+			},
+		},
+		{
+			name: "durations as integer seconds",
+			y: &yamlRetry{
+				MaxAttempts:  3,
+				InitialDelay: "30",
+				MaxDelay:     "120",
+				Backoff:      "exponential",
+			},
+			want: &workflow.RetryConfig{
+				MaxAttempts:    3,
+				InitialDelayMs: 30000,
+				MaxDelayMs:     120000,
+				Backoff:        "exponential",
+				Multiplier:     2.0,
+			},
+		},
+		{
+			name: "empty delays default to 0ms",
+			y: &yamlRetry{
+				MaxAttempts:        1,
+				InitialDelay:       "",
+				MaxDelay:           "",
+				Backoff:            "constant",
+				RetryableExitCodes: nil,
+			},
+			want: &workflow.RetryConfig{
+				MaxAttempts:        1,
+				InitialDelayMs:     0,
+				MaxDelayMs:         0,
+				Backoff:            "constant",
+				Multiplier:         2.0,
+				RetryableExitCodes: nil,
+			},
+		},
+		{
+			name: "multiplier explicit zero is preserved",
+			y: &yamlRetry{
+				MaxAttempts:  1,
+				InitialDelay: "100ms",
+				Multiplier:   ptr(0.0),
+			},
+			want: &workflow.RetryConfig{
+				MaxAttempts:    1,
+				InitialDelayMs: 100,
+				Multiplier:     0.0,
+			},
+		},
+		{
+			name: "millisecond durations",
+			y: &yamlRetry{
+				MaxAttempts:  2,
+				InitialDelay: "500ms",
+				MaxDelay:     "30s",
+			},
+			want: &workflow.RetryConfig{
+				MaxAttempts:    2,
+				InitialDelayMs: 500,
+				MaxDelayMs:     30000,
+				Multiplier:     2.0,
+			},
+		},
+		{
+			name: "minute durations",
+			y: &yamlRetry{
+				MaxAttempts:  2,
+				InitialDelay: "1m",
+				MaxDelay:     "5m",
+			},
+			want: &workflow.RetryConfig{
+				MaxAttempts:    2,
+				InitialDelayMs: 60000,
+				MaxDelayMs:     300000,
+				Multiplier:     2.0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mapRetry(tt.y)
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want.MaxAttempts, got.MaxAttempts)
+			assert.Equal(t, tt.want.InitialDelayMs, got.InitialDelayMs)
+			assert.Equal(t, tt.want.MaxDelayMs, got.MaxDelayMs)
+			assert.Equal(t, tt.want.Backoff, got.Backoff)
+			assert.Equal(t, tt.want.Multiplier, got.Multiplier)
+			assert.Equal(t, tt.want.Jitter, got.Jitter)
+			assert.Equal(t, tt.want.RetryableExitCodes, got.RetryableExitCodes)
+		})
+	}
+}
+
+func TestMapRetry_ErrorPaths(t *testing.T) {
+	tests := []struct {
+		name        string
+		y           *yamlRetry
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "invalid initial_delay format",
+			y: &yamlRetry{
+				InitialDelay: "not-a-duration",
+				MaxAttempts:  1,
+			},
+			wantErr:     true,
+			errContains: "initial_delay",
+		},
+		{
+			name: "invalid max_delay format",
+			y: &yamlRetry{
+				InitialDelay: "100ms",
+				MaxDelay:     "invalid",
+				MaxAttempts:  1,
+			},
+			wantErr:     true,
+			errContains: "max_delay",
+		},
+		{
+			name: "initial_delay with invalid characters",
+			y: &yamlRetry{
+				InitialDelay: "100xs",
+				MaxAttempts:  1,
+			},
+			wantErr:     true,
+			errContains: "initial_delay",
+		},
+		{
+			name: "max_delay with invalid characters",
+			y: &yamlRetry{
+				MaxDelay:    "5z",
+				MaxAttempts: 1,
+			},
+			wantErr:     true,
+			errContains: "max_delay",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mapRetry(tt.y)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				assert.Nil(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.NotNil(t, got)
+		})
+	}
+}
+
+// parseDuration Tests
+
+func TestParseDuration_HappyPath(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want int64
+	}{
+		{
+			name: "milliseconds format",
+			s:    "100ms",
+			want: 100000000,
+		},
+		{
+			name: "seconds format",
+			s:    "30s",
+			want: 30000000000,
+		},
+		{
+			name: "minutes format",
+			s:    "2m",
+			want: 120000000000,
+		},
+		{
+			name: "hours format",
+			s:    "1h",
+			want: 3600000000000,
+		},
+		{
+			name: "combined format",
+			s:    "1m30s",
+			want: 90000000000,
+		},
+		{
+			name: "integer as seconds",
+			s:    "60",
+			want: 60000000000,
+		},
+		{
+			name: "single digit integer",
+			s:    "5",
+			want: 5000000000,
+		},
+		{
+			name: "zero",
+			s:    "0",
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDuration(tt.s)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got.Nanoseconds())
+		})
+	}
+}
+
+func TestParseDuration_ErrorPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+	}{
+		{
+			name: "invalid format",
+			s:    "not-a-duration",
+		},
+		{
+			name: "invalid unit",
+			s:    "100xs",
+		},
+		{
+			name: "invalid characters",
+			s:    "abc",
+		},
+		{
+			name: "float seconds without unit",
+			s:    "1.5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDuration(tt.s)
+
+			require.Error(t, err)
+			assert.Equal(t, int64(0), got.Nanoseconds())
+		})
+	}
+}
+
+// Helper function to create a pointer to float64
+func ptr(f float64) *float64 {
+	return &f
 }

--- a/internal/infrastructure/repository/yaml_types.go
+++ b/internal/infrastructure/repository/yaml_types.go
@@ -107,13 +107,13 @@ type yamlInputValidation struct {
 
 // yamlRetry is the YAML representation of retry configuration.
 type yamlRetry struct {
-	MaxAttempts        int     `yaml:"max_attempts"`
-	InitialDelay       string  `yaml:"initial_delay"`
-	MaxDelay           string  `yaml:"max_delay"`
-	Backoff            string  `yaml:"backoff"`
-	Multiplier         float64 `yaml:"multiplier"`
-	Jitter             float64 `yaml:"jitter"`
-	RetryableExitCodes []int   `yaml:"retryable_exit_codes"`
+	MaxAttempts        int      `yaml:"max_attempts"`
+	InitialDelay       string   `yaml:"initial_delay"`
+	MaxDelay           string   `yaml:"max_delay"`
+	Backoff            string   `yaml:"backoff"`
+	Multiplier         *float64 `yaml:"multiplier"`
+	Jitter             float64  `yaml:"jitter"`
+	RetryableExitCodes []int    `yaml:"retryable_exit_codes"`
 }
 
 // yamlCapture is the YAML representation of capture configuration.

--- a/pkg/retry/backoff.go
+++ b/pkg/retry/backoff.go
@@ -48,7 +48,7 @@ func CalculateDelay(strategy Strategy, attempt int, initialDelay, maxDelay time.
 		delay = initialDelay
 	}
 
-	if delay > maxDelay {
+	if maxDelay > 0 && delay > maxDelay {
 		delay = maxDelay
 	}
 

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -51,7 +51,7 @@ func TestCalculateDelay(t *testing.T) {
 		{name: "constant zero initial delay", strategy: StrategyConstant, attempt: 5, initialDelay: 0, maxDelay: 30 * time.Second, multiplier: 2.0, want: 0},
 		{name: "linear zero initial delay", strategy: StrategyLinear, attempt: 5, initialDelay: 0, maxDelay: 30 * time.Second, multiplier: 2.0, want: 0},
 		{name: "exponential zero initial delay", strategy: StrategyExponential, attempt: 5, initialDelay: 0, maxDelay: 30 * time.Second, multiplier: 2.0, want: 0},
-		{name: "exponential max delay zero", strategy: StrategyExponential, attempt: 5, initialDelay: 1 * time.Second, maxDelay: 0, multiplier: 2.0, want: 0},
+		{name: "exponential max delay zero", strategy: StrategyExponential, attempt: 5, initialDelay: 1 * time.Second, maxDelay: 0, multiplier: 2.0, want: 16 * time.Second},
 		{name: "constant attempt 1", strategy: StrategyConstant, attempt: 1, initialDelay: 1 * time.Second, maxDelay: 30 * time.Second, multiplier: 2.0, want: 1 * time.Second},
 	}
 
@@ -125,6 +125,86 @@ func TestApplyJitter(t *testing.T) {
 
 		assert.Equal(t, got1, got2)
 	})
+}
+
+// TestCalculateDelay_MaxDelayGuard verifies the maxDelay > 0 guard prevents
+// silently capping delays to zero when maxDelay is omitted (found = 0).
+func TestCalculateDelay_MaxDelayGuard(t *testing.T) {
+	tests := []struct {
+		name         string
+		strategy     Strategy
+		attempt      int
+		initialDelay time.Duration
+		maxDelay     time.Duration
+		multiplier   float64
+		want         time.Duration
+	}{
+		// When maxDelay=0, delay should NOT be capped to zero.
+		// This tests the guard: if maxDelay > 0 && delay > maxDelay
+		{
+			name:         "exponential with zero max_delay should return computed delay",
+			strategy:     StrategyExponential,
+			attempt:      3,
+			initialDelay: 1 * time.Second,
+			maxDelay:     0, // No cap
+			multiplier:   2.0,
+			want:         4 * time.Second, // 1s * 2^(3-1) = 4s, NOT capped to 0
+		},
+		{
+			name:         "linear with zero max_delay should return computed delay",
+			strategy:     StrategyLinear,
+			attempt:      5,
+			initialDelay: 1 * time.Second,
+			maxDelay:     0, // No cap
+			multiplier:   2.0,
+			want:         5 * time.Second, // 1s * 5 = 5s, NOT capped to 0
+		},
+		{
+			name:         "constant with zero max_delay returns initial delay",
+			strategy:     StrategyConstant,
+			attempt:      10,
+			initialDelay: 2 * time.Second,
+			maxDelay:     0, // No cap
+			multiplier:   1.0,
+			want:         2 * time.Second, // constant = initial, NOT capped to 0
+		},
+		// When maxDelay > 0, delays SHOULD still be capped normally.
+		{
+			name:         "exponential capped when max_delay is set and delay exceeds it",
+			strategy:     StrategyExponential,
+			attempt:      6,
+			initialDelay: 1 * time.Second,
+			maxDelay:     30 * time.Second,
+			multiplier:   2.0,
+			want:         30 * time.Second, // 1s * 2^5 = 32s → capped to 30s
+		},
+		{
+			name:         "linear capped when max_delay is set",
+			strategy:     StrategyLinear,
+			attempt:      100,
+			initialDelay: 1 * time.Second,
+			maxDelay:     60 * time.Second,
+			multiplier:   1.0,
+			want:         60 * time.Second, // 1s * 100 = 100s → capped to 60s
+		},
+		// Edge case: very small but positive maxDelay still caps.
+		{
+			name:         "exponential capped to 1ms when max_delay=1ms",
+			strategy:     StrategyExponential,
+			attempt:      5,
+			initialDelay: 100 * time.Millisecond,
+			maxDelay:     1 * time.Millisecond,
+			multiplier:   2.0,
+			want:         1 * time.Millisecond, // computed 6.4s → capped to 1ms
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CalculateDelay(tt.strategy, tt.attempt, tt.initialDelay, tt.maxDelay, tt.multiplier)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestShouldRetry(t *testing.T) {

--- a/tests/fixtures/workflows/conversation-error.yaml
+++ b/tests/fixtures/workflows/conversation-error.yaml
@@ -29,7 +29,7 @@ states:
     timeout: 45
     retry:
       max_attempts: 3
-      delay: 2s
+      initial_delay: 2s
       backoff: exponential
     hooks:
       pre:

--- a/tests/fixtures/workflows/retry-audit.yaml
+++ b/tests/fixtures/workflows/retry-audit.yaml
@@ -1,0 +1,28 @@
+name: retry-audit
+description: Retry configuration fixture with all fields for C064 audit testing
+version: "1.0.0"
+
+states:
+  initial: run
+
+  run:
+    type: step
+    command: echo "ok"
+    retry:
+      max_attempts: 3
+      initial_delay: 200ms
+      max_delay: 2s
+      backoff: exponential
+      multiplier: 2.0
+      jitter: 0.3
+      retryable_exit_codes: [1, 2]
+    on_success: done
+    on_failure: error
+
+  done:
+    type: terminal
+    status: success
+
+  error:
+    type: terminal
+    status: failure

--- a/tests/integration/execution/retry_audit_test.go
+++ b/tests/integration/execution/retry_audit_test.go
@@ -1,0 +1,196 @@
+//go:build integration
+
+// Feature: C064
+package execution_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/awf-project/cli/internal/application"
+	"github.com/awf-project/cli/internal/infrastructure/executor"
+	infraExpr "github.com/awf-project/cli/internal/infrastructure/expression"
+	"github.com/awf-project/cli/internal/infrastructure/repository"
+	"github.com/awf-project/cli/pkg/interpolation"
+)
+
+// newRetryAuditServices creates a fresh set of services for retry audit tests.
+func newRetryAuditServices(workflowDir string) *application.ExecutionService {
+	repo := repository.NewYAMLRepository(workflowDir)
+	store := newRetryMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &retryMockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger, infraExpr.NewExprValidator())
+	parallelExec := application.NewParallelExecutor(logger)
+
+	return application.NewExecutionService(wfSvc, exec, parallelExec, store, logger, resolver, nil)
+}
+
+// TestRetry_MultiplierDefault_Integration verifies that omitting the multiplier
+// field in YAML produces exponential growth (default 2.0), not constant delays.
+func TestRetry_MultiplierDefault_Integration(t *testing.T) {
+	tmpDir := t.TempDir()
+	counterFile := filepath.Join(tmpDir, "counter")
+	tsFile := filepath.Join(tmpDir, "timestamps")
+
+	// Exponential backoff WITHOUT multiplier — should default to 2.0
+	wfYAML := `name: retry-multiplier-default
+version: "1.0.0"
+states:
+  initial: run
+  run:
+    type: step
+    command: |
+      COUNT=$(cat "` + counterFile + `" 2>/dev/null || echo "0")
+      COUNT=$((COUNT + 1))
+      echo $COUNT > "` + counterFile + `"
+      date +%s%N >> "` + tsFile + `"
+      if [ $COUNT -lt 3 ]; then exit 1; fi
+      exit 0
+    retry:
+      max_attempts: 4
+      initial_delay: 50ms
+      backoff: exponential
+    on_success: done
+    on_failure: error
+  done:
+    type: terminal
+  error:
+    type: terminal
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "retry-multiplier-default.yaml"), []byte(wfYAML), 0o644))
+
+	execSvc := newRetryAuditServices(tmpDir)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	execCtx, err := execSvc.Run(ctx, "retry-multiplier-default", nil)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, "done", execCtx.CurrentStep)
+
+	// With default multiplier 2.0: delay1=50ms, delay2=100ms → total ≥ 150ms
+	// With broken multiplier 0.0: both delays would be 0ms
+	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond, "exponential backoff with default multiplier should produce meaningful delays")
+}
+
+// TestRetry_InvalidDurationRejected_Integration verifies that a malformed duration
+// string in retry config produces a parse error instead of silently defaulting to 0ms.
+func TestRetry_InvalidDurationRejected_Integration(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	wfYAML := `name: retry-bad-duration
+version: "1.0.0"
+states:
+  initial: run
+  run:
+    type: step
+    command: echo "never runs"
+    retry:
+      max_attempts: 3
+      initial_delay: "not-a-duration"
+    on_success: done
+    on_failure: error
+  done:
+    type: terminal
+  error:
+    type: terminal
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "retry-bad-duration.yaml"), []byte(wfYAML), 0o644))
+
+	execSvc := newRetryAuditServices(tmpDir)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := execSvc.Run(ctx, "retry-bad-duration", nil)
+	require.Error(t, err, "invalid duration string should be rejected at parse time")
+	assert.Contains(t, err.Error(), "initial_delay")
+}
+
+// TestRetry_ValidationRejectsInvalidConfig_Integration verifies that domain validation
+// catches invalid retry configurations (e.g., max_attempts < 1, invalid backoff strategy).
+func TestRetry_ValidationRejectsInvalidConfig_Integration(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name    string
+		wfYAML  string
+		wantErr string
+	}{
+		{
+			name: "invalid backoff strategy",
+			wfYAML: "name: retry-invalid-backoff\nversion: \"1.0.0\"\nstates:\n  initial: run\n  run:\n    type: step\n    command: echo \"never runs\"\n    retry:\n      max_attempts: 3\n      backoff: random\n    on_success: done\n    on_failure: error\n  done:\n    type: terminal\n  error:\n    type: terminal\n",
+			wantErr: "backoff",
+		},
+		{
+			name: "jitter out of range",
+			wfYAML: "name: retry-invalid-jitter\nversion: \"1.0.0\"\nstates:\n  initial: run\n  run:\n    type: step\n    command: echo \"never runs\"\n    retry:\n      max_attempts: 3\n      jitter: 2.0\n    on_success: done\n    on_failure: error\n  done:\n    type: terminal\n  error:\n    type: terminal\n",
+			wantErr: "jitter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wfName := filepath.Base(tt.name)
+			require.NoError(t, os.WriteFile(filepath.Join(tmpDir, wfName+".yaml"), []byte(tt.wfYAML), 0o644))
+
+			execSvc := newRetryAuditServices(tmpDir)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			_, err := execSvc.Run(ctx, wfName, nil)
+			require.Error(t, err, "invalid retry config should be rejected")
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestDryRun_RetryAllFieldsMapped_Integration verifies that the dry-run executor
+// maps all 7 retry fields (including Jitter and RetryableExitCodes) from domain to output.
+func TestDryRun_RetryAllFieldsMapped_Integration(t *testing.T) {
+	fixturesDir := "../../fixtures/workflows"
+
+	repo := repository.NewYAMLRepository(fixturesDir)
+	store := newRetryMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &retryMockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger, infraExpr.NewExprValidator())
+
+	dryRunExec := application.NewDryRunExecutor(wfSvc, resolver, infraExpr.NewExprEvaluator(), logger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	plan, err := dryRunExec.Execute(ctx, "retry-audit", nil)
+	require.NoError(t, err)
+
+	found := false
+	for _, step := range plan.Steps {
+		if step.Retry == nil {
+			continue
+		}
+
+		assert.Equal(t, 3, step.Retry.MaxAttempts)
+		assert.Equal(t, 200, step.Retry.InitialDelayMs)
+		assert.Equal(t, 2000, step.Retry.MaxDelayMs)
+		assert.Equal(t, "exponential", step.Retry.Backoff)
+		assert.Equal(t, 2.0, step.Retry.Multiplier)
+		assert.Equal(t, 0.3, step.Retry.Jitter, "Jitter must be mapped to DryRunRetry")
+		assert.Equal(t, []int{1, 2}, step.Retry.RetryableExitCodes, "RetryableExitCodes must be mapped to DryRunRetry")
+		found = true
+		break
+	}
+	require.True(t, found, "fixture must contain a step with retry configuration")
+}

--- a/tests/integration/execution/retry_test.go
+++ b/tests/integration/execution/retry_test.go
@@ -504,6 +504,74 @@ states:
 	assert.Less(t, elapsed, 2*time.Second, "delays should be capped at max_delay")
 }
 
+func TestRetry_NoMaxDelay_Integration(t *testing.T) {
+	tmpDir := t.TempDir()
+	counterFile := filepath.Join(tmpDir, "counter")
+
+	// Workflow with exponential backoff but NO max_delay — omitting max_delay
+	// previously mapped to maxDelay=0, which silently capped all delays to zero.
+	// With the guard fix (maxDelay > 0), delays should be uncapped and meaningful.
+	wfYAML := `name: retry-no-max-delay
+version: "1.0.0"
+states:
+  initial: exp_no_cap
+  exp_no_cap:
+    type: step
+    command: |
+      COUNT=$(cat "` + counterFile + `" 2>/dev/null || echo "0")
+      COUNT=$((COUNT + 1))
+      echo $COUNT > "` + counterFile + `"
+      if [ $COUNT -lt 3 ]; then
+        exit 1
+      fi
+      exit 0
+    retry:
+      max_attempts: 5
+      initial_delay: 50ms
+      backoff: exponential
+      multiplier: 2
+    on_success: done
+    on_failure: error
+  done:
+    type: terminal
+  error:
+    type: terminal
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "retry-no-max-delay.yaml"), []byte(wfYAML), 0o644)
+	require.NoError(t, err)
+
+	repo := repository.NewYAMLRepository(tmpDir)
+	store := newRetryMockStateStore()
+	exec := executor.NewShellExecutor()
+	logger := &retryMockLogger{}
+	resolver := interpolation.NewTemplateResolver()
+
+	wfSvc := application.NewWorkflowService(repo, store, exec, logger, infraExpr.NewExprValidator())
+	parallelExec := application.NewParallelExecutor(logger)
+	execSvc := application.NewExecutionService(wfSvc, exec, parallelExec, store, logger, resolver, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	execCtx, err := execSvc.Run(ctx, "retry-no-max-delay", nil)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, "done", execCtx.CurrentStep, "should succeed after retries")
+
+	// With exponential backoff (no max_delay cap) requiring 3 attempts:
+	// - Attempt 2: after ~50ms (initial_delay * multiplier^0)
+	// - Attempt 3: after ~100ms (initial_delay * multiplier^1)
+	// Total minimum: ~150ms — assert 100ms to give CI headroom.
+	// Before the fix, maxDelay=0 capped all delays to 0ms and retries happened instantly.
+	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond, "delays should not be capped to zero when max_delay is omitted")
+
+	counterData, err := os.ReadFile(counterFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(counterData), "3", "should have made 3 attempts")
+}
+
 func TestRetry_NoRetryOnSuccess_Integration(t *testing.T) {
 	tmpDir := t.TempDir()
 	counterFile := filepath.Join(tmpDir, "counter")


### PR DESCRIPTION
## Summary

- Audited the retry subsystem and fixed 7 gaps where documentation diverged from implementation or implementation had silent failure modes
- Critical bug: `CalculateDelay()` silently capped all delays to zero when `max_delay` was omitted; fixed with a guard in `backoff.go`
- High-severity bug: YAML mapper defaulted `multiplier` to 0.0 when omitted, degrading exponential backoff to constant delays; fixed by using pointer detection to apply a 2.0 default
- Added `RetryConfig.Validate()` for structural validation, surface duration parse errors instead of silent defaults, expanded `DryRunRetry` to include missing fields, and created a comprehensive retry user guide

## Changes

### Domain
- `internal/domain/workflow/step.go`: Add `RetryConfig.Validate()` with checks for `max_attempts >= 1`, valid backoff strategy, `jitter ∈ [0.0, 1.0]`, `multiplier >= 0`; wire into `Step.Validate()`
- `internal/domain/workflow/dry_run.go`: Add missing `Jitter` and `RetryableExitCodes` fields to `DryRunRetry` struct

### Infrastructure
- `internal/infrastructure/repository/yaml_mapper.go`: Surface duration parse errors from `mapRetry()` instead of silently defaulting to 0ms; remove redundant "retry." prefix from error messages; default `multiplier` to 2.0 via pointer detection
- `internal/infrastructure/repository/yaml_types.go`: Change `Multiplier` field to pointer type (`*float64`) to distinguish omitted from explicit zero
- `tests/fixtures/workflows/conversation-error.yaml`: Rename non-existent `delay:` field to `initial_delay:`

### Application
- `internal/application/dry_run_executor.go`: Map new `Jitter` and `RetryableExitCodes` fields from `RetryConfig` into `DryRunRetry`

### Package
- `pkg/retry/backoff.go`: Guard `CalculateDelay()` against `maxDelay=0` silently capping all delays to zero

### Documentation
- `docs/user-guide/retry.md`: New comprehensive retry configuration guide (418 lines) covering backoff strategies, delay capping, jitter, exit code filtering, and validation
- `docs/user-guide/workflow-syntax.md`: Replace deprecated `initial_delay_ms` with `initial_delay` duration string syntax
- `docs/user-guide/examples.md`: Replace deprecated `initial_delay_ms` with `initial_delay: 1s`
- `docs/user-guide/plugins.md`: Replace deprecated `initial_delay_ms` with `initial_delay: 1s`
- `docs/README.md`: Add link to new retry configuration guide
- `CHANGELOG.md`: Document all 7 findings and fixes for C064
- `CLAUDE.md`: Add two new architecture rules on pointer types for optional fields and error surfacing

### Tests
- `internal/domain/workflow/step_retry_test.go`: New file — 285-line table-driven test suite for `RetryConfig.Validate()` covering all validation rules
- `internal/domain/workflow/step_command_test.go`: Add tests for `Step.Validate()` wiring to retry validation
- `internal/infrastructure/repository/yaml_mapper_test.go`: Extend with tests for multiplier default, duration error propagation, and corrected `Backoff` fixture value
- `internal/application/dry_run_executor_test.go`: Consolidate 4 duplicate dry-run retry test functions into single table-driven test; add assertions for `Jitter` and `RetryableExitCodes`
- `pkg/retry/retry_test.go`: Add tests for `maxDelay=0` guard in `CalculateDelay()`
- `tests/integration/execution/retry_audit_test.go`: New file — integration tests for retry validation, multiplier default, and duration error surfacing
- `tests/integration/execution/retry_test.go`: Add integration tests for `maxDelay` guard and no-max-delay behavior
- `tests/fixtures/workflows/retry-audit.yaml`: New fixture for retry audit integration tests

## Test plan

- [ ] Unit tests pass: `make test-unit` — verify `RetryConfig.Validate()`, `CalculateDelay()` guard, and YAML multiplier default
- [ ] Integration tests pass: `make test-integration` — verify retry audit scenarios in `retry_audit_test.go` and `retry_test.go`
- [ ] Confirm `max_delay` omission no longer zeroes delays: workflow with `backoff: exponential` and no `max_delay` produces increasing delays
- [ ] Confirm `multiplier` omission defaults to 2.0: YAML with no `multiplier` field produces exponential delays doubling each attempt

Closes #268

---
Generated with [awf](https://github.com/Pмузlcky/awf) commit workflow

