### PR TITLE
fix(agent): interpolate provider field before registry lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **B014**: Resolve `provider` field through interpolation engine in agent steps — `provider: "{{.inputs.agent}}"` was passed as a literal string to the registry instead of being resolved; now interpolated before lookup in both `executeAgentStep` and `ExecuteConversation` paths; resolution errors include step name context
+
 ## [0.6.0] - 2026-04-05
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,6 @@ func TestWorkflowValidation(t *testing.T) {
 
 ## Architecture Rules
 
-- When documenting code duplication across layers in comments, include explicit file path cross-references to prevent maintenance divergence (e.g., `// Note: Parallel definitions in pkg/interpolation/reference.go`)
 - In global init, create each directory resource independently; never early-exit when one resource already exists (enables recovery from partial initialization failures)
 - Apply bug fixes uniformly across all components implementing the same pattern; verify path resolution consistency across all executors when fixing one
 - Never modify production code in test-only fixes; bugs discovered during testing must be documented in Bug Escalation Protocol (.specify/implementation/ISSUE/bug/) before implementing fixes
@@ -239,6 +238,7 @@ func TestWorkflowValidation(t *testing.T) {
 - Extract shared configuration keys as named constants in the application layer (e.g., AWFPackNameKey); import and use throughout codebase rather than duplicating string literals
 - Wire optional dependencies via Set*() calls in consistent order; SetConversationManager must follow SetAgentRegistry to ensure agent registry is available before conversation manager initialization
 - Initialize ApproximationTokenizer immediately before NewConversationManager in interfaces layer; token counting must be ready before conversation context is established
+- Resolve user-provided interpolated variables before registry or dependency lookups to enable dynamic selection at runtime; apply identical resolution logic across all related code paths
 
 ## Common Pitfalls
 

--- a/docs/reference/interpolation.md
+++ b/docs/reference/interpolation.md
@@ -557,6 +557,14 @@ command: curl -H "Authorization: Bearer {{.env.API_KEY}}" https://api.example.co
 
 ## Interpolation in Different Contexts
 
+### Agent Provider
+
+```yaml
+provider: "{{.inputs.agent}}"
+```
+
+Resolves the provider name before registry lookup. Works in both `type: agent` (single-shot) and `mode: conversation` steps.
+
 ### Commands
 
 ```yaml

--- a/docs/user-guide/agent-steps.md
+++ b/docs/user-guide/agent-steps.md
@@ -34,6 +34,36 @@ states:
 awf run workflow --input code="$(cat main.py)"
 ```
 
+### Dynamic Provider Selection
+
+The `provider` field supports template interpolation, enabling dynamic provider selection based on workflow inputs or state:
+
+```yaml
+inputs:
+  - name: model_source
+    type: string
+    default: claude
+
+states:
+  initial: process
+
+  process:
+    type: agent
+    provider: "{{.inputs.model_source}}"
+    prompt: "Process: {{.inputs.data}}"
+    on_success: done
+
+  done:
+    type: terminal
+```
+
+```bash
+awf run workflow --input model_source=gemini --input data="..."
+awf run workflow --input model_source=codex --input data="..."
+```
+
+This enables workflows to support multiple AI backends without duplicating step definitions.
+
 ## Supported Providers
 
 ### Claude (Anthropic)

--- a/docs/user-guide/conversation-steps.md
+++ b/docs/user-guide/conversation-steps.md
@@ -70,7 +70,7 @@ states:
 |--------|------|----------|---------|-------------|
 | `type` | string | Yes | — | Must be `agent` |
 | `mode` | string | No | `step` | Set to `conversation` to enable multi-turn mode |
-| `provider` | string | Yes | — | Agent provider: `claude`, `codex`, `gemini`, `opencode`, `openai_compatible` |
+| `provider` | string | Yes | — | Agent provider: `claude`, `codex`, `gemini`, `opencode`, `openai_compatible`. Supports dynamic interpolation: `{{.inputs.agent}}` |
 | `system_prompt` | string | No | — | System message for the entire conversation (preserved during truncation) |
 | `initial_prompt` | string | Yes | — | Initial user message to start the conversation |
 | `prompt` | string | No | — | Used when injecting context mid-conversation (see [Injecting Context](#injecting-context-mid-conversation)) |

--- a/internal/application/agent_step_test.go
+++ b/internal/application/agent_step_test.go
@@ -3,6 +3,8 @@ package application_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/awf-project/cli/internal/domain/ports"
 	"github.com/awf-project/cli/internal/domain/workflow"
 	"github.com/awf-project/cli/internal/testutil/mocks"
+	"github.com/awf-project/cli/pkg/interpolation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1278,4 +1281,163 @@ func TestExecutionService_AgentStep_ExecutionError(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, workflow.StatusFailed, state.Status)
 	assert.Contains(t, state.Error, "network connection failed")
+}
+
+// configurableResolver is a test resolver that maps template expressions to resolved values.
+// Used for testing interpolation behavior with specific mappings.
+// For unmapped templates (not in mapping), it passes through as-is if not a template expression,
+// otherwise returns an error.
+type configurableResolver struct {
+	mapping map[string]string
+}
+
+func newConfigurableResolver(mapping map[string]string) *configurableResolver {
+	return &configurableResolver{mapping: mapping}
+}
+
+func (c *configurableResolver) Resolve(template string, ctx *interpolation.Context) (string, error) {
+	// Check if this exact template is in our mapping
+	if resolved, ok := c.mapping[template]; ok {
+		return resolved, nil
+	}
+	// If not in mapping and doesn't look like a template, pass through
+	// (this allows non-templated strings like "Test prompt" to work)
+	if !strings.Contains(template, "{{") && !strings.Contains(template, "}}") {
+		return template, nil
+	}
+	// If it looks like a template but isn't in mapping, return error
+	return "", fmt.Errorf("template parse error: %s", template)
+}
+
+// TestExecutionService_AgentStep_ProviderInterpolation tests that the provider field
+// is correctly interpolated before registry lookup.
+func TestExecutionService_AgentStep_ProviderInterpolation(t *testing.T) {
+	tests := []struct {
+		name             string
+		providerExpr     string
+		resolveMap       map[string]string
+		registeredNames  []string
+		expectError      bool
+		expectedErrorMsg string
+	}{
+		{
+			name:             "literal provider name",
+			providerExpr:     "claude",
+			resolveMap:       map[string]string{"claude": "claude"}, // pass-through
+			registeredNames:  []string{"claude"},
+			expectError:      false,
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "interpolated provider from inputs",
+			providerExpr:     "{{inputs.agent}}",
+			resolveMap:       map[string]string{"{{inputs.agent}}": "claude"},
+			registeredNames:  []string{"claude"},
+			expectError:      false,
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "interpolated provider different value",
+			providerExpr:     "{{inputs.agent}}",
+			resolveMap:       map[string]string{"{{inputs.agent}}": "gemini"},
+			registeredNames:  []string{"gemini"},
+			expectError:      false,
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "invalid template expression",
+			providerExpr:     "{{invalid",
+			resolveMap:       map[string]string{},
+			registeredNames:  []string{},
+			expectError:      true,
+			expectedErrorMsg: "resolve provider",
+		},
+		{
+			name:             "resolved provider name not in registry",
+			providerExpr:     "{{inputs.agent}}",
+			resolveMap:       map[string]string{"{{inputs.agent}}": "unknown"},
+			registeredNames:  []string{"claude"},
+			expectError:      true,
+			expectedErrorMsg: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newMockRepository()
+			repo.workflows["provider-interp"] = &workflow.Workflow{
+				Name:    "provider-interp",
+				Initial: "ask",
+				Inputs: []workflow.Input{
+					{Name: "agent", Type: "string", Default: "claude"},
+				},
+				Steps: map[string]*workflow.Step{
+					"ask": {
+						Name: "ask",
+						Type: workflow.StepTypeAgent,
+						Agent: &workflow.AgentConfig{
+							Provider: tt.providerExpr,
+							Prompt:   "Test prompt",
+						},
+						OnSuccess: "done",
+					},
+					"done": {
+						Name: "done",
+						Type: workflow.StepTypeTerminal,
+					},
+				},
+			}
+
+			configResolver := newConfigurableResolver(tt.resolveMap)
+
+			registry := mocks.NewMockAgentRegistry()
+			for _, name := range tt.registeredNames {
+				provider := mocks.NewMockAgentProvider(name)
+				provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+					return &workflow.AgentResult{
+						Provider:    name,
+						Output:      "Result from " + name,
+						Response:    map[string]any{},
+						Tokens:      50,
+						Error:       nil,
+						StartedAt:   time.Now(),
+						CompletedAt: time.Now(),
+					}, nil
+				})
+				_ = registry.Register(provider)
+			}
+
+			wfSvc := application.NewWorkflowService(repo, newMockStateStore(), newMockExecutor(), &mockLogger{}, nil)
+			execSvc := application.NewExecutionService(
+				wfSvc,
+				newMockExecutor(),
+				newMockParallelExecutor(),
+				newMockStateStore(),
+				&mockLogger{},
+				configResolver,
+				nil,
+			)
+			execSvc.SetAgentRegistry(registry)
+
+			// Provide input for interpolation
+			ctx, err := execSvc.Run(context.Background(), "provider-interp", map[string]any{
+				"agent": "claude",
+			})
+
+			if tt.expectError {
+				require.Error(t, err, "should return error")
+				if tt.expectedErrorMsg != "" {
+					assert.Contains(t, err.Error(), tt.expectedErrorMsg, "error should contain expected message")
+				}
+				assert.Equal(t, workflow.StatusFailed, ctx.Status)
+			} else {
+				require.NoError(t, err, "should not return error")
+				assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+				state, ok := ctx.GetStepState("ask")
+				require.True(t, ok, "step state should be recorded")
+				assert.Equal(t, workflow.StatusCompleted, state.Status)
+			}
+		})
+	}
 }

