### PR TITLE
feat(conversation): add inject_context mid-conversation enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- **F074**: `continue_from` field in conversation steps now resumes a prior step's session — CLI providers hand off session ID, `openai_compatible` loads turn history
-
 ### Fixed
 - **F073**: Documentation corrections for conversation mode
   - Corrected false claim about history serialization in CLI providers (`conversation-steps.md`)
@@ -52,6 +49,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New unit and integration tests covering transition priority on execution errors
 
 ### Added
+- **F075**: `inject_context` field in conversation steps appends interpolated context to user prompts on turns 2+
+    - Template variables (`{{.states.*}}`, `{{.inputs.*}}`, `{{.env.*}}`, `{{.workflow.*}}`) re-interpolated per turn to capture latest state
+    - First-turn exclusion: `inject_context` is excluded from turn 1, keeping `initial_prompt` clean
+    - Empty or whitespace-only values treated as no injection (no-op)
+    - Errors wrapped with field-specific context (`inject_context: <error>`) for debugging
+    - Removed C062 validation guard (`"inject_context is not yet implemented"`)
+    - Added FR-002 mode validation: `inject_context` rejected when `mode` is not `conversation`
+    - Documentation in `conversation-steps.md` and `workflow-syntax.md` updated
+- **F074**: `continue_from` field in conversation steps now resumes a prior step's session — CLI providers hand off session ID, `openai_compatible` loads turn history
 - **F073**: Session resume for CLI providers
     - Multi-turn conversations with CLI-based providers (`claude`, `codex`, `gemini`, `opencode`) now maintain context across turns via native session resume flags (`-r`, `resume`, `--resume`, `-s`). Previously, each turn was stateless.
     - `SessionID` field on `ConversationState` domain entity for session persistence
@@ -238,6 +244,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Zero breaking changes: all existing consumers compile unchanged
 
 ### Added
+- **F075**: Inject Context — Mid-Conversation Context Enrichment
 - **F071**: Structured Audit Trail for Workflow Executions
 - **F070**: Replace Custom Agent Provider with OpenAI-Compatible Provider
 - **F066**: Inline Error Terminal Shorthand for on_failure
@@ -477,6 +484,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Affects: Template interpolation, workflow validation, all state references
 
 ### Added