--- a/internal/application/conversation_manager.go
+++ b/internal/application/conversation_manager.go
@@ -62,6 +62,7 @@ func (m *ConversationManager) validateConversationInputs(
 // loads prior conversation state from the referenced predecessor step.
 func (m *ConversationManager) initializeConversationState(
 	step *workflow.Step,
+	resolvedProvider string,
 	config *workflow.ConversationConfig,
 	execCtx *workflow.ExecutionContext,
 	buildContext ContextBuilderFunc,
@@ -80,8 +81,8 @@ func (m *ConversationManager) initializeConversationState(
 			return nil, "", fmt.Errorf("continue_from: step %q has no session ID or conversation history to resume", config.ContinueFrom)
 		}
 		// openai_compatible uses Turns for session resume, not SessionID
-		if step.Agent.Provider == "openai_compatible" && len(prior.Turns) == 0 {
-			return nil, "", fmt.Errorf("continue_from: step %q has no conversation turns for HTTP-based provider %q", config.ContinueFrom, step.Agent.Provider)
+		if resolvedProvider == "openai_compatible" && len(prior.Turns) == 0 {
+			return nil, "", fmt.Errorf("continue_from: step %q has no conversation turns for HTTP-based provider %q", config.ContinueFrom, resolvedProvider)
 		}
 		// Clone prior state for the new step
 		state = &workflow.ConversationState{
@@ -104,7 +105,7 @@ func (m *ConversationManager) initializeConversationState(
 	intCtx := buildContext(execCtx)
 	resolvedPrompt, err := m.resolver.Resolve(initialPrompt, intCtx)
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf("step %s: resolve prompt: %w", step.Name, err)
 	}
 
 	return state, resolvedPrompt, nil
@@ -201,12 +202,18 @@ func (m *ConversationManager) ExecuteConversation(
 		return nil, err
 	}
 
-	provider, err := m.agentRegistry.Get(step.Agent.Provider)
+	intCtx := buildContext(execCtx)
+	resolvedProvider, err := m.resolver.Resolve(step.Agent.Provider, intCtx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("step %s: resolve provider: %w", step.Name, err)
 	}
 
-	state, resolvedPrompt, err := m.initializeConversationState(step, config, execCtx, buildContext)
+	provider, err := m.agentRegistry.Get(resolvedProvider)
+	if err != nil {
+		return nil, fmt.Errorf("step %s: %w", step.Name, err)
+	}
+
+	state, resolvedPrompt, err := m.initializeConversationState(step, resolvedProvider, config, execCtx, buildContext)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/application/conversation_manager_helpers_test.go
+++ b/internal/application/conversation_manager_helpers_test.go
@@ -327,7 +327,7 @@ func TestConversationManager_initializeConversationState(t *testing.T) {
 			}
 			execCtx := workflow.NewExecutionContext("test-wf", "test")
 
-			state, prompt, err := mgr.initializeConversationState(tt.step, &workflow.ConversationConfig{}, execCtx, tt.buildContext)
+			state, prompt, err := mgr.initializeConversationState(tt.step, tt.step.Agent.Provider, &workflow.ConversationConfig{}, execCtx, tt.buildContext)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/internal/application/conversation_manager_test.go
+++ b/internal/application/conversation_manager_test.go
@@ -2169,3 +2169,114 @@ func TestConversationManager_InjectContext_TemplateInterpolation(t *testing.T) {
 	assert.Contains(t, secondTurnPrompt, "Results: all tests passed, task: review",
 		"inject_context should interpolate both states.* and inputs.* namespaces (FR-007)")
 }
+
+// TestConversationManager_ProviderInterpolation tests that the provider field
+// is correctly interpolated before registry lookup in conversation mode.
+func TestConversationManager_ProviderInterpolation(t *testing.T) {
+	tests := []struct {
+		name             string
+		providerExpr     string
+		resolveMap       map[string]string
+		registeredNames  []string
+		expectError      bool
+		expectedErrorMsg string
+	}{
+		{
+			name:             "literal provider name",
+			providerExpr:     "claude",
+			resolveMap:       map[string]string{"claude": "claude"},
+			registeredNames:  []string{"claude"},
+			expectError:      false,
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "interpolated provider from inputs",
+			providerExpr:     "{{inputs.agent}}",
+			resolveMap:       map[string]string{"{{inputs.agent}}": "claude"},
+			registeredNames:  []string{"claude"},
+			expectError:      false,
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "interpolated provider different value",
+			providerExpr:     "{{inputs.agent}}",
+			resolveMap:       map[string]string{"{{inputs.agent}}": "gemini"},
+			registeredNames:  []string{"gemini"},
+			expectError:      false,
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "invalid template expression",
+			providerExpr:     "{{invalid",
+			resolveMap:       map[string]string{},
+			registeredNames:  []string{},
+			expectError:      true,
+			expectedErrorMsg: "resolve provider",
+		},
+		{
+			name:             "resolved provider name not in registry",
+			providerExpr:     "{{inputs.agent}}",
+			resolveMap:       map[string]string{"{{inputs.agent}}": "unknown"},
+			registeredNames:  []string{"claude"},
+			expectError:      true,
+			expectedErrorMsg: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := &mockLogger{}
+			evaluator := newMockExpressionEvaluator()
+			configResolver := newConfigurableResolver(tt.resolveMap)
+			tokenizer := newMockTokenizer()
+
+			registry := mocks.NewMockAgentRegistry()
+			for _, name := range tt.registeredNames {
+				provider := mocks.NewMockAgentProvider(name)
+				_ = registry.Register(provider)
+			}
+
+			manager := application.NewConversationManager(
+				logger,
+				evaluator,
+				configResolver,
+				tokenizer,
+				registry,
+			)
+
+			step := &workflow.Step{
+				Name: "converse",
+				Type: workflow.StepTypeAgent,
+				Agent: &workflow.AgentConfig{
+					Provider: tt.providerExpr,
+					Mode:     "conversation",
+				},
+			}
+
+			config := &workflow.ConversationConfig{
+				MaxTurns: 1,
+			}
+
+			execCtx := workflow.NewExecutionContext("test-id", "test-workflow")
+			execCtx.States = make(map[string]workflow.StepState)
+
+			buildContext := func(ec *workflow.ExecutionContext) *interpolation.Context {
+				ctx := interpolation.NewContext()
+				ctx.Inputs["agent"] = "claude"
+				return ctx
+			}
+
+			result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+
+			if tt.expectError {
+				require.Error(t, err, "should return error")
+				if tt.expectedErrorMsg != "" {
+					assert.Contains(t, err.Error(), tt.expectedErrorMsg, "error should contain expected message")
+				}
+			} else {
+				require.NoError(t, err, "should not return error")
+				require.NotNil(t, result)
+			}
+		})
+	}
+}

--- a/internal/application/execution_service.go
+++ b/internal/application/execution_service.go
@@ -2010,8 +2010,12 @@ func (s *ExecutionService) executeAgentStep(
 		return "", fmt.Errorf("step %s: resolve prompt: %w", step.Name, err)
 	}
 
-	// Get provider from registry
-	provider, err := s.agentRegistry.Get(step.Agent.Provider)
+	resolvedProvider, err := s.resolver.Resolve(step.Agent.Provider, intCtx)
+	if err != nil {
+		return "", fmt.Errorf("step %s: resolve provider: %w", step.Name, err)
+	}
+
+	provider, err := s.agentRegistry.Get(resolvedProvider)
 	if err != nil {
 		return "", fmt.Errorf("step %s: %w", step.Name, err)
 	}
@@ -2022,13 +2026,13 @@ func (s *ExecutionService) executeAgentStep(
 			s.logger.Warn("dangerouslySkipPermissions enabled",
 				"workflow", execCtx.WorkflowName,
 				"step", step.Name,
-				"provider", step.Agent.Provider,
+				"provider", resolvedProvider,
 				"timestamp", time.Now().Format(time.RFC3339))
 		}
 	}
 
 	// Execute the agent
-	s.logger.Debug("executing agent step", "step", step.Name, "provider", step.Agent.Provider)
+	s.logger.Debug("executing agent step", "step", step.Name, "provider", resolvedProvider)
 	result, execErr := provider.Execute(stepCtx, resolvedPrompt, step.Agent.Options)
 
 	// Record step state

--- a/tests/integration/execution/provider_interpolation_test.go
+++ b/tests/integration/execution/provider_interpolation_test.go
@@ -1,0 +1,199 @@
+//go:build integration
+
+// Feature: B014
+
+package execution_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/awf-project/cli/internal/application"
+	"github.com/awf-project/cli/internal/domain/workflow"
+	"github.com/awf-project/cli/internal/infrastructure/executor"
+	infraExpr "github.com/awf-project/cli/internal/infrastructure/expression"
+	"github.com/awf-project/cli/internal/infrastructure/repository"
+	"github.com/awf-project/cli/internal/testutil/mocks"
+	"github.com/awf-project/cli/pkg/interpolation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestExecSvc(tempDir string) *application.ExecutionService {
+	log := &mockExecutionLogger{}
+	repo := repository.NewYAMLRepository(tempDir)
+	store := newMockStateStore()
+	shellExec := executor.NewShellExecutor()
+	resolver := interpolation.NewTemplateResolver()
+
+	wfSvc := application.NewWorkflowService(repo, store, shellExec, log, infraExpr.NewExprValidator())
+	parallelExec := application.NewParallelExecutor(log)
+	return application.NewExecutionService(wfSvc, shellExec, parallelExec, store, log, resolver, nil)
+}
+
+func TestProviderInterpolation_AgentStep_Integration(t *testing.T) {
+	tempDir := t.TempDir()
+
+	workflowYAML := `name: provider-interp
+version: "1.0.0"
+
+inputs:
+  - name: agent
+    type: string
+    required: true
+    description: "Provider name to use"
+
+states:
+  initial: ask
+
+  ask:
+    type: agent
+    provider: "{{inputs.agent}}"
+    prompt: "Hello world"
+    on_success: done
+    on_failure: error
+
+  done:
+    type: terminal
+    status: success
+
+  error:
+    type: terminal
+    status: failure
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tempDir, "provider-interp.yaml"),
+		[]byte(workflowYAML), 0o644,
+	))
+
+	execSvc := newTestExecSvc(tempDir)
+
+	registry := mocks.NewMockAgentRegistry()
+	claude := mocks.NewMockAgentProvider("claude")
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+		return &workflow.AgentResult{
+			Provider:    "claude",
+			Output:      "Resolved provider executed",
+			Tokens:      42,
+			StartedAt:   time.Now(),
+			CompletedAt: time.Now(),
+		}, nil
+	})
+	_ = registry.Register(claude)
+	execSvc.SetAgentRegistry(registry)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	execCtx, err := execSvc.Run(ctx, "provider-interp", map[string]any{"agent": "claude"})
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+	assert.Equal(t, "done", execCtx.CurrentStep)
+
+	state, ok := execCtx.GetStepState("ask")
+	require.True(t, ok)
+	assert.Equal(t, "Resolved provider executed", state.Output)
+}
+
+func TestProviderInterpolation_ResolvedNotFound_Integration(t *testing.T) {
+	tempDir := t.TempDir()
+
+	workflowYAML := `name: provider-not-found
+version: "1.0.0"
+
+inputs:
+  - name: agent
+    type: string
+    required: true
+
+states:
+  initial: ask
+
+  ask:
+    type: agent
+    provider: "{{inputs.agent}}"
+    prompt: "Hello"
+    on_success: done
+    on_failure: error
+
+  done:
+    type: terminal
+    status: success
+
+  error:
+    type: terminal
+    status: failure
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tempDir, "provider-not-found.yaml"),
+		[]byte(workflowYAML), 0o644,
+	))
+
+	execSvc := newTestExecSvc(tempDir)
+
+	registry := mocks.NewMockAgentRegistry()
+	execSvc.SetAgentRegistry(registry)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	execCtx, err := execSvc.Run(ctx, "provider-not-found", map[string]any{"agent": "nonexistent"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), "nonexistent")
+	assert.Equal(t, workflow.StatusFailed, execCtx.Status)
+}
+
+func TestProviderInterpolation_LiteralProvider_Integration(t *testing.T) {
+	tempDir := t.TempDir()
+
+	workflowYAML := `name: literal-provider
+version: "1.0.0"
+
+states:
+  initial: ask
+
+  ask:
+    type: agent
+    provider: claude
+    prompt: "Hello world"
+    on_success: done
+
+  done:
+    type: terminal
+    status: success
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tempDir, "literal-provider.yaml"),
+		[]byte(workflowYAML), 0o644,
+	))
+
+	execSvc := newTestExecSvc(tempDir)
+
+	registry := mocks.NewMockAgentRegistry()
+	claude := mocks.NewMockAgentProvider("claude")
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+		return &workflow.AgentResult{
+			Provider:    "claude",
+			Output:      "OK",
+			Tokens:      10,
+			StartedAt:   time.Now(),
+			CompletedAt: time.Now(),
+		}, nil
+	})
+	_ = registry.Register(claude)
+	execSvc.SetAgentRegistry(registry)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	execCtx, err := execSvc.Run(ctx, "literal-provider", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflow.StatusCompleted, execCtx.Status)
+}


### PR DESCRIPTION
## Summary

- The `provider` field in agent steps was passed as a raw string to the registry, so template expressions like `{{inputs.agent}}` were never resolved — providers were silently not found at runtime
- Fix interpolates `step.Agent.Provider` through the existing resolver before registry lookup in both `executeAgentStep` and `ConversationManager.ExecuteConversation`, keeping the two code paths consistent
- `initializeConversationState` now receives the already-resolved provider name instead of re-reading the raw field, fixing the `openai_compatible` resume check for interpolated providers
- Error messages now include step name context for both resolution failures and registry misses

## Changes

### Application — Core Fix
- `internal/application/execution_service.go`: Resolve `step.Agent.Provider` via `s.resolver.Resolve()` before `agentRegistry.Get()`; log resolved name instead of raw expression
- `internal/application/conversation_manager.go`: Resolve provider with interpolation context before registry lookup in `ExecuteConversation`; pass resolved name to `initializeConversationState` for the `openai_compatible` resume guard; improve error wrapping with step name context

### Tests — Unit
- `internal/application/agent_step_test.go`: Add `configurableResolver` test helper and `TestExecutionService_AgentStep_ProviderInterpolation` table-driven suite covering literal, interpolated, invalid template, and unregistered provider cases
- `internal/application/conversation_manager_test.go`: Add `TestConversationManager_ProviderInterpolation` table-driven suite mirroring the same cases for conversation mode
- `internal/application/conversation_manager_helpers_test.go`: Update `initializeConversationState` call to pass resolved provider as new parameter

### Tests — Integration
- `tests/integration/execution/provider_interpolation_test.go`: New integration suite with three scenarios: interpolated provider resolves and executes, resolved name not in registry returns error, literal provider name still works

### Documentation
- `docs/reference/interpolation.md`: Document `provider` field as an interpolation context
- `docs/user-guide/agent-steps.md`: Add "Dynamic Provider Selection" section with YAML and CLI examples
- `docs/user-guide/conversation-steps.md`: Note `{{.inputs.agent}}` as valid value for `provider` field in attribute table

### Project
- `CHANGELOG.md`: Add B014 entry under `[Unreleased] > Fixed`
- `CLAUDE.md`: Replace stale architecture rule with new rule on resolving interpolated variables before lookups

## Test plan

- [x] Unit tests pass: `go test ./internal/application/...`
- [x] Integration tests pass: `go test -tags=integration ./tests/integration/execution/...`
- [x] `awf run <workflow> --input agent=gemini` routes to the correct provider when the workflow uses `provider: "{{inputs.agent}}"`
- [x] `awf run <workflow> --input agent=unknown` fails with a clear "not found" error referencing the resolved name

Closes #296

---
Generated with [awf](https://github.com/awf-project/cli) commit workflow