+- **F075**: Inject Context — Mid-Conversation Context Enrichment
 - **F071**: Structured Audit Trail for Workflow Executions
 - **F070**: Replace Custom Agent Provider with OpenAI-Compatible Provider
 - **F066**: Inline Error Terminal Shorthand for on_failure

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Go CLI tool for orchestrating AI agents (Claude, Gemini, Codex, OpenAI-Compati
 - **Output Formatting for Agent Steps** - Automatically strip markdown code fences and validate JSON output
 - **External Prompt Files** - Load agent prompts from `.md` files with full template interpolation, helper functions, and local override support
 - **External Script Files** - Load commands from external script files with shebang-based interpreter dispatch, template interpolation, path resolution, and local override support
-- **Conversation Mode** - Multi-turn conversations with native session resume for CLI providers (`claude`, `codex`, `gemini`, `opencode`) and automatic context window management for HTTP providers, with token tracking across all turns
+- **Conversation Mode** - Multi-turn conversations with native session resume for CLI providers (`claude`, `codex`, `gemini`, `opencode`), automatic context window management for HTTP providers, mid-conversation context injection via `inject_context` field, and token tracking across all turns
 - **OpenAI-Compatible Provider** - Use any Chat Completions API (OpenAI, Ollama, vLLM, Groq) with native HTTP integration, accurate token reporting, and no CLI tool required
 - **Parallel Execution** - Run multiple steps concurrently with configurable strategies
 - **Loop Constructs** - For-each and while loops with full context access

--- a/docs/user-guide/conversation-steps.md
+++ b/docs/user-guide/conversation-steps.md
@@ -74,7 +74,7 @@ states:
 | `provider` | string | Yes | — | Agent provider: `claude`, `codex`, `gemini`, `opencode`, `openai_compatible` |
 | `system_prompt` | string | No | — | System message for the entire conversation (preserved during truncation) |
 | `initial_prompt` | string | Yes | — | Initial user message to start the conversation |
-| `prompt` | string | No | — | Used when injecting context mid-conversation (see [Injecting Context](#injecting-context)) |
+| `prompt` | string | No | — | Used when injecting context mid-conversation (see [Injecting Context](#injecting-context-mid-conversation)) |
 | `options` | object | No | — | Provider-specific options (model, max_tokens, temperature, etc.) |
 | `timeout` | duration | No | `300s` | Timeout for each turn |
 | `on_success` | string | Yes | — | Next state on successful completion |
@@ -552,6 +552,49 @@ refine:
   on_success: done
 ```
 
+## Injecting Context Mid-Conversation
+
+The `inject_context` field enriches ongoing conversations with additional context after the first turn. This is useful for passing results from other steps or static reference material without cluttering `initial_prompt`.
+
+### How It Works
+
+- **Turn 1**: Only `initial_prompt` (or `prompt`) is sent — `inject_context` is excluded
+- **Turn 2+**: The interpolated `inject_context` content is appended to the user prompt, separated by two newlines
+- **Per-turn interpolation**: Template variables are re-evaluated each turn, so `{{.states.*}}` references reflect the latest available state
+
+### Example: Injecting Step Results
+
+```yaml
+states:
+  initial: run_tests
+
+  run_tests:
+    type: step
+    command: "make test"
+    on_success: review
+
+  review:
+    type: agent
+    provider: claude
+    mode: conversation
+    initial_prompt: "Review the codebase for quality issues"
+    conversation:
+      max_turns: 5
+      inject_context: |
+        Test results from the previous step:
+        {{.states.run_tests.output}}
+      stop_condition: "response contains 'APPROVED'"
+    on_success: done
+```
+
+In this example, the agent receives only the review prompt on turn 1. On turns 2 through 5, each user prompt also includes the interpolated test results.
+
+### Edge Cases
+
+- **Empty or whitespace-only**: Treated as no injection — nothing appended
+- **Missing state references**: Template resolves to empty string (no error)
+- **With `continue_from`**: Both work together — `continue_from` resumes the session, `inject_context` enriches subsequent turns
+
 ## Limitations
 
 ### Provider Compatibility
@@ -564,7 +607,6 @@ All providers support conversation mode with context continuity:
 ### Current Implementation
 
 - Only `sliding_window` strategy implemented (dropping oldest turns); `summarize` and `truncate_middle` are rejected at validation
-- `inject_context` field is parsed but not yet implemented; using it produces a validation error
 - Stop conditions limited to string/token/turn expressions
 - No branching conversations (single linear path)
 
@@ -572,7 +614,6 @@ All providers support conversation mode with context continuity:
 
 - `summarize` strategy (LLM-based compression of old turns)
 - `truncate_middle` strategy (keep first and last turns)
-- `inject_context` for adding context mid-conversation
 - Conversation branching (explore multiple paths)
 
 ## See Also

--- a/docs/user-guide/workflow-syntax.md
+++ b/docs/user-guide/workflow-syntax.md
@@ -443,7 +443,7 @@ refine_code:
 | `strategy` | string | `-` | Context window strategy: `sliding_window`, `summarize` (not yet implemented), `truncate_middle` (not yet implemented). Omitting means no context management is applied |
 | `stop_condition` | string | - | Expression to exit early |
 | `continue_from` | string | - | Step name to continue conversation from — resumes prior step's session |
-| `inject_context` | string | - | Additional context to inject mid-conversation (not yet implemented) |
+| `inject_context` | string | - | Additional context to inject into user prompts on turns 2+. Supports template variables (`{{.states.*}}`, `{{.inputs.*}}`, etc.). Re-interpolated per turn. |
 
 ### Available Providers
 

--- a/internal/application/conversation_manager.go
+++ b/internal/application/conversation_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/awf-project/cli/internal/domain/ports"
 	"github.com/awf-project/cli/internal/domain/workflow"
@@ -241,6 +242,16 @@ func (m *ConversationManager) ExecuteConversation(
 		resolvedPrompt, err = m.resolver.Resolve(step.Agent.Prompt, intCtx)
 		if err != nil {
 			return nil, err
+		}
+
+		if config.InjectContext != "" {
+			resolvedInjectContext, injectErr := m.resolver.Resolve(config.InjectContext, intCtx)
+			if injectErr != nil {
+				return nil, fmt.Errorf("inject_context: %w", injectErr)
+			}
+			if trimmed := strings.TrimSpace(resolvedInjectContext); trimmed != "" {
+				resolvedPrompt = resolvedPrompt + "\n\n" + trimmed
+			}
 		}
 	}
 

--- a/internal/application/conversation_manager_test.go
+++ b/internal/application/conversation_manager_test.go
@@ -1857,3 +1857,315 @@ func TestConversationManager_ContinueFrom_ThreeStepChain(t *testing.T) {
 	// This proves O(1) per-hop: step3 doesn't recursively load step1
 	assert.Equal(t, 4, step3InitialTurnCount)
 }
+
+// T004: Implement inject_context appending on turn 2+
+
+func TestConversationManager_InjectContext_AppendedOnSecondTurn(t *testing.T) {
+	logger := &mockLogger{}
+	evaluator := newMockExpressionEvaluator()
+	resolver := newConfigurableMockResolver()
+	resolver.results["What is AI?"] = "What is AI?"
+	resolver.results["Additional context from step1"] = "Additional context from step1"
+	tokenizer := newMockTokenizer()
+	registry := mocks.NewMockAgentRegistry()
+
+	var capturedPrompts []string
+	mockProvider := mocks.NewMockAgentProvider("claude")
+
+	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+		capturedPrompts = append(capturedPrompts, prompt)
+		result := workflow.NewConversationResult("claude")
+		result.State = state
+		assistantTurn := workflow.NewTurn(workflow.TurnRoleAssistant, "response")
+		assistantTurn.Tokens = 10
+		_ = result.State.AddTurn(workflow.NewTurn(workflow.TurnRoleUser, prompt))
+		_ = result.State.AddTurn(assistantTurn)
+		result.Output = "response"
+		return result, nil
+	})
+
+	_ = registry.Register(mockProvider)
+	manager := application.NewConversationManager(logger, evaluator, resolver, tokenizer, registry)
+
+	step := &workflow.Step{
+		Name: "chat",
+		Type: workflow.StepTypeAgent,
+		Agent: &workflow.AgentConfig{
+			Provider: "claude",
+			Prompt:   "What is AI?",
+		},
+	}
+
+	config := &workflow.ConversationConfig{
+		MaxTurns:      3,
+		InjectContext: "Additional context from step1",
+	}
+
+	execCtx := workflow.NewExecutionContext("test-id", "test-workflow")
+	execCtx.States = make(map[string]workflow.StepState)
+
+	buildContext := func(ec *workflow.ExecutionContext) *interpolation.Context {
+		return interpolation.NewContext()
+	}
+
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, capturedPrompts, 3, "should have 3 turn prompts")
+
+	// Turn 1: no inject_context
+	assert.Equal(t, "What is AI?", capturedPrompts[0], "turn 1 should not contain inject_context")
+
+	// Turn 2+: inject_context appended with \n\n separator
+	expectedPrompt2 := "What is AI?\n\nAdditional context from step1"
+	assert.Equal(t, expectedPrompt2, capturedPrompts[1], "turn 2 should have inject_context appended with \\n\\n separator")
+
+	expectedPrompt3 := "What is AI?\n\nAdditional context from step1"
+	assert.Equal(t, expectedPrompt3, capturedPrompts[2], "turn 3 should have inject_context appended with \\n\\n separator")
+}
+
+func TestConversationManager_InjectContext_ExcludedFromFirstTurn(t *testing.T) {
+	logger := &mockLogger{}
+	evaluator := newMockExpressionEvaluator()
+	resolver := newConfigurableMockResolver()
+	resolver.results["What is AI?"] = "What is AI?"
+	resolver.results["Additional context from step1"] = "Additional context from step1"
+	tokenizer := newMockTokenizer()
+	registry := mocks.NewMockAgentRegistry()
+
+	var capturedPrompts []string
+	mockProvider := mocks.NewMockAgentProvider("claude")
+
+	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+		capturedPrompts = append(capturedPrompts, prompt)
+		result := workflow.NewConversationResult("claude")
+		result.State = state
+		assistantTurn := workflow.NewTurn(workflow.TurnRoleAssistant, "response")
+		assistantTurn.Tokens = 10
+		_ = result.State.AddTurn(workflow.NewTurn(workflow.TurnRoleUser, prompt))
+		_ = result.State.AddTurn(assistantTurn)
+		result.Output = "response"
+		return result, nil
+	})
+
+	_ = registry.Register(mockProvider)
+	manager := application.NewConversationManager(logger, evaluator, resolver, tokenizer, registry)
+
+	step := &workflow.Step{
+		Name: "chat",
+		Type: workflow.StepTypeAgent,
+		Agent: &workflow.AgentConfig{
+			Provider: "claude",
+			Prompt:   "What is AI?",
+		},
+	}
+
+	config := &workflow.ConversationConfig{
+		MaxTurns:      1,
+		InjectContext: "Additional context from step1",
+	}
+
+	execCtx := workflow.NewExecutionContext("test-id", "test-workflow")
+	execCtx.States = make(map[string]workflow.StepState)
+
+	buildContext := func(ec *workflow.ExecutionContext) *interpolation.Context {
+		return interpolation.NewContext()
+	}
+
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, capturedPrompts, 1, "should have 1 turn prompt")
+
+	assert.Equal(t, "What is AI?", capturedPrompts[0], "turn 1 should not contain inject_context")
+}
+
+// T006: empty/whitespace inject_context must be a no-op (FR-005)
+
+func TestConversationManager_InjectContext_EmptyIsNoOp(t *testing.T) {
+	tests := []struct {
+		name          string
+		injectContext string
+	}{
+		{"empty string", ""},
+		{"whitespace only", "   \t\n  "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := &mockLogger{}
+			evaluator := newMockExpressionEvaluator()
+			resolver := newConfigurableMockResolver()
+			resolver.results["What is AI?"] = "What is AI?"
+			tokenizer := newMockTokenizer()
+			registry := mocks.NewMockAgentRegistry()
+
+			var capturedPrompts []string
+			mockProvider := mocks.NewMockAgentProvider("claude")
+
+			mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+				capturedPrompts = append(capturedPrompts, prompt)
+				result := workflow.NewConversationResult("claude")
+				result.State = state
+				assistantTurn := workflow.NewTurn(workflow.TurnRoleAssistant, "response")
+				assistantTurn.Tokens = 10
+				_ = result.State.AddTurn(workflow.NewTurn(workflow.TurnRoleUser, prompt))
+				_ = result.State.AddTurn(assistantTurn)
+				result.Output = "response"
+				return result, nil
+			})
+
+			_ = registry.Register(mockProvider)
+			manager := application.NewConversationManager(logger, evaluator, resolver, tokenizer, registry)
+
+			step := &workflow.Step{
+				Name: "chat",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider: "claude",
+					Prompt:   "What is AI?",
+				},
+			}
+
+			config := &workflow.ConversationConfig{
+				MaxTurns:      2,
+				InjectContext: tt.injectContext,
+			}
+
+			execCtx := workflow.NewExecutionContext("test-id", "test-workflow")
+			execCtx.States = make(map[string]workflow.StepState)
+
+			buildContext := func(ec *workflow.ExecutionContext) *interpolation.Context {
+				return interpolation.NewContext()
+			}
+
+			result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Len(t, capturedPrompts, 2, "should have 2 turn prompts")
+
+			assert.Equal(t, "What is AI?", capturedPrompts[0], "turn 1 should be unchanged")
+			assert.Equal(t, "What is AI?", capturedPrompts[1], "turn 2 should not have empty inject_context appended")
+		})
+	}
+}
+
+func TestConversationManager_InjectContext_InterpolationError(t *testing.T) {
+	logger := &mockLogger{}
+	evaluator := newMockExpressionEvaluator()
+	resolver := newConfigurableMockResolver()
+	resolver.results["Continue the work"] = "Continue the work"
+	resolver.templateErrors["{{.states.bad_template"] = errors.New("template parse error: unexpected end of input")
+	tokenizer := newMockTokenizer()
+	registry := mocks.NewMockAgentRegistry()
+
+	mockProvider := mocks.NewMockAgentProvider("claude")
+	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+		result := workflow.NewConversationResult("claude")
+		result.State = state
+		_ = result.State.AddTurn(workflow.NewTurn(workflow.TurnRoleUser, prompt))
+		assistantTurn := workflow.NewTurn(workflow.TurnRoleAssistant, "response")
+		assistantTurn.Tokens = 10
+		_ = result.State.AddTurn(assistantTurn)
+		result.Output = "response"
+		return result, nil
+	})
+	_ = registry.Register(mockProvider)
+
+	manager := application.NewConversationManager(logger, evaluator, resolver, tokenizer, registry)
+
+	step := &workflow.Step{
+		Name: "chat",
+		Type: workflow.StepTypeAgent,
+		Agent: &workflow.AgentConfig{
+			Provider: "claude",
+			Prompt:   "Continue the work",
+		},
+	}
+
+	config := &workflow.ConversationConfig{
+		MaxTurns:      3,
+		InjectContext: "{{.states.bad_template",
+	}
+
+	execCtx := workflow.NewExecutionContext("test-id", "test-workflow")
+	execCtx.States = make(map[string]workflow.StepState)
+
+	buildContext := func(ec *workflow.ExecutionContext) *interpolation.Context {
+		return interpolation.NewContext()
+	}
+
+	_, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+
+	// First turn succeeds (no injection). Second turn fails on inject_context interpolation.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inject_context:", "Error should be wrapped with field name (FR-006)")
+	assert.Contains(t, err.Error(), "template parse error")
+}
+
+// F075: InjectContext per-turn template interpolation — verify states.* and inputs.* namespaces
+func TestConversationManager_InjectContext_TemplateInterpolation(t *testing.T) {
+	logger := &mockLogger{}
+	evaluator := newMockExpressionEvaluator()
+	resolver := newConfigurableMockResolver()
+	resolver.results["Analyze this"] = "Analyze this"
+	resolver.results["Results: {{.states.run_tests.output}}, task: {{.inputs.task}}"] = "Results: all tests passed, task: review"
+	tokenizer := newMockTokenizer()
+	registry := mocks.NewMockAgentRegistry()
+
+	var secondTurnPrompt string
+	callCount := 0
+	mockProvider := mocks.NewMockAgentProvider("claude")
+	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+		callCount++
+		if callCount == 2 {
+			secondTurnPrompt = prompt
+		}
+		result := workflow.NewConversationResult("claude")
+		result.State = state
+		_ = result.State.AddTurn(workflow.NewTurn(workflow.TurnRoleUser, prompt))
+		assistantTurn := workflow.NewTurn(workflow.TurnRoleAssistant, "response")
+		assistantTurn.Tokens = 10
+		_ = result.State.AddTurn(assistantTurn)
+		result.Output = "response"
+		return result, nil
+	})
+	_ = registry.Register(mockProvider)
+
+	manager := application.NewConversationManager(logger, evaluator, resolver, tokenizer, registry)
+
+	step := &workflow.Step{
+		Name: "chat",
+		Type: workflow.StepTypeAgent,
+		Agent: &workflow.AgentConfig{
+			Provider: "claude",
+			Prompt:   "Analyze this",
+		},
+	}
+
+	config := &workflow.ConversationConfig{
+		MaxTurns:      3,
+		InjectContext: "Results: {{.states.run_tests.output}}, task: {{.inputs.task}}",
+	}
+
+	execCtx := workflow.NewExecutionContext("test-id", "test-workflow")
+
+	buildContext := func(ec *workflow.ExecutionContext) *interpolation.Context {
+		ctx := interpolation.NewContext()
+		ctx.States["run_tests"] = interpolation.StepStateData{
+			Output: "all tests passed",
+		}
+		ctx.Inputs["task"] = "review"
+		return ctx
+	}
+
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Contains(t, secondTurnPrompt, "Results: all tests passed, task: review",
+		"inject_context should interpolate both states.* and inputs.* namespaces (FR-007)")
+}

--- a/internal/application/loop_executor_mocks_test.go
+++ b/internal/application/loop_executor_mocks_test.go
@@ -60,15 +60,17 @@ func (m *mockExpressionEvaluator) EvaluateInt(expr string, ctx *interpolation.Co
 
 // configurableMockResolver implements interpolation.Resolver with configurable results
 type configurableMockResolver struct {
-	results map[string]string
-	calls   []string
-	err     error
+	results        map[string]string
+	calls          []string
+	err            error
+	templateErrors map[string]error // per-template error injection
 }
 
 func newConfigurableMockResolver() *configurableMockResolver {
 	return &configurableMockResolver{
-		results: make(map[string]string),
-		calls:   make([]string, 0),
+		results:        make(map[string]string),
+		calls:          make([]string, 0),
+		templateErrors: make(map[string]error),
 	}
 }
 
@@ -76,6 +78,9 @@ func (m *configurableMockResolver) Resolve(template string, ctx *interpolation.C
 	m.calls = append(m.calls, template)
 	if m.err != nil {
 		return "", m.err
+	}
+	if err, ok := m.templateErrors[template]; ok {
+		return "", err
 	}
 	if result, ok := m.results[template]; ok {
 		return result, nil

--- a/internal/domain/workflow/agent_config.go
+++ b/internal/domain/workflow/agent_config.go
@@ -63,6 +63,11 @@ func (c *AgentConfig) Validate(validator ExpressionCompiler) error {
 		return errors.New("mode must be 'single' or 'conversation'")
 	}
 
+	// Reject inject_context outside conversation mode
+	if c.Mode != "conversation" && c.Conversation != nil && strings.TrimSpace(c.Conversation.InjectContext) != "" {
+		return errors.New("inject_context requires conversation mode")
+	}
+
 	// Normalize and validate output_format
 	c.OutputFormat = OutputFormat(strings.TrimSpace(strings.ToLower(string(c.OutputFormat))))
 	if !validOutputFormats[c.OutputFormat] {

--- a/internal/domain/workflow/agent_config_conversation_test.go
+++ b/internal/domain/workflow/agent_config_conversation_test.go
@@ -550,3 +550,66 @@ func TestAgentConfig_ConversationMode_Errors(t *testing.T) {
 		})
 	}
 }
+
+// TestAgentConfig_InjectContextModeValidation validates that inject_context is rejected outside conversation mode
+func TestAgentConfig_InjectContextModeValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  workflow.AgentConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "conversation mode with inject_context is valid",
+			config: workflow.AgentConfig{
+				Provider:      "claude",
+				Mode:          "conversation",
+				InitialPrompt: "Start",
+				Conversation: &workflow.ConversationConfig{
+					MaxTurns:      5,
+					InjectContext: "Additional context",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "single mode with inject_context is rejected",
+			config: workflow.AgentConfig{
+				Provider: "claude",
+				Mode:     "single",
+				Prompt:   "Test",
+				Conversation: &workflow.ConversationConfig{
+					InjectContext: "Additional context",
+				},
+			},
+			wantErr: true,
+			errMsg:  "inject_context requires conversation mode",
+		},
+		{
+			name: "empty mode (defaults to single) with inject_context is rejected",
+			config: workflow.AgentConfig{
+				Provider: "claude",
+				Prompt:   "Test",
+				Conversation: &workflow.ConversationConfig{
+					InjectContext: "Additional context",
+				},
+			},
+			wantErr: true,
+			errMsg:  "inject_context requires conversation mode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate(nil)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/domain/workflow/conversation.go
+++ b/internal/domain/workflow/conversation.go
@@ -88,10 +88,6 @@ type ConversationConfig struct {
 // Validate checks if the conversation configuration is valid.
 // The validator parameter is used to check stop condition expression syntax.
 func (c *ConversationConfig) Validate(validator ExpressionCompiler) error {
-	if c.InjectContext != "" {
-		return errors.New("inject_context is not yet implemented")
-	}
-
 	// Validate MaxTurns (0 is allowed and means use default)
 	if c.MaxTurns < 0 {
 		return errors.New("max_turns must be non-negative")

--- a/internal/domain/workflow/conversation_test.go
+++ b/internal/domain/workflow/conversation_test.go
@@ -223,8 +223,7 @@ func TestConversationConfig_Validate(t *testing.T) {
 				MaxTurns:      5,
 				InjectContext: "Additional context here",
 			},
-			wantErr: true,
-			errMsg:  "inject_context is not yet implemented",
+			wantErr: false,
 		},
 		{
 			name: "zero max_turns (uses default)",

--- a/tests/fixtures/workflows/conversation-inject-context.yaml
+++ b/tests/fixtures/workflows/conversation-inject-context.yaml
@@ -1,5 +1,5 @@
-# Feature: C062 — reject inject_context (not yet implemented)
-name: conversation-invalid-inject-context
+# Feature: F075 — inject_context field in conversation mode
+name: conversation-inject-context
 version: "1.0.0"
 
 inputs:
@@ -17,7 +17,7 @@ states:
     initial_prompt: "{{inputs.task}}"
     conversation:
       max_turns: 5
-      inject_context: "extra context for mid-conversation injection"
+      inject_context: "Additional context for the conversation"
     on_success: done
     on_failure: error
 

--- a/tests/integration/features/conversation_validation_test.go
+++ b/tests/integration/features/conversation_validation_test.go
@@ -22,11 +22,6 @@ func TestConversationValidation_RejectsUnimplementedFeatures(t *testing.T) {
 		wantErr      string
 	}{
 		{
-			name:         "inject_context_rejected",
-			workflowName: "conversation-invalid-inject-context",
-			wantErr:      "inject_context is not yet implemented",
-		},
-		{
 			name:         "summarize_strategy_rejected",
 			workflowName: "conversation-invalid-summarize",
 			wantErr:      "not yet implemented",
@@ -83,6 +78,10 @@ func TestConversationValidation_AcceptsValidConfigs(t *testing.T) {
 		{
 			name:         "continue_from_valid_step_reference",
 			workflowName: "conversation-continue-from",
+		},
+		{
+			name:         "inject_context_valid",
+			workflowName: "conversation-inject-context",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Implements F075: `inject_context` field in conversation steps, enabling workflow authors to append interpolated context to agent prompts on turns 2+ without polluting `initial_prompt`
- Removes the C062 "not yet implemented" validation guard that blocked `inject_context` usage, replacing it with a proper mode check that rejects it outside `conversation` mode
- Template variables in `inject_context` are re-resolved each turn against the current interpolation context, so `{{.states.*}}` and `{{.inputs.*}}` reflect the latest step outputs
- Empty/whitespace values are treated as no-ops; interpolation errors are wrapped with `inject_context: <error>` for clear attribution

## Changes

### Core Implementation
- `internal/application/conversation_manager.go`: ~10 LOC added to the turn loop — resolves `InjectContext` via the existing resolver, trims whitespace, appends with `"\n\n"` separator on turns 2+
- `internal/domain/workflow/conversation.go`: Removed `"inject_context is not yet implemented"` guard from `ConversationConfig.Validate()`
- `internal/domain/workflow/agent_config.go`: Added FR-002 validation: rejects `inject_context` when `mode != "conversation"`

### Tests
- `internal/application/conversation_manager_test.go`: 312 lines of new unit tests covering appending on turn 2+, first-turn exclusion, empty/whitespace no-op, interpolation errors, and multi-namespace template resolution
- `internal/application/loop_executor_mocks_test.go`: Enhanced `configurableMockResolver` with `templateErrors` map for per-template error injection (removes duplicate mock)
- `internal/domain/workflow/agent_config_conversation_test.go`: 63-line table-driven test for `inject_context` mode validation (valid in conversation, rejected in single/empty mode)
- `internal/domain/workflow/conversation_test.go`: Updated existing `inject_context` test expectation from error to success

### Fixtures & Integration Tests
- `tests/fixtures/workflows/conversation-inject-context.yaml`: Renamed from `conversation-invalid-inject-context.yaml`; updated to represent a valid `inject_context` workflow (F075 fixture)
- `tests/integration/features/conversation_validation_test.go`: Removed rejection test for `inject_context`; added acceptance test using renamed fixture

### Documentation
- `docs/user-guide/conversation-steps.md`: New "Injecting Context Mid-Conversation" section (~47 lines) with usage example, per-turn interpolation explanation, and edge case notes; removed "not yet implemented" limitation entries
- `docs/user-guide/workflow-syntax.md`: Updated `inject_context` field description from "not yet implemented" to full description with supported template namespaces
- `README.md`: Updated Conversation Mode feature bullet to mention `inject_context`
- `CHANGELOG.md`: Added F075 entry under Unreleased; reorganised F074/F075 ordering

## Test plan

- [ ] Run unit tests: `make test-unit` — all conversation manager and domain tests pass
- [ ] Run integration tests: `make test-integration` — `conversation-inject-context` fixture validates successfully
- [ ] Verify first-turn exclusion: check that a 2-turn conversation only appends `inject_context` on the second prompt
- [ ] Verify mode guard: `awf validate` on a workflow with `inject_context` under `mode: single` returns `"inject_context requires conversation mode"`

Closes #269

---
Generated with [awf](https://github.com/awf-project/awf) commit workflow

