### PR TITLE
feat(agents): fix CLI provider invocations and add streaming output support (F078)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- **F078**: CLI provider invocation flags updated to match current binary APIs — Claude and Gemini `output_format: json` now maps to `--output-format stream-json` (was `--output-format json`); Codex invocation changed from `codex --prompt "<prompt>" --quiet` to `codex exec --json "<prompt>"`; `quiet` option removed from Codex (silently ignored); Codex conversation resume changed from `codex resume <id> --prompt "<prompt>"` to `codex resume <id> --json "<prompt>"`; workflows using `output_format: json` require no YAML changes (mapping is automatic); workflows using `quiet: true` for Codex should remove the option (no-op)
 - **F077**: Option keys normalized to snake_case — `allowedTools` renamed to `allowed_tools`, `dangerouslySkipPermissions` renamed to `dangerously_skip_permissions` in workflow YAML; old camelCase keys are silently ignored (Go map miss); `dangerously_skip_permissions` fails closed (permissions not skipped), `allowed_tools` fails open (no tool restriction applied); update existing workflow files to use the new snake_case keys
 
 ### Added
 
+- **F078**: OpenCode `--model` flag support — `model` option in workflow YAML now passed as `--model <value>` to OpenCode CLI in both `Execute` and `ExecuteConversation`; OpenCode always passes `--format json` for structured output
 - **F077**: `dangerously_skip_permissions` support for Gemini (`--approval-mode=yolo`) and Codex (`--yolo`) providers — unified permission bypass key works across all three agent providers (Claude, Gemini, Codex)
 - **F076**: `awf upgrade` self-update command — checks latest release on GitHub, downloads platform-specific binary, verifies SHA256 checksum, and atomically replaces the current executable; `--check` reports available updates without installing; `--version v0.5.0` installs a specific version; `--force` upgrades even if already on latest or running a dev build; heuristic warning when binary appears managed by a package manager (homebrew, apt, snap, nix); cross-filesystem fallback (copy + chmod) when `os.Rename` fails; `GITHUB_TOKEN` env var supported for rate-limited environments
 
@@ -22,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **F078**: Dead validation helpers `validatePrompt()`, `validateContext()`, `validateState()` removed from agent helpers — all were no-ops or unreachable after provider refactoring
 - **F077**: Dead helper functions `getWorkflowID()` and `getStepName()` removed from agent helpers — keys `workflowID`/`stepName` were never injected by any caller; `workflow` and `step` fields removed from Claude provider audit log (redundant with execution service context)
 
 ## [0.6.0] - 2026-04-05

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,6 @@ func TestWorkflowValidation(t *testing.T) {
 
 ## Architecture Rules
 
-- Apply bug fixes uniformly across all components implementing the same pattern; verify path resolution consistency across all executors when fixing one
 - Never modify production code in test-only fixes; bugs discovered during testing must be documented in Bug Escalation Protocol (.specify/implementation/ISSUE/bug/) before implementing fixes
 - Document discovered runtime bugs in .specify/implementation/ISSUE/bug/ directory before implementation; prevents scope creep and enables separate tracking from test fixes
 - Own timeout responsibility in application layer via context.WithTimeout; infrastructure adapters must respect context cancellation without enforcing additional timeouts
@@ -239,6 +238,7 @@ func TestWorkflowValidation(t *testing.T) {
 - Initialize ApproximationTokenizer immediately before NewConversationManager in interfaces layer; token counting must be ready before conversation context is established
 - Resolve user-provided interpolated variables before registry or dependency lookups to enable dynamic selection at runtime; apply identical resolution logic across all related code paths
 - Implement per-provider flag mapping without shared abstraction when CLI syntax diverges fundamentally; document divergence (Claude: --flag-name, Gemini: --flag-name=value, Codex: --flag-name) inline
+- Synchronize provider CLI flag changes across both implementation files and central options configuration (options.go); verify declarations and validation rules align
 
 ## Common Pitfalls
 
@@ -306,6 +306,3 @@ func TestWorkflowValidation(t *testing.T) {
 - Extract repeated test assertion patterns (>5 duplicates) into table-driven or closure-based helpers to eliminate code duplication
 - Extract HTTP server setup patterns from integration tests into helper functions; eliminate duplication across multiple test functions
 - When flipping integration test assertions for newly-enabled features, transition from 'not configured' errors to provider-level implementation errors; verify assertions change state, not disappear
-
-## Review Standards
-

--- a/internal/application/agent_step_test.go
+++ b/internal/application/agent_step_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -186,7 +187,7 @@ func TestExecutionService_AgentStep_BasicExecution(t *testing.T) {
 
 	registry := mocks.NewMockAgentRegistry()
 	claude := mocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Summarize this text" {
 			return &workflow.AgentResult{
 				Provider:    "claude",
@@ -265,7 +266,7 @@ func TestExecutionService_AgentStep_WithOnFailure(t *testing.T) {
 
 	registry := mocks.NewMockAgentRegistry()
 	claude := mocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Summarize this text" {
 			return &workflow.AgentResult{
 				Provider:    "claude",
@@ -348,7 +349,7 @@ func TestExecutionService_AgentStep_InMixedWorkflow(t *testing.T) {
 
 	registry := mocks.NewMockAgentRegistry()
 	claude := mocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Analyze the prepared data" {
 			return &workflow.AgentResult{
 				Provider:    "claude",
@@ -431,7 +432,7 @@ func TestExecutionService_AgentStep_StepTimeout(t *testing.T) {
 
 	registry := mocks.NewMockAgentRegistry()
 	claude := mocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Summarize this text" {
 			return &workflow.AgentResult{
 				Provider:    "claude",
@@ -501,7 +502,7 @@ func TestExecutionService_AgentStep_AgentTimeout(t *testing.T) {
 
 	registry := mocks.NewMockAgentRegistry()
 	claude := mocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Summarize this text" {
 			return &workflow.AgentResult{
 				Provider:    "claude",
@@ -574,7 +575,7 @@ func TestExecutionService_AgentStep_ContextCancellation(t *testing.T) {
 
 	registry := mocks.NewMockAgentRegistry()
 	claude := mocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return nil, context.Canceled
 	})
 	_ = registry.Register(claude)
@@ -644,7 +645,7 @@ func TestExecutionService_AgentStep_InParallelBranches(t *testing.T) {
 	registry := mocks.NewMockAgentRegistry()
 
 	claude := mocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Analyze sentiment" {
 			return &workflow.AgentResult{
 				Provider:    "claude",
@@ -667,7 +668,7 @@ func TestExecutionService_AgentStep_InParallelBranches(t *testing.T) {
 	_ = registry.Register(claude)
 
 	gemini := mocks.NewMockAgentProvider("gemini")
-	gemini.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	gemini.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Extract keywords" {
 			return &workflow.AgentResult{
 				Provider:    "gemini",
@@ -750,7 +751,7 @@ func TestExecutionService_AgentStep_PromptInterpolation(t *testing.T) {
 	registry := mocks.NewMockAgentRegistry()
 	claude := mocks.NewMockAgentProvider("claude")
 	// Note: mock resolver doesn't interpolate, so prompt stays as-is
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Explain {{inputs.topic}} in simple terms" {
 			return &workflow.AgentResult{
 				Provider:    "claude",
@@ -829,7 +830,7 @@ func TestExecutionService_AgentStep_MultipleProviders(t *testing.T) {
 	registry := mocks.NewMockAgentRegistry()
 
 	claude := mocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Analyze this code" {
 			return &workflow.AgentResult{
 				Provider:    "claude",
@@ -852,7 +853,7 @@ func TestExecutionService_AgentStep_MultipleProviders(t *testing.T) {
 	_ = registry.Register(claude)
 
 	gemini := mocks.NewMockAgentProvider("gemini")
-	gemini.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	gemini.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Review the analysis" {
 			return &workflow.AgentResult{
 				Provider:    "gemini",
@@ -1004,7 +1005,7 @@ func TestExecutionService_Resume_WithAgentStep(t *testing.T) {
 
 	registry := mocks.NewMockAgentRegistry()
 	claude := mocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Summarize this text" {
 			return &workflow.AgentResult{
 				Provider:    "claude",
@@ -1073,7 +1074,7 @@ func TestExecutionService_AgentStep_ContinueOnError(t *testing.T) {
 
 	registry := mocks.NewMockAgentRegistry()
 	claude := mocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Summarize this text" {
 			return &workflow.AgentResult{
 				Provider:    "claude",
@@ -1252,7 +1253,7 @@ func TestExecutionService_AgentStep_ExecutionError(t *testing.T) {
 
 	registry := mocks.NewMockAgentRegistry()
 	claude := mocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return nil, errors.New("network connection failed")
 	})
 	_ = registry.Register(claude)
@@ -1393,7 +1394,7 @@ func TestExecutionService_AgentStep_ProviderInterpolation(t *testing.T) {
 			registry := mocks.NewMockAgentRegistry()
 			for _, name := range tt.registeredNames {
 				provider := mocks.NewMockAgentProvider(name)
-				provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+				provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 					return &workflow.AgentResult{
 						Provider:    name,
 						Output:      "Result from " + name,

--- a/internal/application/conversation_manager.go
+++ b/internal/application/conversation_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/awf-project/cli/internal/domain/ports"
@@ -118,6 +119,7 @@ func (m *ConversationManager) executeTurn(
 	state *workflow.ConversationState,
 	prompt string,
 	options map[string]any,
+	stdoutW, stderrW io.Writer,
 ) (*workflow.ConversationResult, error) {
 	select {
 	case <-ctx.Done():
@@ -125,7 +127,7 @@ func (m *ConversationManager) executeTurn(
 	default:
 	}
 
-	result, err := provider.ExecuteConversation(ctx, state, prompt, options)
+	result, err := provider.ExecuteConversation(ctx, state, prompt, options, stdoutW, stderrW)
 	if err != nil {
 		return nil, err
 	}
@@ -197,6 +199,7 @@ func (m *ConversationManager) ExecuteConversation(
 	config *workflow.ConversationConfig,
 	execCtx *workflow.ExecutionContext,
 	buildContext ContextBuilderFunc,
+	stdoutW, stderrW io.Writer,
 ) (*workflow.ConversationResult, error) {
 	if err := m.validateConversationInputs(step, config); err != nil {
 		return nil, err
@@ -233,7 +236,7 @@ func (m *ConversationManager) ExecuteConversation(
 
 	var lastResult *workflow.ConversationResult
 	for turnCount := 0; turnCount < maxTurns; turnCount++ {
-		result, err := m.executeTurn(ctx, provider, state, resolvedPrompt, options)
+		result, err := m.executeTurn(ctx, provider, state, resolvedPrompt, options, stdoutW, stderrW)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/application/conversation_manager_helpers_test.go
+++ b/internal/application/conversation_manager_helpers_test.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/awf-project/cli/internal/domain/ports"
@@ -29,7 +30,7 @@ func (m *mockAgentProvider) Name() string {
 	return m.name
 }
 
-func (m *mockAgentProvider) Execute(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+func (m *mockAgentProvider) Execute(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 	return nil, nil // Not used in conversation manager tests
 }
 
@@ -38,6 +39,7 @@ func (m *mockAgentProvider) ExecuteConversation(
 	state *workflow.ConversationState,
 	prompt string,
 	options map[string]any,
+	stdout, stderr io.Writer,
 ) (*workflow.ConversationResult, error) {
 	if m.err != nil {
 		return nil, m.err
@@ -433,7 +435,7 @@ func TestConversationManager_executeTurn(t *testing.T) {
 				cancel() // Cancel immediately
 			}
 
-			result, err := mgr.executeTurn(ctx, provider, tt.state, tt.prompt, tt.options)
+			result, err := mgr.executeTurn(ctx, provider, tt.state, tt.prompt, tt.options, nil, nil)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/internal/application/conversation_manager_test.go
+++ b/internal/application/conversation_manager_test.go
@@ -3,6 +3,7 @@ package application_test
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/awf-project/cli/internal/application"
@@ -79,11 +80,11 @@ func newMockConversationProvider(name string) *mockConversationProvider {
 	}
 }
 
-func (m *mockConversationProvider) Execute(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+func (m *mockConversationProvider) Execute(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 	return nil, errors.New("single execution not supported, use ExecuteConversation")
 }
 
-func (m *mockConversationProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+func (m *mockConversationProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 	if m.execError != nil {
 		return nil, m.execError
 	}
@@ -156,7 +157,7 @@ func TestConversationManager_SingleTurn_HappyPath(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -198,7 +199,7 @@ func TestConversationManager_MultiTurn_HappyPath(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -241,7 +242,7 @@ func TestConversationManager_WithSystemPrompt(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -285,7 +286,7 @@ func TestConversationManager_StopCondition_ResponseContains(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -329,7 +330,7 @@ func TestConversationManager_StopCondition_TurnCount(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -371,7 +372,7 @@ func TestConversationManager_MaxTurns_Reached(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -413,7 +414,7 @@ func TestConversationManager_MaxTurns_One(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -456,7 +457,7 @@ func TestConversationManager_MaxTokens_Exceeded(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -498,7 +499,7 @@ func TestConversationManager_Strategy_SlidingWindow(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -540,7 +541,7 @@ func TestConversationManager_Strategy_None(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -559,7 +560,7 @@ func TestConversationManager_PassesSystemPromptInOptions(t *testing.T) {
 	var capturedOptions map[string]any
 	mockProvider := mocks.NewMockAgentProvider("claude")
 
-	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		capturedOptions = options
 		result := workflow.NewConversationResult("claude")
 		result.State = state
@@ -598,7 +599,7 @@ func TestConversationManager_PassesSystemPromptInOptions(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -616,7 +617,7 @@ func TestConversationManager_OmitsSystemPromptWhenEmpty(t *testing.T) {
 	var capturedOptions map[string]any
 	mockProvider := mocks.NewMockAgentProvider("claude")
 
-	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		capturedOptions = options
 		result := workflow.NewConversationResult("claude")
 		result.State = state
@@ -655,7 +656,7 @@ func TestConversationManager_OmitsSystemPromptWhenEmpty(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -674,7 +675,7 @@ func TestConversationManager_PreservesExistingOptions(t *testing.T) {
 	var capturedOptions map[string]any
 	mockProvider := mocks.NewMockAgentProvider("claude")
 
-	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		capturedOptions = options
 		result := workflow.NewConversationResult("claude")
 		result.State = state
@@ -717,7 +718,7 @@ func TestConversationManager_PreservesExistingOptions(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -766,7 +767,7 @@ func TestConversationManager_Interpolation_Inputs(t *testing.T) {
 		return ctx
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -822,7 +823,7 @@ func TestConversationManager_Interpolation_States(t *testing.T) {
 		return ctx
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -865,7 +866,7 @@ func TestConversationManager_Error_ProviderNotFound(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect provider not found error
 	require.Error(t, err)
@@ -912,7 +913,7 @@ func TestConversationManager_Error_ProviderExecutionError(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -955,7 +956,7 @@ func TestConversationManager_Error_TokenizerError(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -998,7 +999,7 @@ func TestConversationManager_Error_TemplateResolutionError(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect template resolution error
 	require.Error(t, err)
@@ -1043,7 +1044,7 @@ func TestConversationManager_Error_StopConditionEvaluationError(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -1088,7 +1089,7 @@ func TestConversationManager_Error_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	result, err := manager.ExecuteConversation(ctx, step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(ctx, step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect context cancellation error
 	require.Error(t, err)
@@ -1135,7 +1136,7 @@ func TestConversationManager_ValidateConversationInputs_HappyPath(t *testing.T) 
 
 	// Call ExecuteConversation which uses validateConversationInputs internally
 	// This verifies the refactored validation is working correctly
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 	// Validation passes (step and config are valid)
 	// Execution may fail due to stub implementation, but that's expected in RED phase
 	// The key test is that we don't get a validation error about nil inputs
@@ -1171,7 +1172,7 @@ func TestConversationManager_ValidateConversationInputs_NilStep(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), nil, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), nil, config, execCtx, buildContext, nil, nil)
 
 	// Should fail validation immediately
 	require.Error(t, err)
@@ -1209,7 +1210,7 @@ func TestConversationManager_ValidateConversationInputs_NilAgentConfig(t *testin
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// Should fail validation immediately
 	require.Error(t, err)
@@ -1244,7 +1245,7 @@ func TestConversationManager_ValidateConversationInputs_NilConfig(t *testing.T) 
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, nil, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, nil, execCtx, buildContext, nil, nil)
 
 	// Should fail validation immediately
 	require.Error(t, err)
@@ -1270,7 +1271,7 @@ func TestConversationManager_ValidateConversationInputs_AllNil(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), nil, nil, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), nil, nil, execCtx, buildContext, nil, nil)
 
 	// Should fail validation immediately
 	require.Error(t, err)
@@ -1312,7 +1313,7 @@ func TestConversationManager_ValidateConversationInputs_EdgeCase_EmptyProviderNa
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// Validation passes (step and config are not nil), but should fail at provider lookup
 	require.Error(t, err)
@@ -1349,7 +1350,7 @@ func TestConversationManager_EdgeCase_NilConfig(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, nil, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, nil, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect nil config error
 	require.Error(t, err)
@@ -1392,7 +1393,7 @@ func TestConversationManager_EdgeCase_EmptyInitialPrompt(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -1435,7 +1436,7 @@ func TestConversationManager_EdgeCase_EmptySystemPrompt(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// GREEN PHASE: expect successful execution
 	require.NoError(t, err)
@@ -1453,7 +1454,7 @@ func TestConversationManager_ContinueFrom_SessionID(t *testing.T) {
 
 	var capturedInitialSessionID string
 	mockProvider := mocks.NewMockAgentProvider("claude")
-	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		// Capture initial SessionID before provider modifies it
 		capturedInitialSessionID = state.SessionID
 		result := workflow.NewConversationResult("claude")
@@ -1499,7 +1500,7 @@ func TestConversationManager_ContinueFrom_SessionID(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -1518,7 +1519,7 @@ func TestConversationManager_ContinueFrom_Turns(t *testing.T) {
 
 	var capturedInitialTurnCount int
 	mockProvider := mocks.NewMockAgentProvider("openai_compatible")
-	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		// Capture initial turn count before provider adds new turns
 		capturedInitialTurnCount = len(state.Turns)
 		result := workflow.NewConversationResult("openai_compatible")
@@ -1569,7 +1570,7 @@ func TestConversationManager_ContinueFrom_Turns(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -1611,7 +1612,7 @@ func TestConversationManager_ContinueFrom_StepNotFound(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "nonexistent")
@@ -1655,7 +1656,7 @@ func TestConversationManager_ContinueFrom_NilConversationState(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no conversation state")
@@ -1702,7 +1703,7 @@ func TestConversationManager_ContinueFrom_EmptySessionAndTurns(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no session")
@@ -1751,7 +1752,7 @@ func TestConversationManager_ContinueFrom_TurnsRequired_HTTPProvider(t *testing.
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no conversation turns")
@@ -1769,7 +1770,7 @@ func TestConversationManager_ContinueFrom_ThreeStepChain(t *testing.T) {
 	var step3InitialTurnCount int
 
 	mockProvider := mocks.NewMockAgentProvider("claude")
-	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		// Capture initial turn count before provider adds new turns
 		switch prompt {
 		case "step2-prompt":
@@ -1803,7 +1804,7 @@ func TestConversationManager_ContinueFrom_ThreeStepChain(t *testing.T) {
 	buildContext := func(ec *workflow.ExecutionContext) *interpolation.Context {
 		return interpolation.NewContext()
 	}
-	result1, err := manager.ExecuteConversation(context.Background(), step1, config1, execCtx, buildContext)
+	result1, err := manager.ExecuteConversation(context.Background(), step1, config1, execCtx, buildContext, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result1)
 	execCtx.SetStepState("step1", workflow.StepState{
@@ -1825,7 +1826,7 @@ func TestConversationManager_ContinueFrom_ThreeStepChain(t *testing.T) {
 		MaxTurns:     1,
 		ContinueFrom: "step1",
 	}
-	result2, err := manager.ExecuteConversation(context.Background(), step2, config2, execCtx, buildContext)
+	result2, err := manager.ExecuteConversation(context.Background(), step2, config2, execCtx, buildContext, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result2)
 	// Step2 should receive step1's 2 turns (user + assistant)
@@ -1849,7 +1850,7 @@ func TestConversationManager_ContinueFrom_ThreeStepChain(t *testing.T) {
 		MaxTurns:     1,
 		ContinueFrom: "step2",
 	}
-	result3, err := manager.ExecuteConversation(context.Background(), step3, config3, execCtx, buildContext)
+	result3, err := manager.ExecuteConversation(context.Background(), step3, config3, execCtx, buildContext, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result3)
 
@@ -1872,7 +1873,7 @@ func TestConversationManager_InjectContext_AppendedOnSecondTurn(t *testing.T) {
 	var capturedPrompts []string
 	mockProvider := mocks.NewMockAgentProvider("claude")
 
-	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		capturedPrompts = append(capturedPrompts, prompt)
 		result := workflow.NewConversationResult("claude")
 		result.State = state
@@ -1908,7 +1909,7 @@ func TestConversationManager_InjectContext_AppendedOnSecondTurn(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -1937,7 +1938,7 @@ func TestConversationManager_InjectContext_ExcludedFromFirstTurn(t *testing.T) {
 	var capturedPrompts []string
 	mockProvider := mocks.NewMockAgentProvider("claude")
 
-	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		capturedPrompts = append(capturedPrompts, prompt)
 		result := workflow.NewConversationResult("claude")
 		result.State = state
@@ -1973,7 +1974,7 @@ func TestConversationManager_InjectContext_ExcludedFromFirstTurn(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -2005,7 +2006,7 @@ func TestConversationManager_InjectContext_EmptyIsNoOp(t *testing.T) {
 			var capturedPrompts []string
 			mockProvider := mocks.NewMockAgentProvider("claude")
 
-			mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+			mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 				capturedPrompts = append(capturedPrompts, prompt)
 				result := workflow.NewConversationResult("claude")
 				result.State = state
@@ -2041,7 +2042,7 @@ func TestConversationManager_InjectContext_EmptyIsNoOp(t *testing.T) {
 				return interpolation.NewContext()
 			}
 
-			result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+			result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -2063,7 +2064,7 @@ func TestConversationManager_InjectContext_InterpolationError(t *testing.T) {
 	registry := mocks.NewMockAgentRegistry()
 
 	mockProvider := mocks.NewMockAgentProvider("claude")
-	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		result := workflow.NewConversationResult("claude")
 		result.State = state
 		_ = result.State.AddTurn(workflow.NewTurn(workflow.TurnRoleUser, prompt))
@@ -2098,7 +2099,7 @@ func TestConversationManager_InjectContext_InterpolationError(t *testing.T) {
 		return interpolation.NewContext()
 	}
 
-	_, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	_, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	// First turn succeeds (no injection). Second turn fails on inject_context interpolation.
 	require.Error(t, err)
@@ -2119,7 +2120,7 @@ func TestConversationManager_InjectContext_TemplateInterpolation(t *testing.T) {
 	var secondTurnPrompt string
 	callCount := 0
 	mockProvider := mocks.NewMockAgentProvider("claude")
-	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	mockProvider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		callCount++
 		if callCount == 2 {
 			secondTurnPrompt = prompt
@@ -2162,7 +2163,7 @@ func TestConversationManager_InjectContext_TemplateInterpolation(t *testing.T) {
 		return ctx
 	}
 
-	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+	result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -2266,7 +2267,7 @@ func TestConversationManager_ProviderInterpolation(t *testing.T) {
 				return ctx
 			}
 
-			result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext)
+			result, err := manager.ExecuteConversation(context.Background(), step, config, execCtx, buildContext, nil, nil)
 
 			if tt.expectError {
 				require.Error(t, err, "should return error")

--- a/internal/application/execution_service.go
+++ b/internal/application/execution_service.go
@@ -35,6 +35,7 @@ type ConversationExecutor interface {
 		config *workflow.ConversationConfig,
 		execCtx *workflow.ExecutionContext,
 		buildContext ContextBuilderFunc,
+		stdoutW, stderrW io.Writer,
 	) (*workflow.ConversationResult, error)
 }
 
@@ -2033,7 +2034,7 @@ func (s *ExecutionService) executeAgentStep(
 
 	// Execute the agent
 	s.logger.Debug("executing agent step", "step", step.Name, "provider", resolvedProvider)
-	result, execErr := provider.Execute(stepCtx, resolvedPrompt, step.Agent.Options)
+	result, execErr := provider.Execute(stepCtx, resolvedPrompt, step.Agent.Options, s.stdoutWriter, s.stderrWriter)
 
 	// Record step state
 	state := workflow.StepState{
@@ -2179,6 +2180,8 @@ func (s *ExecutionService) executeConversationStep(
 		step.Agent.Conversation,
 		execCtx,
 		buildContext,
+		s.stdoutWriter,
+		s.stderrWriter,
 	)
 
 	// 6. Map ConversationResult to StepState

--- a/internal/application/execution_service_conversation_step_test.go
+++ b/internal/application/execution_service_conversation_step_test.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -322,7 +323,7 @@ func TestExecuteConversationStep_T009_EdgeCase_ContextCancellation(t *testing.T)
 	execCtx.Status = workflow.StatusRunning
 	// Mock manager that checks context
 	mockConvMgr := &mockConversationManagerWithContextT009{
-		executeFunc: func(ctx context.Context, step *workflow.Step, config *workflow.ConversationConfig, execCtx *workflow.ExecutionContext, buildContext ContextBuilderFunc) (*workflow.ConversationResult, error) {
+		executeFunc: func(ctx context.Context, step *workflow.Step, config *workflow.ConversationConfig, execCtx *workflow.ExecutionContext, buildContext ContextBuilderFunc, stdoutW, stderrW io.Writer) (*workflow.ConversationResult, error) {
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
@@ -531,6 +532,7 @@ func (m *mockConversationManagerT009) ExecuteConversation(
 	config *workflow.ConversationConfig,
 	execCtx *workflow.ExecutionContext,
 	buildContext ContextBuilderFunc,
+	stdoutW, stderrW io.Writer,
 ) (*workflow.ConversationResult, error) {
 	if m.err != nil {
 		return nil, m.err
@@ -540,7 +542,7 @@ func (m *mockConversationManagerT009) ExecuteConversation(
 
 // mockConversationManagerWithContextT009 allows testing context cancellation.
 type mockConversationManagerWithContextT009 struct {
-	executeFunc func(ctx context.Context, step *workflow.Step, config *workflow.ConversationConfig, execCtx *workflow.ExecutionContext, buildContext ContextBuilderFunc) (*workflow.ConversationResult, error)
+	executeFunc func(ctx context.Context, step *workflow.Step, config *workflow.ConversationConfig, execCtx *workflow.ExecutionContext, buildContext ContextBuilderFunc, stdoutW, stderrW io.Writer) (*workflow.ConversationResult, error)
 }
 
 func (m *mockConversationManagerWithContextT009) ExecuteConversation(
@@ -549,8 +551,9 @@ func (m *mockConversationManagerWithContextT009) ExecuteConversation(
 	config *workflow.ConversationConfig,
 	execCtx *workflow.ExecutionContext,
 	buildContext ContextBuilderFunc,
+	stdoutW, stderrW io.Writer,
 ) (*workflow.ConversationResult, error) {
-	return m.executeFunc(ctx, step, config, execCtx, buildContext)
+	return m.executeFunc(ctx, step, config, execCtx, buildContext, stdoutW, stderrW)
 }
 
 // mockConversationManagerWithBuildContextT009 captures buildContext calls for verification.
@@ -565,6 +568,7 @@ func (m *mockConversationManagerWithBuildContextT009) ExecuteConversation(
 	config *workflow.ConversationConfig,
 	execCtx *workflow.ExecutionContext,
 	buildContext ContextBuilderFunc,
+	stdoutW, stderrW io.Writer,
 ) (*workflow.ConversationResult, error) {
 	if m.onExecute != nil {
 		m.onExecute(buildContext, execCtx)

--- a/internal/application/execution_service_conversation_test.go
+++ b/internal/application/execution_service_conversation_test.go
@@ -3,6 +3,7 @@ package application_test
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/awf-project/cli/internal/application"
@@ -239,7 +240,7 @@ func TestExecutionService_ConversationStep_SingleModeSkipsConversation(t *testin
 
 	registry := mocks.NewMockAgentRegistry()
 	claude := mocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Summarize this" {
 			return &workflow.AgentResult{
 				Provider: "claude",
@@ -303,7 +304,7 @@ func TestExecutionService_ConversationStep_EmptyModeDefaultsToSingle(t *testing.
 
 	registry := mocks.NewMockAgentRegistry()
 	claude := mocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Execute this task" {
 			return &workflow.AgentResult{
 				Provider: "claude",

--- a/internal/application/execution_service_dangerous_skip_audit_test.go
+++ b/internal/application/execution_service_dangerous_skip_audit_test.go
@@ -2,6 +2,7 @@ package application_test
 
 import (
 	"context"
+	"io"
 	"testing"
 	"time"
 
@@ -66,7 +67,7 @@ func TestExecutionService_AgentStep_DangerouslySkipPermissions_AuditLog(t *testi
 
 			registry := testmocks.NewMockAgentRegistry()
 			provider := testmocks.NewMockAgentProvider("claude")
-			provider.SetExecuteFunc(func(_ context.Context, _ string, _ map[string]any) (*workflow.AgentResult, error) {
+			provider.SetExecuteFunc(func(_ context.Context, _ string, _ map[string]any, _, _ io.Writer) (*workflow.AgentResult, error) {
 				return &workflow.AgentResult{
 					Provider:    "claude",
 					Output:      "ok",

--- a/internal/application/execution_service_hooks_test.go
+++ b/internal/application/execution_service_hooks_test.go
@@ -3,6 +3,7 @@ package application_test
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -63,7 +64,7 @@ func TestExecutionService_AgentStep_WithPreHook_Success(t *testing.T) {
 
 	registry := testmocks.NewMockAgentRegistry()
 	claude := testmocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, params map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, params map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Summarize this text" {
 			return &workflow.AgentResult{
 				Provider:    "claude",
@@ -145,7 +146,7 @@ func TestExecutionService_AgentStep_WithPostHook_OnSuccess(t *testing.T) {
 
 	registry := testmocks.NewMockAgentRegistry()
 	claude := testmocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, params map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, params map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Analyze the data" {
 			return &workflow.AgentResult{
 				Provider:    "claude",
@@ -232,7 +233,7 @@ func TestExecutionService_AgentStep_WithPostHook_OnFailure(t *testing.T) {
 
 	registry := testmocks.NewMockAgentRegistry()
 	claude := testmocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, params map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, params map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		if prompt == "Process the input" {
 			return &workflow.AgentResult{
 				Provider:    "claude",

--- a/internal/application/execution_service_json_field_mapping_test.go
+++ b/internal/application/execution_service_json_field_mapping_test.go
@@ -2,6 +2,7 @@ package application_test
 
 import (
 	"context"
+	"io"
 	"testing"
 
 	"github.com/awf-project/cli/internal/domain/ports"
@@ -60,7 +61,7 @@ func TestExecutionService_buildInterpolationContext_MapsJSONFieldToStepStateData
 	claude := mocks.NewMockAgentProvider("claude")
 
 	// Agent returns JSON that will be parsed into StepState.JSON
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider: "claude",
 			Output:   `{"name":"alice","count":42}`,
@@ -189,7 +190,7 @@ func TestExecutionService_buildInterpolationContext_JSONFieldNestedObjectAccess(
 	claude := mocks.NewMockAgentProvider("claude")
 
 	// Agent returns nested JSON structure
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider: "claude",
 			Output:   `{"user":{"name":"bob","address":{"city":"NYC","zip":"10001"}}}`,
@@ -279,7 +280,7 @@ func TestExecutionService_buildInterpolationContext_JSONFieldFromMultipleSteps(t
 	claude := mocks.NewMockAgentProvider("claude")
 
 	callCount := 0
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		callCount++
 		if callCount == 1 {
 			// First call returns user data
@@ -367,7 +368,7 @@ func TestExecutionService_buildInterpolationContext_JSONFieldWithBothResponseAnd
 	registry := mocks.NewMockAgentRegistry()
 	claude := mocks.NewMockAgentProvider("claude")
 
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider: "claude",
 			Output:   `{"source":"output_format"}`,

--- a/internal/application/execution_service_output_format_test.go
+++ b/internal/application/execution_service_output_format_test.go
@@ -2,6 +2,7 @@ package application_test
 
 import (
 	"context"
+	"io"
 	"testing"
 
 	"github.com/awf-project/cli/internal/application"
@@ -50,7 +51,7 @@ func TestExecutionService_AgentStep_OutputFormat_JSON_StripsFencesAndParsesJSON(
 	claude := mocks.NewMockAgentProvider("claude")
 
 	// Mock agent returns JSON wrapped in markdown code fences
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider: "claude",
 			Output:   "```json\n{\"name\":\"alice\",\"count\":3}\n```",
@@ -115,7 +116,7 @@ func TestExecutionService_AgentStep_OutputFormat_JSON_NoFences_ParsesDirectly(t 
 	claude := mocks.NewMockAgentProvider("claude")
 
 	// Agent returns raw JSON without fences
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider: "claude",
 			Output:   `{"status":"ok","value":42}`,
@@ -183,7 +184,7 @@ func TestExecutionService_AgentStep_OutputFormat_JSON_InvalidJSON_FailsStep(t *t
 	claude := mocks.NewMockAgentProvider("claude")
 
 	// Agent returns malformed JSON
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider: "claude",
 			Output:   "```json\n{invalid json here\n```",
@@ -243,7 +244,7 @@ func TestExecutionService_AgentStep_OutputFormat_Text_StripsFencesOnly(t *testin
 	claude := mocks.NewMockAgentProvider("claude")
 
 	// Agent returns text in bash code fence
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider: "claude",
 			Output:   "```bash\necho hello world\n```",
@@ -303,7 +304,7 @@ func TestExecutionService_AgentStep_OutputFormat_None_BackwardCompatibility(t *t
 
 	// Agent returns output with code fences
 	rawOutput := "```json\n{\"data\":\"value\"}\n```"
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider: "claude",
 			Output:   rawOutput,
@@ -362,7 +363,7 @@ func TestExecutionService_AgentStep_OutputFormat_JSON_ArrayParsing(t *testing.T)
 	claude := mocks.NewMockAgentProvider("claude")
 
 	// Agent returns JSON array
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider: "claude",
 			Output:   `["item1","item2","item3"]`,
@@ -429,7 +430,7 @@ func TestExecutionService_AgentStep_OutputFormat_JSON_LargeOutput(t *testing.T) 
 	}
 	largeJSON := `{"data":"` + string(largeValue) + `"}`
 
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider: "claude",
 			Output:   "```json\n" + largeJSON + "\n```",
@@ -494,7 +495,7 @@ func TestExecutionService_AgentStep_OutputFormat_JSON_ConversationMode(t *testin
 	claude := mocks.NewMockAgentProvider("claude")
 
 	// Mock conversation agent returns JSON wrapped in code fences
-	claude.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	claude.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		return &workflow.ConversationResult{
 			Provider:     "claude",
 			State:        state,
@@ -566,7 +567,7 @@ func TestExecutionService_AgentStep_OutputFormat_JSON_NestedFences(t *testing.T)
 
 	// Agent returns JSON containing code fences in a string field
 	// Note: JSON strings use literal characters, not escape sequences
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider: "claude",
 			Output:   "```json\n{\"code\":\"```\\necho hello\\n```\",\"type\":\"bash\"}\n```",
@@ -635,7 +636,7 @@ func TestExecutionService_AgentStep_OutputFormat_JSON_MultiStepInterpolation(t *
 	claude := mocks.NewMockAgentProvider("claude")
 
 	// Step 1: Agent returns JSON with name and count
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider: "claude",
 			Output:   "```json\n{\"name\":\"alice\",\"count\":3}\n```",
@@ -741,7 +742,7 @@ func TestExecutionService_AgentStep_OutputFormat_Text_DifferentLanguageTags(t *t
 			claude := mocks.NewMockAgentProvider("claude")
 
 			output := "```" + tt.langTag + "\n" + tt.content + "\n```"
-			claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+			claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 				return &workflow.AgentResult{
 					Provider: "claude",
 					Output:   output,
@@ -828,7 +829,7 @@ func TestExecutionService_AgentStep_OutputFormat_JSON_EmptyOutput(t *testing.T) 
 			registry := mocks.NewMockAgentRegistry()
 			claude := mocks.NewMockAgentProvider("claude")
 
-			claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+			claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 				return &workflow.AgentResult{
 					Provider: "claude",
 					Output:   tt.output,

--- a/internal/domain/ports/agent_provider.go
+++ b/internal/domain/ports/agent_provider.go
@@ -2,6 +2,7 @@ package ports
 
 import (
 	"context"
+	"io"
 
 	"github.com/awf-project/cli/internal/domain/workflow"
 )
@@ -11,13 +12,15 @@ import (
 // to this unified interface.
 type AgentProvider interface {
 	// Execute invokes the agent with the given prompt and options.
+	// When stdout/stderr writers are non-nil, agent output is streamed to them in real-time.
 	// Returns AgentResult containing output, parsed response, token usage, and any errors.
-	Execute(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error)
+	Execute(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error)
 
 	// ExecuteConversation invokes the agent with conversation history for multi-turn interactions.
+	// When stdout/stderr writers are non-nil, agent output is streamed to them in real-time.
 	// The state parameter contains the conversation history (turns) to send to the agent.
 	// Returns ConversationResult containing the updated conversation state, final output, and token usage.
-	ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error)
+	ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error)
 
 	// Name returns the provider identifier (e.g., "claude", "codex", "gemini").
 	Name() string

--- a/internal/domain/ports/agent_provider_test.go
+++ b/internal/domain/ports/agent_provider_test.go
@@ -3,6 +3,7 @@ package ports_test
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -16,8 +17,8 @@ import (
 // mockAgentProvider is a test implementation of AgentProvider interface
 type mockAgentProvider struct {
 	name                      string
-	executeFunc               func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error)
-	executeConversationFunc   func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error)
+	executeFunc               func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error)
+	executeConversationFunc   func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error)
 	validateFunc              func() error
 	executeCalled             int
 	executeConversationCalled int
@@ -26,13 +27,13 @@ type mockAgentProvider struct {
 func newMockAgentProvider(name string) *mockAgentProvider {
 	return &mockAgentProvider{
 		name: name,
-		executeFunc: func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+		executeFunc: func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 			result := workflow.NewAgentResult(name)
 			result.Output = "mock output"
 			result.CompletedAt = time.Now()
 			return result, nil
 		},
-		executeConversationFunc: func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+		executeConversationFunc: func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 			return nil, errors.New("not implemented")
 		},
 		validateFunc: func() error {
@@ -41,14 +42,14 @@ func newMockAgentProvider(name string) *mockAgentProvider {
 	}
 }
 
-func (m *mockAgentProvider) Execute(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+func (m *mockAgentProvider) Execute(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 	m.executeCalled++
-	return m.executeFunc(ctx, prompt, options)
+	return m.executeFunc(ctx, prompt, options, stdout, stderr)
 }
 
-func (m *mockAgentProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+func (m *mockAgentProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 	m.executeConversationCalled++
-	return m.executeConversationFunc(ctx, state, prompt, options)
+	return m.executeConversationFunc(ctx, state, prompt, options, stdout, stderr)
 }
 
 func (m *mockAgentProvider) Name() string {
@@ -116,7 +117,7 @@ func TestAgentProvider_Execute_HappyPath(t *testing.T) {
 		"max_tokens": 4096,
 	}
 
-	result, err := provider.Execute(ctx, prompt, options)
+	result, err := provider.Execute(ctx, prompt, options, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -173,7 +174,7 @@ func TestAgentProvider_Execute_EmptyPrompt(t *testing.T) {
 	prompt := ""
 	options := map[string]any{}
 
-	result, err := provider.Execute(ctx, prompt, options)
+	result, err := provider.Execute(ctx, prompt, options, nil, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -187,7 +188,7 @@ func TestAgentProvider_Execute_NilOptions(t *testing.T) {
 	ctx := context.Background()
 	prompt := "test prompt"
 
-	result, err := provider.Execute(ctx, prompt, nil)
+	result, err := provider.Execute(ctx, prompt, nil, nil, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -202,7 +203,7 @@ func TestAgentProvider_Execute_LargePrompt(t *testing.T) {
 	largePrompt := string(make([]byte, 10240))
 	options := map[string]any{}
 
-	result, err := provider.Execute(ctx, largePrompt, options)
+	result, err := provider.Execute(ctx, largePrompt, options, nil, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -213,7 +214,7 @@ func TestAgentProvider_Execute_LargePrompt(t *testing.T) {
 
 func TestAgentProvider_Execute_ContextCancellation(t *testing.T) {
 	provider := newMockAgentProvider("claude")
-	provider.executeFunc = func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	provider.executeFunc = func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -228,7 +229,7 @@ func TestAgentProvider_Execute_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	result, err := provider.Execute(ctx, "test", nil)
+	result, err := provider.Execute(ctx, "test", nil, nil, nil)
 
 	if err == nil {
 		t.Error("expected error from cancelled context")
@@ -241,11 +242,11 @@ func TestAgentProvider_Execute_ContextCancellation(t *testing.T) {
 func TestAgentProvider_Execute_ExecutionError(t *testing.T) {
 	provider := newMockAgentProvider("claude")
 	expectedErr := errors.New("execution failed")
-	provider.executeFunc = func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	provider.executeFunc = func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return nil, expectedErr
 	}
 
-	result, err := provider.Execute(context.Background(), "test", nil)
+	result, err := provider.Execute(context.Background(), "test", nil, nil, nil)
 
 	if err == nil {
 		t.Error("expected error, got nil")
@@ -261,7 +262,7 @@ func TestAgentProvider_Execute_ExecutionError(t *testing.T) {
 func TestAgentProvider_Execute_PartialResult(t *testing.T) {
 	provider := newMockAgentProvider("claude")
 	expectedErr := errors.New("partial execution")
-	provider.executeFunc = func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	provider.executeFunc = func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		// Return partial result with error
 		result := workflow.NewAgentResult("claude")
 		result.Output = "partial output"
@@ -270,7 +271,7 @@ func TestAgentProvider_Execute_PartialResult(t *testing.T) {
 		return result, expectedErr
 	}
 
-	result, err := provider.Execute(context.Background(), "test", nil)
+	result, err := provider.Execute(context.Background(), "test", nil, nil, nil)
 
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -465,7 +466,7 @@ func TestAgentProvider_FullWorkflow(t *testing.T) {
 		}
 
 		// Execute provider
-		result, err := provider.Execute(context.Background(), "test prompt", nil)
+		result, err := provider.Execute(context.Background(), "test prompt", nil, nil, nil)
 		if err != nil {
 			t.Errorf("execution failed for %s: %v", name, err)
 		}
@@ -485,7 +486,7 @@ func TestAgentProvider_FullWorkflow(t *testing.T) {
 // TestAgentProvider_ExecuteConversation_HappyPath tests normal conversation execution
 func TestAgentProvider_ExecuteConversation_HappyPath(t *testing.T) {
 	provider := newMockAgentProvider("claude")
-	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		result := workflow.NewConversationResult("claude")
 		result.Output = "Assistant response"
 		result.TokensInput = 100
@@ -503,7 +504,7 @@ func TestAgentProvider_ExecuteConversation_HappyPath(t *testing.T) {
 		"max_tokens": 4096,
 	}
 
-	result, err := provider.ExecuteConversation(ctx, state, prompt, options)
+	result, err := provider.ExecuteConversation(ctx, state, prompt, options, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -533,7 +534,7 @@ func TestAgentProvider_ExecuteConversation_HappyPath(t *testing.T) {
 // TestAgentProvider_ExecuteConversation_WithConversationHistory tests execution with existing turns
 func TestAgentProvider_ExecuteConversation_WithConversationHistory(t *testing.T) {
 	provider := newMockAgentProvider("claude")
-	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		result := workflow.NewConversationResult("claude")
 		result.State = state
 		result.Output = "Response based on history"
@@ -551,7 +552,7 @@ func TestAgentProvider_ExecuteConversation_WithConversationHistory(t *testing.T)
 	prompt := "Tell me more about it"
 	options := map[string]any{}
 
-	result, err := provider.ExecuteConversation(ctx, state, prompt, options)
+	result, err := provider.ExecuteConversation(ctx, state, prompt, options, nil, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -612,7 +613,7 @@ func TestAgentProvider_ExecuteConversation_WithOptions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := newMockAgentProvider("claude")
 			var capturedOptions map[string]any
-			provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+			provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 				capturedOptions = options
 				result := workflow.NewConversationResult("claude")
 				result.Output = "Response"
@@ -624,7 +625,7 @@ func TestAgentProvider_ExecuteConversation_WithOptions(t *testing.T) {
 			state := workflow.NewConversationState("System prompt")
 			prompt := "Test prompt"
 
-			result, err := provider.ExecuteConversation(ctx, state, prompt, tt.options)
+			result, err := provider.ExecuteConversation(ctx, state, prompt, tt.options, nil, nil)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -645,7 +646,7 @@ func TestAgentProvider_ExecuteConversation_WithOptions(t *testing.T) {
 // TestAgentProvider_ExecuteConversation_EmptyPrompt tests conversation with empty prompt
 func TestAgentProvider_ExecuteConversation_EmptyPrompt(t *testing.T) {
 	provider := newMockAgentProvider("claude")
-	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		if prompt == "" {
 			return nil, errors.New("prompt cannot be empty")
 		}
@@ -659,7 +660,7 @@ func TestAgentProvider_ExecuteConversation_EmptyPrompt(t *testing.T) {
 	prompt := ""
 	options := map[string]any{}
 
-	result, err := provider.ExecuteConversation(ctx, state, prompt, options)
+	result, err := provider.ExecuteConversation(ctx, state, prompt, options, nil, nil)
 
 	if err == nil {
 		t.Error("expected error for empty prompt")
@@ -675,7 +676,7 @@ func TestAgentProvider_ExecuteConversation_EmptyPrompt(t *testing.T) {
 // TestAgentProvider_ExecuteConversation_NilState tests conversation with nil state
 func TestAgentProvider_ExecuteConversation_NilState(t *testing.T) {
 	provider := newMockAgentProvider("claude")
-	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		if state == nil {
 			return nil, errors.New("conversation state cannot be nil")
 		}
@@ -689,7 +690,7 @@ func TestAgentProvider_ExecuteConversation_NilState(t *testing.T) {
 	prompt := "What is Go?"
 	options := map[string]any{}
 
-	result, err := provider.ExecuteConversation(ctx, state, prompt, options)
+	result, err := provider.ExecuteConversation(ctx, state, prompt, options, nil, nil)
 
 	if err == nil {
 		t.Error("expected error for nil conversation state")
@@ -702,7 +703,7 @@ func TestAgentProvider_ExecuteConversation_NilState(t *testing.T) {
 // TestAgentProvider_ExecuteConversation_EmptyState tests conversation with empty state (no turns)
 func TestAgentProvider_ExecuteConversation_EmptyState(t *testing.T) {
 	provider := newMockAgentProvider("claude")
-	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		result := workflow.NewConversationResult("claude")
 		result.Output = "First response"
 		result.State = state
@@ -715,7 +716,7 @@ func TestAgentProvider_ExecuteConversation_EmptyState(t *testing.T) {
 	prompt := "Hello"
 	options := map[string]any{}
 
-	result, err := provider.ExecuteConversation(ctx, state, prompt, options)
+	result, err := provider.ExecuteConversation(ctx, state, prompt, options, nil, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -730,7 +731,7 @@ func TestAgentProvider_ExecuteConversation_EmptyState(t *testing.T) {
 // TestAgentProvider_ExecuteConversation_LargeConversationHistory tests with many turns
 func TestAgentProvider_ExecuteConversation_LargeConversationHistory(t *testing.T) {
 	provider := newMockAgentProvider("claude")
-	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		result := workflow.NewConversationResult("claude")
 		result.State = state
 		result.Output = "Response to turn 100"
@@ -753,7 +754,7 @@ func TestAgentProvider_ExecuteConversation_LargeConversationHistory(t *testing.T
 	prompt := "100th question"
 	options := map[string]any{}
 
-	result, err := provider.ExecuteConversation(ctx, state, prompt, options)
+	result, err := provider.ExecuteConversation(ctx, state, prompt, options, nil, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -768,7 +769,7 @@ func TestAgentProvider_ExecuteConversation_LargeConversationHistory(t *testing.T
 // TestAgentProvider_ExecuteConversation_LongPrompt tests with very long prompt
 func TestAgentProvider_ExecuteConversation_LongPrompt(t *testing.T) {
 	provider := newMockAgentProvider("claude")
-	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		result := workflow.NewConversationResult("claude")
 		result.Output = "Response to long prompt"
 		result.CompletedAt = time.Now()
@@ -786,7 +787,7 @@ func TestAgentProvider_ExecuteConversation_LongPrompt(t *testing.T) {
 
 	options := map[string]any{}
 
-	result, err := provider.ExecuteConversation(ctx, state, longPrompt, options)
+	result, err := provider.ExecuteConversation(ctx, state, longPrompt, options, nil, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -799,7 +800,7 @@ func TestAgentProvider_ExecuteConversation_LongPrompt(t *testing.T) {
 func TestAgentProvider_ExecuteConversation_ProviderError(t *testing.T) {
 	provider := newMockAgentProvider("claude")
 	expectedError := errors.New("provider execution failed")
-	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		return nil, expectedError
 	}
 
@@ -808,7 +809,7 @@ func TestAgentProvider_ExecuteConversation_ProviderError(t *testing.T) {
 	prompt := "What is Go?"
 	options := map[string]any{}
 
-	result, err := provider.ExecuteConversation(ctx, state, prompt, options)
+	result, err := provider.ExecuteConversation(ctx, state, prompt, options, nil, nil)
 
 	if err == nil {
 		t.Error("expected error from provider")
@@ -824,7 +825,7 @@ func TestAgentProvider_ExecuteConversation_ProviderError(t *testing.T) {
 // TestAgentProvider_ExecuteConversation_ContextCanceled tests canceled context
 func TestAgentProvider_ExecuteConversation_ContextCanceled(t *testing.T) {
 	provider := newMockAgentProvider("claude")
-	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		// Check for context cancellation
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
@@ -841,7 +842,7 @@ func TestAgentProvider_ExecuteConversation_ContextCanceled(t *testing.T) {
 	prompt := "What is Go?"
 	options := map[string]any{}
 
-	result, err := provider.ExecuteConversation(ctx, state, prompt, options)
+	result, err := provider.ExecuteConversation(ctx, state, prompt, options, nil, nil)
 
 	if err == nil {
 		t.Error("expected error for canceled context")
@@ -857,7 +858,7 @@ func TestAgentProvider_ExecuteConversation_ContextCanceled(t *testing.T) {
 // TestAgentProvider_ExecuteConversation_ContextTimeout tests timeout
 func TestAgentProvider_ExecuteConversation_ContextTimeout(t *testing.T) {
 	provider := newMockAgentProvider("claude")
-	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		// Simulate work that respects context
 		select {
 		case <-ctx.Done():
@@ -876,7 +877,7 @@ func TestAgentProvider_ExecuteConversation_ContextTimeout(t *testing.T) {
 	prompt := "What is Go?"
 	options := map[string]any{}
 
-	result, err := provider.ExecuteConversation(ctx, state, prompt, options)
+	result, err := provider.ExecuteConversation(ctx, state, prompt, options, nil, nil)
 
 	if err == nil {
 		t.Error("expected timeout error")
@@ -922,7 +923,7 @@ func TestAgentProvider_ExecuteConversation_InvalidOptions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := newMockAgentProvider("claude")
-			provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+			provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 				// Validate options
 				if maxTokens, ok := options["max_tokens"].(int); ok && maxTokens < 0 {
 					return nil, errors.New("max_tokens must be non-negative")
@@ -942,7 +943,7 @@ func TestAgentProvider_ExecuteConversation_InvalidOptions(t *testing.T) {
 			state := workflow.NewConversationState("System prompt")
 			prompt := "What is Go?"
 
-			result, err := provider.ExecuteConversation(ctx, state, prompt, tt.options)
+			result, err := provider.ExecuteConversation(ctx, state, prompt, tt.options, nil, nil)
 
 			if err == nil {
 				t.Errorf("expected error for %s", tt.name)
@@ -964,7 +965,7 @@ func TestAgentProvider_ExecuteConversation_MultipleProviders(t *testing.T) {
 	for _, name := range providers {
 		t.Run(name, func(t *testing.T) {
 			provider := newMockAgentProvider(name)
-			provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+			provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 				result := workflow.NewConversationResult(name)
 				result.Output = "Response from " + name
 				result.CompletedAt = time.Now()
@@ -976,7 +977,7 @@ func TestAgentProvider_ExecuteConversation_MultipleProviders(t *testing.T) {
 			prompt := "Test"
 			options := map[string]any{}
 
-			result, err := provider.ExecuteConversation(ctx, state, prompt, options)
+			result, err := provider.ExecuteConversation(ctx, state, prompt, options, nil, nil)
 			if err != nil {
 				t.Errorf("unexpected error for %s: %v", name, err)
 			}
@@ -995,7 +996,7 @@ func TestAgentProvider_ExecuteConversation_WithRegistry(t *testing.T) {
 	registry := newMockAgentRegistry()
 
 	provider := newMockAgentProvider("claude")
-	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		result := workflow.NewConversationResult("claude")
 		result.Output = "Response"
 		result.CompletedAt = time.Now()
@@ -1011,7 +1012,7 @@ func TestAgentProvider_ExecuteConversation_WithRegistry(t *testing.T) {
 
 	ctx := context.Background()
 	state := workflow.NewConversationState("System prompt")
-	result, err := retrieved.ExecuteConversation(ctx, state, "Test", nil)
+	result, err := retrieved.ExecuteConversation(ctx, state, "Test", nil, nil, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -1026,7 +1027,7 @@ func TestAgentProvider_ExecuteConversation_WithRegistry(t *testing.T) {
 // TestAgentProvider_ExecuteConversation_TokenCounting tests token usage tracking
 func TestAgentProvider_ExecuteConversation_TokenCounting(t *testing.T) {
 	provider := newMockAgentProvider("claude")
-	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.executeConversationFunc = func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		result := workflow.NewConversationResult("claude")
 		result.Output = "Response"
 		result.TokensInput = 250
@@ -1042,7 +1043,7 @@ func TestAgentProvider_ExecuteConversation_TokenCounting(t *testing.T) {
 	prompt := "What is Go?"
 	options := map[string]any{}
 
-	result, err := provider.ExecuteConversation(ctx, state, prompt, options)
+	result, err := provider.ExecuteConversation(ctx, state, prompt, options, nil, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -1073,7 +1074,7 @@ func TestAgentProvider_ExecuteConversation_NotImplementedError(t *testing.T) {
 	prompt := "What is Go?"
 	options := map[string]any{}
 
-	result, err := provider.ExecuteConversation(ctx, state, prompt, options)
+	result, err := provider.ExecuteConversation(ctx, state, prompt, options, nil, nil)
 
 	if err == nil {
 		t.Error("expected 'not implemented' error from stub")

--- a/internal/domain/ports/cli_executor.go
+++ b/internal/domain/ports/cli_executor.go
@@ -1,6 +1,9 @@
 package ports
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 // CLIExecutor defines the contract for executing external CLI binaries.
 // Unlike CommandExecutor (shell execution via detected shell), this executes
@@ -13,6 +16,10 @@ type CLIExecutor interface {
 	// Run executes a binary with given arguments.
 	// Returns stdout and stderr as byte slices, plus any execution error.
 	//
+	// When stdoutW or stderrW are non-nil, output is tee'd to these writers
+	// in real-time (streaming mode) while also being captured in the returned
+	// byte slices. When nil, output is only captured (buffer mode).
+	//
 	// The context allows cancellation and timeout control.
 	// If the context is cancelled, the execution should be terminated.
 	//
@@ -20,5 +27,5 @@ type CLIExecutor interface {
 	// - Binary not found: error != nil
 	// - Non-zero exit code: error != nil (error should contain exit code info)
 	// - Context cancelled/timeout: error will be context.Canceled or context.DeadlineExceeded
-	Run(ctx context.Context, name string, args ...string) (stdout, stderr []byte, err error)
+	Run(ctx context.Context, name string, stdoutW, stderrW io.Writer, args ...string) (stdout, stderr []byte, err error)
 }

--- a/internal/domain/ports/cli_executor_test.go
+++ b/internal/domain/ports/cli_executor_test.go
@@ -3,6 +3,7 @@ package ports_test
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/awf-project/cli/internal/domain/ports"
@@ -13,7 +14,7 @@ import (
 
 // mockCLIExecutor is a test implementation of CLIExecutor interface
 type mockCLIExecutor struct {
-	runFunc    func(ctx context.Context, name string, args ...string) (stdout, stderr []byte, err error)
+	runFunc    func(ctx context.Context, name string, stdoutW, stderrW io.Writer, args ...string) (stdout, stderr []byte, err error)
 	runCalled  int
 	lastCalled struct {
 		name string
@@ -23,17 +24,17 @@ type mockCLIExecutor struct {
 
 func newMockCLIExecutor() *mockCLIExecutor {
 	return &mockCLIExecutor{
-		runFunc: func(ctx context.Context, name string, args ...string) (stdout, stderr []byte, err error) {
+		runFunc: func(ctx context.Context, name string, stdoutW, stderrW io.Writer, args ...string) (stdout, stderr []byte, err error) {
 			return []byte("mock stdout"), []byte(""), nil
 		},
 	}
 }
 
-func (m *mockCLIExecutor) Run(ctx context.Context, name string, args ...string) (stdout, stderr []byte, err error) {
+func (m *mockCLIExecutor) Run(ctx context.Context, name string, stdoutW, stderrW io.Writer, args ...string) (stdout, stderr []byte, err error) {
 	m.runCalled++
 	m.lastCalled.name = name
 	m.lastCalled.args = args
-	return m.runFunc(ctx, name, args...)
+	return m.runFunc(ctx, name, stdoutW, stderrW, args...)
 }
 
 func TestCLIExecutorInterface(t *testing.T) {
@@ -84,7 +85,7 @@ func TestCLIExecutor_Run_HappyPath(t *testing.T) {
 			mock := newMockCLIExecutor()
 			ctx := context.Background()
 
-			stdout, stderr, err := mock.Run(ctx, tt.binaryName, tt.args...)
+			stdout, stderr, err := mock.Run(ctx, tt.binaryName, nil, nil, tt.args...)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -106,12 +107,12 @@ func TestCLIExecutor_Run_HappyPath(t *testing.T) {
 
 func TestCLIExecutor_Run_WithStderr(t *testing.T) {
 	mock := newMockCLIExecutor()
-	mock.runFunc = func(ctx context.Context, name string, args ...string) ([]byte, []byte, error) {
+	mock.runFunc = func(ctx context.Context, name string, stdoutW, stderrW io.Writer, args ...string) ([]byte, []byte, error) {
 		return []byte("output"), []byte("warning message"), nil
 	}
 	ctx := context.Background()
 
-	stdout, stderr, err := mock.Run(ctx, "test-binary", "--flag")
+	stdout, stderr, err := mock.Run(ctx, "test-binary", nil, nil, "--flag")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -125,7 +126,7 @@ func TestCLIExecutor_Run_WithStderr(t *testing.T) {
 
 func TestCLIExecutor_Run_EmptyBinaryName(t *testing.T) {
 	mock := newMockCLIExecutor()
-	mock.runFunc = func(ctx context.Context, name string, args ...string) ([]byte, []byte, error) {
+	mock.runFunc = func(ctx context.Context, name string, stdoutW, stderrW io.Writer, args ...string) ([]byte, []byte, error) {
 		if name == "" {
 			return nil, nil, errors.New("binary name cannot be empty")
 		}
@@ -133,7 +134,7 @@ func TestCLIExecutor_Run_EmptyBinaryName(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	_, _, err := mock.Run(ctx, "", "--arg")
+	_, _, err := mock.Run(ctx, "", nil, nil, "--arg")
 
 	if err == nil {
 		t.Error("expected error for empty binary name, got nil")
@@ -147,7 +148,7 @@ func TestCLIExecutor_Run_NoArgs(t *testing.T) {
 	mock := newMockCLIExecutor()
 	ctx := context.Background()
 
-	stdout, stderr, err := mock.Run(ctx, "test-binary")
+	stdout, stderr, err := mock.Run(ctx, "test-binary", nil, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -164,12 +165,12 @@ func TestCLIExecutor_Run_NoArgs(t *testing.T) {
 
 func TestCLIExecutor_Run_EmptyStdout(t *testing.T) {
 	mock := newMockCLIExecutor()
-	mock.runFunc = func(ctx context.Context, name string, args ...string) ([]byte, []byte, error) {
+	mock.runFunc = func(ctx context.Context, name string, stdoutW, stderrW io.Writer, args ...string) ([]byte, []byte, error) {
 		return []byte(""), []byte(""), nil
 	}
 	ctx := context.Background()
 
-	stdout, stderr, err := mock.Run(ctx, "test-binary")
+	stdout, stderr, err := mock.Run(ctx, "test-binary", nil, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -187,12 +188,12 @@ func TestCLIExecutor_Run_LargeOutput(t *testing.T) {
 	for i := range largeOutput {
 		largeOutput[i] = 'A'
 	}
-	mock.runFunc = func(ctx context.Context, name string, args ...string) ([]byte, []byte, error) {
+	mock.runFunc = func(ctx context.Context, name string, stdoutW, stderrW io.Writer, args ...string) ([]byte, []byte, error) {
 		return largeOutput, []byte(""), nil
 	}
 	ctx := context.Background()
 
-	stdout, _, err := mock.Run(ctx, "test-binary")
+	stdout, _, err := mock.Run(ctx, "test-binary", nil, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -232,12 +233,12 @@ func TestCLIExecutor_Run_ExecutionError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := newMockCLIExecutor()
-			mock.runFunc = func(ctx context.Context, name string, args ...string) ([]byte, []byte, error) {
+			mock.runFunc = func(ctx context.Context, name string, stdoutW, stderrW io.Writer, args ...string) ([]byte, []byte, error) {
 				return nil, []byte("error output"), tt.mockError
 			}
 			ctx := context.Background()
 
-			stdout, stderr, err := mock.Run(ctx, "test-binary")
+			stdout, stderr, err := mock.Run(ctx, "test-binary", nil, nil)
 
 			if err == nil {
 				t.Error("expected error, got nil")
@@ -257,7 +258,7 @@ func TestCLIExecutor_Run_ExecutionError(t *testing.T) {
 
 func TestCLIExecutor_Run_ContextCancellation(t *testing.T) {
 	mock := newMockCLIExecutor()
-	mock.runFunc = func(ctx context.Context, name string, args ...string) ([]byte, []byte, error) {
+	mock.runFunc = func(ctx context.Context, name string, stdoutW, stderrW io.Writer, args ...string) ([]byte, []byte, error) {
 		select {
 		case <-ctx.Done():
 			return nil, nil, ctx.Err()
@@ -268,7 +269,7 @@ func TestCLIExecutor_Run_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	_, _, err := mock.Run(ctx, "test-binary")
+	_, _, err := mock.Run(ctx, "test-binary", nil, nil)
 
 	if err == nil {
 		t.Error("expected error for cancelled context, got nil")
@@ -280,7 +281,7 @@ func TestCLIExecutor_Run_ContextCancellation(t *testing.T) {
 
 func TestCLIExecutor_Run_ContextDeadline(t *testing.T) {
 	mock := newMockCLIExecutor()
-	mock.runFunc = func(ctx context.Context, name string, args ...string) ([]byte, []byte, error) {
+	mock.runFunc = func(ctx context.Context, name string, stdoutW, stderrW io.Writer, args ...string) ([]byte, []byte, error) {
 		select {
 		case <-ctx.Done():
 			return nil, nil, ctx.Err()
@@ -291,7 +292,7 @@ func TestCLIExecutor_Run_ContextDeadline(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 0) // Already expired
 	defer cancel()
 
-	_, _, err := mock.Run(ctx, "test-binary")
+	_, _, err := mock.Run(ctx, "test-binary", nil, nil)
 
 	if err == nil {
 		t.Error("expected error for expired context, got nil")
@@ -303,12 +304,12 @@ func TestCLIExecutor_Run_ContextDeadline(t *testing.T) {
 
 func TestCLIExecutor_Run_ErrorWithStderr(t *testing.T) {
 	mock := newMockCLIExecutor()
-	mock.runFunc = func(ctx context.Context, name string, args ...string) ([]byte, []byte, error) {
+	mock.runFunc = func(ctx context.Context, name string, stdoutW, stderrW io.Writer, args ...string) ([]byte, []byte, error) {
 		return nil, []byte("detailed error message"), errors.New("command failed")
 	}
 	ctx := context.Background()
 
-	stdout, stderr, err := mock.Run(ctx, "test-binary")
+	stdout, stderr, err := mock.Run(ctx, "test-binary", nil, nil)
 
 	if err == nil {
 		t.Error("expected error, got nil")
@@ -326,7 +327,7 @@ func TestCLIExecutor_Run_ArgumentOrder(t *testing.T) {
 	ctx := context.Background()
 	expectedArgs := []string{"--flag1", "value1", "--flag2", "value2"}
 
-	_, _, _ = mock.Run(ctx, "test-binary", expectedArgs...)
+	_, _, _ = mock.Run(ctx, "test-binary", nil, nil, expectedArgs...)
 
 	if len(mock.lastCalled.args) != len(expectedArgs) {
 		t.Errorf("expected %d args, got %d", len(expectedArgs), len(mock.lastCalled.args))
@@ -343,7 +344,7 @@ func TestCLIExecutor_Run_ArgumentsWithSpaces(t *testing.T) {
 	ctx := context.Background()
 	argsWithSpaces := []string{"-p", "hello world", "--data", "value with spaces"}
 
-	_, _, _ = mock.Run(ctx, "test-binary", argsWithSpaces...)
+	_, _, _ = mock.Run(ctx, "test-binary", nil, nil, argsWithSpaces...)
 
 	if len(mock.lastCalled.args) != len(argsWithSpaces) {
 		t.Errorf("expected %d args, got %d", len(argsWithSpaces), len(mock.lastCalled.args))
@@ -372,7 +373,7 @@ func TestCLIExecutor_Run_SpecialCharacters(t *testing.T) {
 			mock := newMockCLIExecutor()
 			ctx := context.Background()
 
-			_, _, err := mock.Run(ctx, "test-binary", tt.args...)
+			_, _, err := mock.Run(ctx, "test-binary", nil, nil, tt.args...)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -387,9 +388,9 @@ func TestCLIExecutor_Run_MultipleCallsTracking(t *testing.T) {
 	mock := newMockCLIExecutor()
 	ctx := context.Background()
 
-	_, _, _ = mock.Run(ctx, "first-binary", "arg1")
-	_, _, _ = mock.Run(ctx, "second-binary", "arg2", "arg3")
-	_, _, _ = mock.Run(ctx, "third-binary")
+	_, _, _ = mock.Run(ctx, "first-binary", nil, nil, "arg1")
+	_, _, _ = mock.Run(ctx, "second-binary", nil, nil, "arg2", "arg3")
+	_, _, _ = mock.Run(ctx, "third-binary", nil, nil)
 
 	if mock.runCalled != 3 {
 		t.Errorf("expected 3 calls, got %d", mock.runCalled)

--- a/internal/infrastructure/agents/claude_provider.go
+++ b/internal/infrastructure/agents/claude_provider.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os/exec"
 	"slices"
 	"strings"
@@ -16,7 +17,7 @@ import (
 )
 
 // ClaudeProvider implements AgentProvider for Claude CLI.
-// Invokes: claude -p "prompt" --output-format json
+// Invokes: claude -p "prompt" --output-format stream-json
 type ClaudeProvider struct {
 	logger   ports.Logger
 	executor ports.CLIExecutor
@@ -46,7 +47,7 @@ func NewClaudeProviderWithOptions(opts ...ClaudeProviderOption) *ClaudeProvider 
 	return p
 }
 
-func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 	startedAt := time.Now()
 
 	if strings.TrimSpace(prompt) == "" {
@@ -66,8 +67,11 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, options map
 	if model, ok := getStringOption(options, "model"); ok {
 		args = append(args, "--model", model)
 	}
-	if outputFormat, ok := getStringOption(options, "output_format"); ok && outputFormat == "json" {
-		args = append(args, "--output-format", "json")
+	if outputFormat, ok := getStringOption(options, "output_format"); ok {
+		if outputFormat == "json" {
+			outputFormat = "stream-json"
+		}
+		args = append(args, "--output-format", outputFormat)
 	}
 	if allowedTools, ok := getStringOption(options, "allowed_tools"); ok && allowedTools != "" {
 		args = append(args, "--allowedTools", allowedTools)
@@ -77,16 +81,16 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, options map
 		p.logger.Info("[SECURITY AUDIT] dangerously_skip_permissions enabled",
 			"timestamp", time.Now().Format(time.RFC3339))
 	}
-	stdout, stderr, err := p.executor.Run(ctx, "claude", args...)
+	stdoutBytes, stderrBytes, err := p.executor.Run(ctx, "claude", stdout, stderr, args...)
 	completedAt := time.Now()
 
 	if err != nil {
 		return nil, fmt.Errorf("claude execution failed: %w", err)
 	}
 
-	output := make([]byte, 0, len(stdout)+len(stderr))
-	output = append(output, stdout...)
-	output = append(output, stderr...)
+	output := make([]byte, 0, len(stdoutBytes)+len(stderrBytes))
+	output = append(output, stdoutBytes...)
+	output = append(output, stderrBytes...)
 	outputStr := string(output)
 	result := &workflow.AgentResult{
 		Provider:        "claude",
@@ -113,7 +117,7 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, options map
 // ExecuteConversation invokes the Claude CLI with conversation history for multi-turn interactions.
 //
 //nolint:gocognit // Complexity 31: conversation executor manages multi-turn state, context windows, token limits, retries, streaming. Conversation orchestration requires this.
-func (p *ClaudeProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+func (p *ClaudeProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 	startedAt := time.Now()
 
 	if state == nil {
@@ -145,8 +149,8 @@ func (p *ClaudeProvider) ExecuteConversation(ctx context.Context, state *workflo
 		args = append(args, "--model", model)
 	}
 
-	// Force JSON output for session ID extraction on all conversation turns
-	args = append(args, "--output-format", "json")
+	// Force stream-json output for session ID extraction on all conversation turns
+	args = append(args, "--output-format", "stream-json")
 
 	// Resume from previous session if available
 	if workingState.SessionID != "" {
@@ -170,19 +174,19 @@ func (p *ClaudeProvider) ExecuteConversation(ctx context.Context, state *workflo
 			"timestamp", time.Now().Format(time.RFC3339))
 	}
 
-	stdout, stderr, err := p.executor.Run(ctx, "claude", args...)
+	stdoutBytes, stderrBytes, err := p.executor.Run(ctx, "claude", stdout, stderr, args...)
 	completedAt := time.Now()
 
 	if err != nil {
 		return nil, fmt.Errorf("claude execution failed: %w", err)
 	}
 
-	output := make([]byte, 0, len(stdout)+len(stderr))
-	output = append(output, stdout...)
-	output = append(output, stderr...)
+	output := make([]byte, 0, len(stdoutBytes)+len(stderrBytes))
+	output = append(output, stdoutBytes...)
+	output = append(output, stderrBytes...)
 
 	// Extract text content from JSON wrapper
-	// Claude's --output-format json wraps response in JSON: {"session_id":"...", "result":"actual text", ...}
+	// Claude's --output-format stream-json wraps response in JSON: {"session_id":"...", "result":"actual text", ...}
 	// We need the clean text for the assistant turn, not the raw JSON.
 	// On extraction failure, gracefully fall back to raw output string.
 	rawOutputStr := string(output)

--- a/internal/infrastructure/agents/claude_provider_session_test.go
+++ b/internal/infrastructure/agents/claude_provider_session_test.go
@@ -39,7 +39,7 @@ func TestClaudeProvider_ExecuteConversation_ResumeFlag(t *testing.T) {
 			state := workflow.NewConversationState("system")
 			state.SessionID = tt.sessionID
 
-			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", nil)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", nil, nil, nil)
 			require.NoError(t, err)
 			require.NotNil(t, result)
 
@@ -88,7 +88,7 @@ func TestClaudeProvider_ExecuteConversation_SessionIDExtracted(t *testing.T) {
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 			state := workflow.NewConversationState("system")
-			result, err := provider.ExecuteConversation(context.Background(), state, "test", nil)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test", nil, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -106,7 +106,7 @@ func TestClaudeProvider_ExecuteConversation_SystemPromptOnFirstTurn(t *testing.T
 	state := workflow.NewConversationState("")
 	options := map[string]any{"system_prompt": "You are a code reviewer"}
 
-	_, err := provider.ExecuteConversation(context.Background(), state, "Review this", options)
+	_, err := provider.ExecuteConversation(context.Background(), state, "Review this", options, nil, nil)
 	require.NoError(t, err)
 
 	calls := mockExec.GetCalls()
@@ -124,7 +124,7 @@ func TestClaudeProvider_ExecuteConversation_NoSystemPromptOnResumeTurn(t *testin
 	state.SessionID = "existing_session_id"
 	options := map[string]any{"system_prompt": "You are a code reviewer"}
 
-	_, err := provider.ExecuteConversation(context.Background(), state, "Continue", options)
+	_, err := provider.ExecuteConversation(context.Background(), state, "Continue", options, nil, nil)
 	require.NoError(t, err)
 
 	calls := mockExec.GetCalls()
@@ -138,7 +138,7 @@ func TestClaudeProvider_ExecuteConversation_GracefulFallback_NonJSON(t *testing.
 	provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 	state := workflow.NewConversationState("system")
-	result, err := provider.ExecuteConversation(context.Background(), state, "test", nil)
+	result, err := provider.ExecuteConversation(context.Background(), state, "test", nil, nil, nil)
 
 	require.NoError(t, err, "extraction failure must not cause error")
 	require.NotNil(t, result)
@@ -152,11 +152,11 @@ func TestClaudeProvider_ExecuteConversation_ForceJSONOutputFormat(t *testing.T) 
 
 	state := workflow.NewConversationState("system")
 
-	_, err := provider.ExecuteConversation(context.Background(), state, "test", nil)
+	_, err := provider.ExecuteConversation(context.Background(), state, "test", nil, nil, nil)
 	require.NoError(t, err)
 
 	calls := mockExec.GetCalls()
 	require.Len(t, calls, 1)
 	assert.Contains(t, calls[0].Args, "--output-format")
-	assert.Contains(t, calls[0].Args, "json")
+	assert.Contains(t, calls[0].Args, "stream-json")
 }

--- a/internal/infrastructure/agents/claude_provider_stream_json_test.go
+++ b/internal/infrastructure/agents/claude_provider_stream_json_test.go
@@ -1,0 +1,317 @@
+package agents
+
+import (
+	"context"
+	"testing"
+
+	"github.com/awf-project/cli/internal/domain/workflow"
+	"github.com/awf-project/cli/internal/testutil/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// F078 Tests: Fix CLI Provider Invocations (output_format mapping and ExecuteConversation session handling)
+
+// T001: Execute maps output_format: json to stream-json
+func TestClaudeProvider_Execute_OutputFormatMapping(t *testing.T) {
+	tests := []struct {
+		name           string
+		options        map[string]any
+		mockOutput     []byte
+		wantFormatFlag string
+	}{
+		{
+			name:           "json format mapped to stream-json",
+			options:        map[string]any{"output_format": "json"},
+			mockOutput:     []byte(`{"result":"test output"}`),
+			wantFormatFlag: "stream-json",
+		},
+		{
+			name:           "stream-json format passed through",
+			options:        map[string]any{"output_format": "stream-json"},
+			mockOutput:     []byte("test output"),
+			wantFormatFlag: "stream-json",
+		},
+		{
+			name:           "no output format specified",
+			options:        map[string]any{},
+			mockOutput:     []byte("test output"),
+			wantFormatFlag: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			mockExec.SetOutput(tt.mockOutput, nil)
+			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
+
+			_, err := provider.Execute(context.Background(), "test prompt", tt.options, nil, nil)
+
+			require.NoError(t, err)
+
+			calls := mockExec.GetCalls()
+			require.Len(t, calls, 1)
+			call := calls[0]
+
+			if tt.wantFormatFlag != "" {
+				// Find --output-format flag in args
+				found := false
+				for i, arg := range call.Args {
+					if arg == "--output-format" && i+1 < len(call.Args) {
+						assert.Equal(t, tt.wantFormatFlag, call.Args[i+1])
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected --output-format flag not found in args: %v", call.Args)
+			} else {
+				// Ensure no --output-format flag
+				for i, arg := range call.Args {
+					if arg == "--output-format" {
+						t.Errorf("unexpected --output-format flag in args: %v", call.Args)
+					}
+					_ = i
+				}
+			}
+		})
+	}
+}
+
+// ExecuteConversation always forces stream-json for session ID extraction
+func TestClaudeProvider_ExecuteConversation_ForcesStreamJSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		state     *workflow.ConversationState
+		sessionID string
+	}{
+		{
+			name:      "first turn (no sessionID)",
+			state:     &workflow.ConversationState{Turns: []workflow.Turn{}},
+			sessionID: "",
+		},
+		{
+			name: "resume turn (with existing sessionID)",
+			state: &workflow.ConversationState{
+				SessionID: "session-123",
+				Turns:     []workflow.Turn{},
+			},
+			sessionID: "session-123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			mockExec.SetOutput([]byte(`{"session_id":"sess-456","result":"response text"}`), nil)
+			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
+
+			_, err := provider.ExecuteConversation(context.Background(), tt.state, "user prompt", map[string]any{}, nil, nil)
+
+			require.NoError(t, err)
+
+			calls := mockExec.GetCalls()
+			require.Len(t, calls, 1)
+			call := calls[0]
+
+			// Assert --output-format stream-json is always present
+			found := false
+			for i, arg := range call.Args {
+				if arg == "--output-format" && i+1 < len(call.Args) {
+					assert.Equal(t, "stream-json", call.Args[i+1],
+						"ExecuteConversation must force stream-json for session ID extraction")
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "--output-format stream-json not found in args: %v", call.Args)
+
+			// Verify session resume flag when sessionID exists
+			if tt.sessionID != "" {
+				hasResume := false
+				for i, arg := range call.Args {
+					if arg == "-r" && i+1 < len(call.Args) && call.Args[i+1] == tt.sessionID {
+						hasResume = true
+						break
+					}
+				}
+				assert.True(t, hasResume, "expected -r %s flag in resume turn", tt.sessionID)
+			}
+		})
+	}
+}
+
+// extractSessionID works with stream-json output format
+func TestClaudeProvider_ExtractSessionID_StreamJSON(t *testing.T) {
+	provider := NewClaudeProvider()
+
+	tests := []struct {
+		name      string
+		output    string
+		wantID    string
+		wantError bool
+	}{
+		{
+			name:      "valid stream-json with session_id",
+			output:    `{"session_id":"sess-abc123","result":"text","cost_usd":0.001}`,
+			wantID:    "sess-abc123",
+			wantError: false,
+		},
+		{
+			name:      "valid stream-json with different field order",
+			output:    `{"result":"text","session_id":"sess-xyz789","cost_usd":0.002}`,
+			wantID:    "sess-xyz789",
+			wantError: false,
+		},
+		{
+			name:      "missing session_id field",
+			output:    `{"result":"text","cost_usd":0.001}`,
+			wantID:    "",
+			wantError: true,
+		},
+		{
+			name:      "invalid JSON",
+			output:    `not valid json`,
+			wantID:    "",
+			wantError: true,
+		},
+		{
+			name:      "empty output",
+			output:    "",
+			wantID:    "",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := provider.extractSessionID(tt.output)
+
+			if tt.wantError {
+				assert.Error(t, err)
+				assert.Equal(t, "", id)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantID, id)
+			}
+		})
+	}
+}
+
+// extractTextFromJSON works with stream-json output
+func TestClaudeProvider_ExtractTextFromJSON_StreamJSON(t *testing.T) {
+	provider := NewClaudeProvider()
+
+	tests := []struct {
+		name     string
+		output   string
+		wantText string
+	}{
+		{
+			name:     "valid stream-json with result field",
+			output:   `{"session_id":"sess-123","result":"Hello, this is the response","cost_usd":0.001}`,
+			wantText: "Hello, this is the response",
+		},
+		{
+			name:     "stream-json with multiline result",
+			output:   `{"session_id":"sess-456","result":"Line 1\nLine 2\nLine 3"}`,
+			wantText: "Line 1\nLine 2\nLine 3",
+		},
+		{
+			name:     "stream-json with empty result",
+			output:   `{"session_id":"sess-789","result":""}`,
+			wantText: "",
+		},
+		{
+			name:     "non-JSON output (graceful fallback)",
+			output:   `plain text response`,
+			wantText: "",
+		},
+		{
+			name:     "invalid JSON (graceful fallback)",
+			output:   `{"result": invalid}`,
+			wantText: "",
+		},
+		{
+			name:     "missing result field (graceful fallback)",
+			output:   `{"session_id":"sess-999","cost_usd":0.001}`,
+			wantText: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text := provider.extractTextFromJSON(tt.output)
+			assert.Equal(t, tt.wantText, text)
+		})
+	}
+}
+
+// Execute with invalid input
+func TestClaudeProvider_Execute_ErrorHandling(t *testing.T) {
+	tests := []struct {
+		name      string
+		prompt    string
+		options   map[string]any
+		wantError bool
+		errMsg    string
+	}{
+		{
+			name:      "empty prompt",
+			prompt:    "",
+			options:   map[string]any{},
+			wantError: true,
+			errMsg:    "prompt cannot be empty",
+		},
+		{
+			name:      "invalid model format",
+			prompt:    "test",
+			options:   map[string]any{"model": "invalid-model"},
+			wantError: true,
+			errMsg:    "invalid model format",
+		},
+		{
+			name:      "valid model alias",
+			prompt:    "test",
+			options:   map[string]any{"model": "sonnet"},
+			wantError: false,
+		},
+		{
+			name:      "valid claude-prefixed model",
+			prompt:    "test",
+			options:   map[string]any{"model": "claude-3-opus"},
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			if !tt.wantError {
+				mockExec.SetOutput([]byte("response"), nil)
+			}
+			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
+
+			_, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
+
+			if tt.wantError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// ExecuteConversation with nil state
+func TestClaudeProvider_ExecuteConversation_NilState(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	mockExec.SetOutput([]byte("response"), nil)
+	provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
+
+	_, err := provider.ExecuteConversation(context.Background(), nil, "prompt", map[string]any{}, nil, nil)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "conversation state cannot be nil")
+}

--- a/internal/infrastructure/agents/claude_provider_unit_test.go
+++ b/internal/infrastructure/agents/claude_provider_unit_test.go
@@ -70,7 +70,7 @@ func TestClaudeProvider_Execute_Success(t *testing.T) {
 			mockExec.SetOutput(tt.mockStdout, nil)
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), tt.prompt, tt.options)
+			result, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -134,7 +134,7 @@ func TestClaudeProvider_Execute_JSONParsing(t *testing.T) {
 			mockExec.SetOutput(tt.mockStdout, nil)
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "test", tt.options)
+			result, err := provider.Execute(context.Background(), "test", tt.options, nil, nil)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -199,7 +199,7 @@ func TestClaudeProvider_Execute_ValidationErrors(t *testing.T) {
 			mockExec.SetOutput([]byte("response"), nil)
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), tt.prompt, tt.options)
+			result, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
 
 			if tt.wantErr != "" {
 				assert.Error(t, err)
@@ -247,7 +247,7 @@ func TestClaudeProvider_Execute_ContextErrors(t *testing.T) {
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 			ctx := tt.ctxFunc()
-			result, err := provider.Execute(ctx, "test prompt", nil)
+			result, err := provider.Execute(ctx, "test prompt", nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -285,7 +285,7 @@ func TestClaudeProvider_Execute_CLIErrors(t *testing.T) {
 			mockExec.SetError(tt.mockErr)
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "test prompt", nil)
+			result, err := provider.Execute(context.Background(), "test prompt", nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -333,7 +333,7 @@ func TestClaudeProvider_Execute_StdoutStderrCombination(t *testing.T) {
 			mockExec.SetOutput(tt.stdout, tt.stderr)
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "test", nil)
+			result, err := provider.Execute(context.Background(), "test", nil, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -369,7 +369,7 @@ func TestClaudeProvider_Execute_CLIArgumentConstruction(t *testing.T) {
 			prompt:       "test",
 			options:      map[string]any{"output_format": "json"},
 			mockOutput:   []byte(`{"result":"ok"}`),
-			wantContains: []string{"-p", "test", "--output-format", "json"},
+			wantContains: []string{"-p", "test", "--output-format", "stream-json"},
 		},
 		{
 			name:         "with allowed tools",
@@ -393,7 +393,7 @@ func TestClaudeProvider_Execute_CLIArgumentConstruction(t *testing.T) {
 			mockExec.SetOutput(tt.mockOutput, nil)
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
-			_, err := provider.Execute(context.Background(), tt.prompt, tt.options)
+			_, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
 			require.NoError(t, err)
 
 			calls := mockExec.GetCalls()
@@ -470,7 +470,7 @@ func TestClaudeProvider_ExecuteConversation_Success(t *testing.T) {
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 			state := tt.stateSetup()
-			result, err := provider.ExecuteConversation(context.Background(), state, tt.prompt, tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), state, tt.prompt, tt.options, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -531,7 +531,7 @@ func TestClaudeProvider_ExecuteConversation_ValidationErrors(t *testing.T) {
 			mockExec.SetOutput([]byte("response"), nil)
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
-			result, err := provider.ExecuteConversation(context.Background(), tt.state, tt.prompt, tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), tt.state, tt.prompt, tt.options, nil, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -575,7 +575,7 @@ func TestClaudeProvider_ExecuteConversation_ContextErrors(t *testing.T) {
 
 			state := workflow.NewConversationState("system")
 			ctx := tt.ctxFunc()
-			result, err := provider.ExecuteConversation(ctx, state, "test", nil)
+			result, err := provider.ExecuteConversation(ctx, state, "test", nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -609,7 +609,7 @@ func TestClaudeProvider_ExecuteConversation_CLIErrors(t *testing.T) {
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 			state := workflow.NewConversationState("system")
-			result, err := provider.ExecuteConversation(context.Background(), state, "test", nil)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test", nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -637,7 +637,7 @@ func TestClaudeProvider_ExecuteConversation_StatePreservation(t *testing.T) {
 	initialTotalTurns := initialState.TotalTurns
 	initialTotalTokens := initialState.TotalTokens
 
-	result, err := provider.ExecuteConversation(context.Background(), initialState, "How are you?", nil)
+	result, err := provider.ExecuteConversation(context.Background(), initialState, "How are you?", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -659,7 +659,7 @@ func TestClaudeProvider_ExecuteConversation_TokenCounting(t *testing.T) {
 	provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 	state := workflow.NewConversationState("You are helpful")
-	result, err := provider.ExecuteConversation(context.Background(), state, "Hello", nil)
+	result, err := provider.ExecuteConversation(context.Background(), state, "Hello", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -699,7 +699,7 @@ func TestClaudeProvider_ExecuteConversation_JSONParsing(t *testing.T) {
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 			state := workflow.NewConversationState("system")
-			result, err := provider.ExecuteConversation(context.Background(), state, "test", tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test", tt.options, nil, nil)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -765,7 +765,7 @@ func TestClaudeProvider_ExecuteConversation_GracefulFallback(t *testing.T) {
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 			state := workflow.NewConversationState("system")
-			result, err := provider.ExecuteConversation(context.Background(), state, "test", tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test", tt.options, nil, nil)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -794,7 +794,7 @@ func TestClaudeProvider_Execute_EmptyState(t *testing.T) {
 	provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 	state := &workflow.ConversationState{}
-	result, err := provider.ExecuteConversation(context.Background(), state, "test", nil)
+	result, err := provider.ExecuteConversation(context.Background(), state, "test", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -806,7 +806,7 @@ func TestClaudeProvider_Execute_OptionsNil(t *testing.T) {
 	mockExec.SetOutput([]byte("response"), nil)
 	provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
-	result, err := provider.Execute(context.Background(), "test", nil)
+	result, err := provider.Execute(context.Background(), "test", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -824,7 +824,7 @@ func TestClaudeProvider_Execute_MultipleOptions(t *testing.T) {
 		"allowed_tools": "bash",
 	}
 
-	result, err := provider.Execute(context.Background(), "test", options)
+	result, err := provider.Execute(context.Background(), "test", options, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -850,28 +850,28 @@ func TestClaudeProvider_ExecuteConversation_CLIArgumentConstruction(t *testing.T
 			prompt:       "Hello",
 			options:      nil,
 			mockOutput:   []byte("Hi there!"),
-			wantContains: []string{"-p", "Hello", "--output-format", "json"},
+			wantContains: []string{"-p", "Hello", "--output-format", "stream-json"},
 		},
 		{
 			name:         "with model",
 			prompt:       "test",
 			options:      map[string]any{"model": "opus"},
 			mockOutput:   []byte("response"),
-			wantContains: []string{"-p", "test", "--model", "opus", "--output-format", "json"},
+			wantContains: []string{"-p", "test", "--model", "opus", "--output-format", "stream-json"},
 		},
 		{
 			name:         "with allowed tools",
 			prompt:       "test",
 			options:      map[string]any{"allowed_tools": "bash,read"},
 			mockOutput:   []byte("response"),
-			wantContains: []string{"-p", "test", "--allowedTools", "bash,read", "--output-format", "json"},
+			wantContains: []string{"-p", "test", "--allowedTools", "bash,read", "--output-format", "stream-json"},
 		},
 		{
 			name:         "with dangerous skip permissions",
 			prompt:       "test",
 			options:      map[string]any{"dangerously_skip_permissions": true},
 			mockOutput:   []byte("response"),
-			wantContains: []string{"-p", "test", "--dangerously-skip-permissions", "--output-format", "json"},
+			wantContains: []string{"-p", "test", "--dangerously-skip-permissions", "--output-format", "stream-json"},
 		},
 		{
 			name:   "with all options",
@@ -887,7 +887,7 @@ func TestClaudeProvider_ExecuteConversation_CLIArgumentConstruction(t *testing.T
 				"--model", "sonnet",
 				"--allowedTools", "bash",
 				"--dangerously-skip-permissions",
-				"--output-format", "json",
+				"--output-format", "stream-json",
 			},
 		},
 	}
@@ -899,7 +899,7 @@ func TestClaudeProvider_ExecuteConversation_CLIArgumentConstruction(t *testing.T
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 			state := workflow.NewConversationState("You are helpful")
-			result, err := provider.ExecuteConversation(context.Background(), state, tt.prompt, tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), state, tt.prompt, tt.options, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -944,7 +944,7 @@ func TestClaudeProvider_Execute_AllowedToolsOption(t *testing.T) {
 			mockExec.SetOutput([]byte("response"), nil)
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "prompt", tt.options)
+			result, err := provider.Execute(context.Background(), "prompt", tt.options, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -988,7 +988,7 @@ func TestClaudeProvider_Execute_DangerouslySkipPermissionsOption(t *testing.T) {
 			mockExec.SetOutput([]byte("response"), nil)
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "prompt", tt.options)
+			result, err := provider.Execute(context.Background(), "prompt", tt.options, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -1033,7 +1033,7 @@ func TestClaudeProvider_ExecuteConversation_AllowedToolsOption(t *testing.T) {
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 			state := workflow.NewConversationState("You are helpful")
-			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", tt.options, nil, nil)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -1076,7 +1076,7 @@ func TestClaudeProvider_ExecuteConversation_DangerouslySkipPermissionsOption(t *
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 			state := workflow.NewConversationState("You are helpful")
-			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", tt.options, nil, nil)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -1117,7 +1117,7 @@ func TestClaudeProvider_OldCamelCaseKeysIgnored(t *testing.T) {
 			mockExec.SetOutput([]byte("response"), nil)
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "test", tt.options)
+			result, err := provider.Execute(context.Background(), "test", tt.options, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)

--- a/internal/infrastructure/agents/cli_executor.go
+++ b/internal/infrastructure/agents/cli_executor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,7 +25,7 @@ func NewExecCLIExecutor() *ExecCLIExecutor {
 	return &ExecCLIExecutor{}
 }
 
-func (e *ExecCLIExecutor) Run(ctx context.Context, name string, args ...string) (stdout, stderr []byte, err error) {
+func (e *ExecCLIExecutor) Run(ctx context.Context, name string, stdoutW, stderrW io.Writer, args ...string) (stdout, stderr []byte, err error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 
 	// Process group management for clean termination
@@ -42,8 +43,16 @@ func (e *ExecCLIExecutor) Run(ctx context.Context, name string, args ...string) 
 	cmd.WaitDelay = 100 * time.Millisecond
 
 	var stdoutBuf, stderrBuf bytes.Buffer
-	cmd.Stdout = &stdoutBuf
-	cmd.Stderr = &stderrBuf
+	if stdoutW != nil {
+		cmd.Stdout = io.MultiWriter(&stdoutBuf, stdoutW)
+	} else {
+		cmd.Stdout = &stdoutBuf
+	}
+	if stderrW != nil {
+		cmd.Stderr = io.MultiWriter(&stderrBuf, stderrW)
+	} else {
+		cmd.Stderr = &stderrBuf
+	}
 
 	if startErr := cmd.Start(); startErr != nil {
 		return []byte{}, []byte{}, fmt.Errorf("CLI start failed for '%s': %w", name, startErr)

--- a/internal/infrastructure/agents/cli_executor_test.go
+++ b/internal/infrastructure/agents/cli_executor_test.go
@@ -73,7 +73,7 @@ func TestExecCLIExecutor_Run_SimpleCommands(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stdout, stderr, err := executor.Run(ctx, tt.binary, tt.args...)
+			stdout, stderr, err := executor.Run(ctx, tt.binary, nil, nil, tt.args...)
 
 			if tt.wantErrNil {
 				require.NoError(t, err, tt.description)
@@ -116,7 +116,7 @@ func TestExecCLIExecutor_Run_CommandWithFlags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stdout, stderr, err := executor.Run(ctx, tt.binary, tt.args...)
+			stdout, stderr, err := executor.Run(ctx, tt.binary, nil, nil, tt.args...)
 
 			require.NoError(t, err)
 			assert.NotNil(t, stdout)
@@ -129,7 +129,7 @@ func TestExecCLIExecutor_Run_EmptyCommand(t *testing.T) {
 	executor := NewExecCLIExecutor()
 	ctx := context.Background()
 
-	stdout, stderr, err := executor.Run(ctx, "", []string{}...)
+	stdout, stderr, err := executor.Run(ctx, "", nil, nil)
 
 	// Empty binary name should cause an error
 	assert.Error(t, err, "empty binary name should fail")
@@ -141,7 +141,7 @@ func TestExecCLIExecutor_Run_NoArguments(t *testing.T) {
 	executor := NewExecCLIExecutor()
 	ctx := context.Background()
 
-	stdout, stderr, err := executor.Run(ctx, "echo")
+	stdout, stderr, err := executor.Run(ctx, "echo", nil, nil)
 
 	require.NoError(t, err)
 	assert.NotNil(t, stdout)
@@ -158,7 +158,7 @@ func TestExecCLIExecutor_Run_ManyArguments(t *testing.T) {
 		args[i] = "arg"
 	}
 
-	stdout, stderr, err := executor.Run(ctx, "echo", args...)
+	stdout, stderr, err := executor.Run(ctx, "echo", nil, nil, args...)
 
 	require.NoError(t, err)
 	assert.NotNil(t, stdout)
@@ -171,7 +171,7 @@ func TestExecCLIExecutor_Run_LargeOutput(t *testing.T) {
 	ctx := context.Background()
 
 	// Generate large output
-	stdout, stderr, err := executor.Run(ctx, "seq", "1", "1000")
+	stdout, stderr, err := executor.Run(ctx, "seq", nil, nil, "1", "1000")
 
 	require.NoError(t, err)
 	assert.Greater(t, len(stdout), 100, "should have substantial output")
@@ -202,7 +202,7 @@ func TestExecCLIExecutor_Run_SpecialCharacters(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stdout, stderr, err := executor.Run(ctx, "echo", tt.args...)
+			stdout, stderr, err := executor.Run(ctx, "echo", nil, nil, tt.args...)
 
 			require.NoError(t, err)
 			assert.NotNil(t, stdout)
@@ -223,7 +223,7 @@ func TestExecCLIExecutor_Run_NilContext(t *testing.T) {
 	}()
 
 	// If no panic, should return error
-	_, _, err := executor.Run(context.Background(), "echo", "test")
+	_, _, err := executor.Run(context.Background(), "echo", nil, nil, "test")
 	if err != nil {
 		assert.Error(t, err, "nil context should cause error")
 	}
@@ -253,7 +253,7 @@ func TestExecCLIExecutor_Run_BinaryNotFound(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stdout, stderr, err := executor.Run(ctx, tt.binary)
+			stdout, stderr, err := executor.Run(ctx, tt.binary, nil, nil)
 
 			assert.Error(t, err, "non-existent binary should cause error")
 			assert.NotNil(t, stdout)
@@ -294,7 +294,7 @@ func TestExecCLIExecutor_Run_NonZeroExitCode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stdout, stderr, err := executor.Run(ctx, tt.binary, tt.args...)
+			stdout, stderr, err := executor.Run(ctx, tt.binary, nil, nil, tt.args...)
 
 			assert.Error(t, err, "non-zero exit should cause error")
 			assert.NotNil(t, stdout)
@@ -331,7 +331,7 @@ func TestExecCLIExecutor_Run_CommandTimeout(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), tt.timeout)
 			defer cancel()
 
-			stdout, stderr, err := executor.Run(ctx, tt.binary, tt.args...)
+			stdout, stderr, err := executor.Run(ctx, tt.binary, nil, nil, tt.args...)
 
 			assert.Error(t, err, "timeout should cause error")
 			assert.True(t,
@@ -375,7 +375,7 @@ func TestExecCLIExecutor_Run_ContextCancellation(t *testing.T) {
 				cancel()
 			}()
 
-			stdout, stderr, err := executor.Run(ctx, tt.binary, tt.args...)
+			stdout, stderr, err := executor.Run(ctx, tt.binary, nil, nil, tt.args...)
 
 			assert.Error(t, err, "cancellation should cause error")
 			assert.True(t,
@@ -409,7 +409,7 @@ func TestExecCLIExecutor_Run_ContextCancellation_TerminatesProcessGroup(t *testi
 	}()
 
 	start := time.Now()
-	stdout, stderr, err := executor.Run(ctx, "sleep", "10")
+	stdout, stderr, err := executor.Run(ctx, "sleep", nil, nil, "10")
 	duration := time.Since(start)
 
 	// Process group kill should complete within 1s (not wait for full 10s)
@@ -441,7 +441,7 @@ func TestExecCLIExecutor_Run_StderrOutput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stdout, stderr, err := executor.Run(ctx, "sh", "-c", tt.command)
+			stdout, stderr, err := executor.Run(ctx, "sh", nil, nil, "-c", tt.command)
 
 			require.NoError(t, err)
 			// Note: os/exec.CombinedOutput merges stderr into stdout
@@ -477,7 +477,7 @@ func TestExecCLIExecutor_Run_InvalidArguments(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stdout, stderr, err := executor.Run(ctx, tt.binary, tt.args...)
+			stdout, stderr, err := executor.Run(ctx, tt.binary, nil, nil, tt.args...)
 
 			// Most commands will error on invalid args
 			// But we're testing the executor handles it gracefully
@@ -500,7 +500,7 @@ func TestExecCLIExecutor_Run_ConcurrentExecutions(t *testing.T) {
 
 	for i := 0; i < concurrency; i++ {
 		go func(n int) {
-			stdout, stderr, err := executor.Run(ctx, "echo", "concurrent")
+			stdout, stderr, err := executor.Run(ctx, "echo", nil, nil, "concurrent")
 			assert.NoError(t, err)
 			assert.NotNil(t, stdout)
 			assert.NotNil(t, stderr)
@@ -522,7 +522,7 @@ func TestExecCLIExecutor_Run_SimulateClaudeProvider(t *testing.T) {
 	// (using echo as a stand-in for claude CLI)
 	args := []string{"test prompt"}
 
-	stdout, stderr, err := executor.Run(ctx, "echo", args...)
+	stdout, stderr, err := executor.Run(ctx, "echo", nil, nil, args...)
 
 	require.NoError(t, err, "Claude provider simulation should succeed")
 	assert.NotNil(t, stdout)
@@ -537,7 +537,7 @@ func TestExecCLIExecutor_Run_SimulateGeminiProvider(t *testing.T) {
 	// Simulate Gemini provider with JSON output flag
 	args := []string{"--json", "test"}
 
-	stdout, stderr, err := executor.Run(ctx, "echo", args...)
+	stdout, stderr, err := executor.Run(ctx, "echo", nil, nil, args...)
 
 	require.NoError(t, err)
 	assert.NotNil(t, stdout)
@@ -552,7 +552,7 @@ func TestExecCLIExecutor_Run_SimulateCodexProvider(t *testing.T) {
 	// Simulate Codex provider with model selection
 	args := []string{"--model", "gpt-4", "prompt"}
 
-	stdout, stderr, err := executor.Run(ctx, "echo", args...)
+	stdout, stderr, err := executor.Run(ctx, "echo", nil, nil, args...)
 
 	require.NoError(t, err)
 	assert.NotNil(t, stdout)
@@ -614,7 +614,7 @@ func TestRun_SetsProcessGroup(t *testing.T) {
 			}()
 
 			// Execute command that spawns child processes
-			stdout, stderr, err := executor.Run(ctx, "sh", "-c", tt.command)
+			stdout, stderr, err := executor.Run(ctx, "sh", nil, nil, "-c", tt.command)
 
 			assert.Error(t, err, tt.description)
 			assert.True(t, errors.Is(err, context.Canceled), "error should be context.Canceled")
@@ -662,7 +662,7 @@ func TestRun_SetsProcessGroup_EdgeCases(t *testing.T) {
 				cancel()
 			}()
 
-			stdout, stderr, err := executor.Run(ctx, "sh", "-c", tt.command)
+			stdout, stderr, err := executor.Run(ctx, "sh", nil, nil, "-c", tt.command)
 
 			assert.NotNil(t, stdout, "stdout should not be nil")
 			assert.NotNil(t, stderr, "stderr should not be nil")
@@ -715,7 +715,7 @@ func TestRun_SetsProcessGroup_ErrorHandling(t *testing.T) {
 			executor := NewExecCLIExecutor()
 			ctx := context.Background()
 
-			stdout, stderr, err := executor.Run(ctx, "sh", "-c", tt.command)
+			stdout, stderr, err := executor.Run(ctx, "sh", nil, nil, "-c", tt.command)
 
 			assert.NotNil(t, stdout, "stdout should not be nil")
 			assert.NotNil(t, stderr, "stderr should not be nil")

--- a/internal/infrastructure/agents/codex_provider.go
+++ b/internal/infrastructure/agents/codex_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
 	"time"
@@ -14,7 +15,7 @@ import (
 )
 
 // CodexProvider implements AgentProvider for Codex CLI.
-// Invokes: codex --prompt "prompt" --quiet
+// Invokes: codex exec --json "prompt"
 type CodexProvider struct {
 	logger   ports.Logger
 	executor ports.CLIExecutor
@@ -38,22 +39,18 @@ func NewCodexProviderWithOptions(opts ...CodexProviderOption) *CodexProvider {
 	return p
 }
 
-func (p *CodexProvider) Execute(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+func (p *CodexProvider) Execute(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 	startedAt := time.Now()
 
 	if strings.TrimSpace(prompt) == "" {
 		return nil, errors.New("prompt cannot be empty")
 	}
 
-	if err := validateCodexOptions(options); err != nil {
-		return nil, err
-	}
-
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("codex provider: %w", err)
 	}
 
-	args := []string{"--prompt", prompt}
+	args := []string{"exec", "--json", prompt}
 
 	if language, ok := getStringOption(options, "language"); ok {
 		args = append(args, "--language", language)
@@ -61,23 +58,20 @@ func (p *CodexProvider) Execute(ctx context.Context, prompt string, options map[
 	if model, ok := getStringOption(options, "model"); ok {
 		args = append(args, "--model", model)
 	}
-	if quiet, ok := getBoolOption(options, "quiet"); ok && quiet {
-		args = append(args, "--quiet")
-	}
 	if skipPerms, ok := getBoolOption(options, "dangerously_skip_permissions"); ok && skipPerms {
 		args = append(args, "--yolo")
 	}
 
-	stdout, stderr, err := p.executor.Run(ctx, "codex", args...)
+	stdoutBytes, stderrBytes, err := p.executor.Run(ctx, "codex", stdout, stderr, args...)
 	completedAt := time.Now()
 
 	if err != nil {
 		return nil, fmt.Errorf("codex execution failed: %w", err)
 	}
 
-	output := make([]byte, 0, len(stdout)+len(stderr))
-	output = append(output, stdout...)
-	output = append(output, stderr...)
+	output := make([]byte, 0, len(stdoutBytes)+len(stderrBytes))
+	output = append(output, stdoutBytes...)
+	output = append(output, stderrBytes...)
 	outputStr := string(output)
 	result := &workflow.AgentResult{
 		Provider:    "codex",
@@ -90,7 +84,7 @@ func (p *CodexProvider) Execute(ctx context.Context, prompt string, options map[
 	return result, nil
 }
 
-func (p *CodexProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+func (p *CodexProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 	startedAt := time.Now()
 
 	if state == nil {
@@ -99,10 +93,6 @@ func (p *CodexProvider) ExecuteConversation(ctx context.Context, state *workflow
 
 	if strings.TrimSpace(prompt) == "" {
 		return nil, errors.New("prompt cannot be empty")
-	}
-
-	if err := validateCodexConversationOptions(options); err != nil {
-		return nil, err
 	}
 
 	if err := ctx.Err(); err != nil {
@@ -129,9 +119,9 @@ func (p *CodexProvider) ExecuteConversation(ctx context.Context, state *workflow
 
 	var args []string
 	if isResume {
-		args = []string{"resume", workingState.SessionID, "--prompt", prompt}
+		args = []string{"resume", workingState.SessionID, "--json", prompt}
 	} else {
-		args = []string{"--prompt", prompt}
+		args = []string{"exec", "--json", prompt}
 		// First turn only (no session yet): pass system prompt if provided
 		if workingState.SessionID == "" {
 			if sysPrompt, ok := getStringOption(options, "system_prompt"); ok && sysPrompt != "" {
@@ -146,23 +136,20 @@ func (p *CodexProvider) ExecuteConversation(ctx context.Context, state *workflow
 	if language, ok := getStringOption(options, "language"); ok {
 		args = append(args, "--language", language)
 	}
-	if quiet, ok := getBoolOption(options, "quiet"); ok && quiet {
-		args = append(args, "--quiet")
-	}
 	if skipPerms, ok := getBoolOption(options, "dangerously_skip_permissions"); ok && skipPerms {
 		args = append(args, "--yolo")
 	}
 
-	stdout, stderr, err := p.executor.Run(ctx, "codex", args...)
+	stdoutBytes, stderrBytes, err := p.executor.Run(ctx, "codex", stdout, stderr, args...)
 	completedAt := time.Now()
 
 	if err != nil {
 		return nil, fmt.Errorf("codex execution failed: %w", err)
 	}
 
-	output := make([]byte, 0, len(stdout)+len(stderr))
-	output = append(output, stdout...)
-	output = append(output, stderr...)
+	output := make([]byte, 0, len(stdoutBytes)+len(stderrBytes))
+	output = append(output, stdoutBytes...)
+	output = append(output, stderrBytes...)
 	outputStr := string(output)
 	if outputStr == "" {
 		outputStr = " "
@@ -209,13 +196,5 @@ func (p *CodexProvider) Validate() error {
 	if err != nil {
 		return fmt.Errorf("codex CLI not found in PATH: %w", err)
 	}
-	return nil
-}
-
-func validateCodexOptions(_ map[string]any) error {
-	return nil
-}
-
-func validateCodexConversationOptions(_ map[string]any) error {
 	return nil
 }

--- a/internal/infrastructure/agents/codex_provider_exec_test.go
+++ b/internal/infrastructure/agents/codex_provider_exec_test.go
@@ -1,0 +1,244 @@
+package agents
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/awf-project/cli/internal/domain/workflow"
+	"github.com/awf-project/cli/internal/testutil/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for T004: Codex Execute with new `exec --json` subcommand
+// Verifies: args are `["exec", "--json", "<prompt>", ...]`; `--quiet` silently ignored
+
+func TestCodexProvider_Execute_ExecJsonArgsStructure(t *testing.T) {
+	tests := []struct {
+		name        string
+		prompt      string
+		options     map[string]any
+		wantArgLen  int
+		wantArgZero string
+		wantArgOne  string
+		wantArgTwo  string
+	}{
+		{
+			name:        "minimal - just prompt",
+			prompt:      "hello",
+			options:     map[string]any{},
+			wantArgLen:  3,
+			wantArgZero: "exec",
+			wantArgOne:  "--json",
+			wantArgTwo:  "hello",
+		},
+		{
+			name:        "with model",
+			prompt:      "test prompt",
+			options:     map[string]any{"model": "gpt-4"},
+			wantArgLen:  5,
+			wantArgZero: "exec",
+			wantArgOne:  "--json",
+			wantArgTwo:  "test prompt",
+		},
+		{
+			name:        "with language",
+			prompt:      "generate code",
+			options:     map[string]any{"language": "python"},
+			wantArgLen:  5,
+			wantArgZero: "exec",
+			wantArgOne:  "--json",
+			wantArgTwo:  "generate code",
+		},
+		{
+			name:        "with model and language",
+			prompt:      "write function",
+			options:     map[string]any{"model": "gpt-4o", "language": "go"},
+			wantArgLen:  7,
+			wantArgZero: "exec",
+			wantArgOne:  "--json",
+			wantArgTwo:  "write function",
+		},
+		{
+			name:        "with dangerously_skip_permissions",
+			prompt:      "risky",
+			options:     map[string]any{"dangerously_skip_permissions": true},
+			wantArgLen:  4,
+			wantArgZero: "exec",
+			wantArgOne:  "--json",
+			wantArgTwo:  "risky",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			mockExec.SetOutput([]byte("result"), nil)
+
+			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+			_, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
+
+			require.NoError(t, err)
+			calls := mockExec.GetCalls()
+			require.Len(t, calls, 1, "expected 1 CLI call")
+			args := calls[0].Args
+			assert.Equal(t, tt.wantArgLen, len(args), "arg count mismatch")
+			assert.Equal(t, tt.wantArgZero, args[0], "args[0] should be 'exec'")
+			assert.Equal(t, tt.wantArgOne, args[1], "args[1] should be '--json'")
+			assert.Equal(t, tt.wantArgTwo, args[2], "args[2] should be prompt")
+		})
+	}
+}
+
+func TestCodexProvider_Execute_QuietOptionIgnored(t *testing.T) {
+	tests := []struct {
+		name       string
+		options    map[string]any
+		shouldHave string
+		notHave    string
+	}{
+		{
+			name:       "quiet true - should NOT add --quiet flag",
+			options:    map[string]any{"quiet": true},
+			shouldHave: "--json",
+			notHave:    "--quiet",
+		},
+		{
+			name:       "quiet false - should NOT add --quiet flag",
+			options:    map[string]any{"quiet": false},
+			shouldHave: "--json",
+			notHave:    "--quiet",
+		},
+		{
+			name:       "no quiet option - should NOT add --quiet flag",
+			options:    map[string]any{},
+			shouldHave: "--json",
+			notHave:    "--quiet",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			mockExec.SetOutput([]byte("output"), nil)
+
+			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+			_, err := provider.Execute(context.Background(), "test", tt.options, nil, nil)
+
+			require.NoError(t, err)
+			calls := mockExec.GetCalls()
+			require.Len(t, calls, 1)
+			argStr := strings.Join(calls[0].Args, " ")
+			assert.Contains(t, argStr, tt.shouldHave, "should contain "+tt.shouldHave)
+			assert.NotContains(t, argStr, tt.notHave, "should NOT contain "+tt.notHave)
+		})
+	}
+}
+
+func TestCodexProvider_Execute_EmptyPromptError(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+
+	tests := []string{"", "   ", "\t", "\n"}
+
+	for _, emptyPrompt := range tests {
+		result, err := provider.Execute(context.Background(), emptyPrompt, map[string]any{}, nil, nil)
+
+		assert.Error(t, err, "should error on empty prompt: %q", emptyPrompt)
+		assert.Nil(t, result)
+	}
+}
+
+func TestCodexProvider_Execute_ContextCancelled(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := provider.Execute(ctx, "test", map[string]any{}, nil, nil)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.True(t, errors.Is(err, context.Canceled))
+}
+
+func TestCodexProvider_Execute_CLIExecutionFailure(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	mockExec.SetError(errors.New("codex not found"))
+
+	provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+	result, err := provider.Execute(context.Background(), "test", map[string]any{}, nil, nil)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "codex execution failed")
+}
+
+func TestCodexProvider_ExecuteConversation_FirstTurnExecJson(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	mockExec.SetOutput([]byte(`{"session_id":"codex-abc123","result":"response"}`), nil)
+
+	provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+	state := workflow.NewConversationState("conv-1")
+
+	result, err := provider.ExecuteConversation(context.Background(), state, "hello", map[string]any{}, nil, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	calls := mockExec.GetCalls()
+	require.Len(t, calls, 1)
+	args := calls[0].Args
+	assert.Equal(t, "exec", args[0], "first turn should use 'exec' subcommand")
+	assert.Equal(t, "--json", args[1], "should have --json flag")
+	assert.Contains(t, strings.Join(args, " "), "hello", "should contain prompt")
+	assert.NotContains(t, strings.Join(args, " "), "--prompt", "should NOT have --prompt")
+}
+
+func TestCodexProvider_ExecuteConversation_ResumeTurnResumeCommand(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	mockExec.SetOutput([]byte(`{"session_id":"codex-xyz789","result":"continued"}`), nil)
+
+	provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+	state := workflow.NewConversationState("conv-1")
+	state.SessionID = "codex-xyz789"
+
+	result, err := provider.ExecuteConversation(context.Background(), state, "continue", map[string]any{}, nil, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	calls := mockExec.GetCalls()
+	require.Len(t, calls, 1)
+	args := calls[0].Args
+	assert.Equal(t, "resume", args[0], "resume turn should use 'resume' subcommand")
+	assert.Equal(t, "codex-xyz789", args[1], "should have session ID as arg[1]")
+	assert.Equal(t, "--json", args[2], "should have --json flag after session ID")
+	assert.Contains(t, strings.Join(args, " "), "continue", "should contain prompt")
+}
+
+func TestCodexProvider_ExecuteConversation_NilStateError(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+
+	result, err := provider.ExecuteConversation(context.Background(), nil, "test", map[string]any{}, nil, nil)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "conversation state cannot be nil")
+}
+
+func TestCodexProvider_ExecuteConversation_EmptyPromptError(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+	state := workflow.NewConversationState("conv-1")
+
+	result, err := provider.ExecuteConversation(context.Background(), state, "", map[string]any{}, nil, nil)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "prompt cannot be empty")
+}

--- a/internal/infrastructure/agents/codex_provider_model_unit_test.go
+++ b/internal/infrastructure/agents/codex_provider_model_unit_test.go
@@ -24,22 +24,22 @@ func TestCodexProvider_Execute_ModelFlag(t *testing.T) {
 		{
 			name:        "model option passed",
 			options:     map[string]any{"model": "gpt-4o"},
-			wantCLIArgs: []string{"--prompt", "test prompt", "--model", "gpt-4o"},
+			wantCLIArgs: []string{"exec", "--json", "test prompt", "--model", "gpt-4o"},
 		},
 		{
 			name:        "no model option",
 			options:     nil,
-			wantCLIArgs: []string{"--prompt", "test prompt"},
+			wantCLIArgs: []string{"exec", "--json", "test prompt"},
 		},
 		{
 			name:        "model with language option",
 			options:     map[string]any{"model": "code-davinci", "language": "python"},
-			wantCLIArgs: []string{"--prompt", "test prompt", "--language", "python", "--model", "code-davinci"},
+			wantCLIArgs: []string{"exec", "--json", "test prompt", "--language", "python", "--model", "code-davinci"},
 		},
 		{
 			name:        "model with quiet option",
 			options:     map[string]any{"model": "gpt-3.5", "quiet": true},
-			wantCLIArgs: []string{"--prompt", "test prompt", "--model", "gpt-3.5", "--quiet"},
+			wantCLIArgs: []string{"exec", "--json", "test prompt", "--model", "gpt-3.5"},
 		},
 	}
 
@@ -49,7 +49,7 @@ func TestCodexProvider_Execute_ModelFlag(t *testing.T) {
 			mockExec.SetOutput([]byte("result"), nil)
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "test prompt", tt.options)
+			result, err := provider.Execute(context.Background(), "test prompt", tt.options, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -85,7 +85,7 @@ func TestCodexProvider_Execute_MaxTokensNotPassed(t *testing.T) {
 			mockExec.SetOutput([]byte("code"), nil)
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
-			_, err := provider.Execute(context.Background(), "test", tt.options)
+			_, err := provider.Execute(context.Background(), "test", tt.options, nil, nil)
 
 			require.NoError(t, err)
 			calls := mockExec.GetCalls()
@@ -123,7 +123,7 @@ func TestCodexProvider_Execute_TemperatureNotPassed(t *testing.T) {
 			mockExec.SetOutput([]byte("code"), nil)
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
-			_, err := provider.Execute(context.Background(), "test", tt.options)
+			_, err := provider.Execute(context.Background(), "test", tt.options, nil, nil)
 
 			require.NoError(t, err)
 			calls := mockExec.GetCalls()
@@ -161,7 +161,7 @@ func TestCodexProvider_ExecuteConversation_MaxTokensNotPassed(t *testing.T) {
 			mockExec.SetOutput([]byte("response"), nil)
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
-			_, err := provider.ExecuteConversation(context.Background(), state, "user prompt", tt.options)
+			_, err := provider.ExecuteConversation(context.Background(), state, "user prompt", tt.options, nil, nil)
 
 			require.NoError(t, err)
 			calls := mockExec.GetCalls()
@@ -199,7 +199,7 @@ func TestCodexProvider_ExecuteConversation_TemperatureNotPassed(t *testing.T) {
 			mockExec.SetOutput([]byte("response"), nil)
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
-			_, err := provider.ExecuteConversation(context.Background(), state, "user prompt", tt.options)
+			_, err := provider.ExecuteConversation(context.Background(), state, "user prompt", tt.options, nil, nil)
 
 			require.NoError(t, err)
 			calls := mockExec.GetCalls()
@@ -208,80 +208,6 @@ func TestCodexProvider_ExecuteConversation_TemperatureNotPassed(t *testing.T) {
 			args := calls[0].Args
 			// Verify --temperature flag is NOT present
 			assert.False(t, slices.Contains(args, "--temperature"), "ExecuteConversation() should not pass --temperature flag")
-		})
-	}
-}
-
-func TestCodexProvider_ValidateOptions_AcceptsAnyOptions(t *testing.T) {
-	tests := []struct {
-		name    string
-		options map[string]any
-	}{
-		{
-			name:    "max_tokens should be silently ignored (no validation error)",
-			options: map[string]any{"max_tokens": 100},
-		},
-		{
-			name:    "temperature should be silently ignored",
-			options: map[string]any{"temperature": 0.7},
-		},
-		{
-			name:    "both max_tokens and temperature should be silently ignored",
-			options: map[string]any{"max_tokens": 100, "temperature": 0.5},
-		},
-		{
-			name:    "nil options should be accepted",
-			options: nil,
-		},
-		{
-			name:    "empty options map should be accepted",
-			options: map[string]any{},
-		},
-		{
-			name:    "unknown options should be silently ignored",
-			options: map[string]any{"unknown_option": "value", "another_unknown": 123},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateCodexOptions(tt.options)
-			assert.NoError(t, err, "validateCodexOptions should accept any options without validation")
-		})
-	}
-}
-
-func TestCodexProvider_ValidateConversationOptions_AcceptsAnyOptions(t *testing.T) {
-	tests := []struct {
-		name    string
-		options map[string]any
-	}{
-		{
-			name:    "max_tokens should be silently ignored",
-			options: map[string]any{"max_tokens": 100},
-		},
-		{
-			name:    "temperature should be silently ignored",
-			options: map[string]any{"temperature": 0.7},
-		},
-		{
-			name:    "both should be silently ignored",
-			options: map[string]any{"max_tokens": 100, "temperature": 0.5},
-		},
-		{
-			name:    "nil options should be accepted",
-			options: nil,
-		},
-		{
-			name:    "unknown options should be silently ignored",
-			options: map[string]any{"unknown": "value"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateCodexConversationOptions(tt.options)
-			assert.NoError(t, err, "validateCodexConversationOptions should accept any options without validation")
 		})
 	}
 }
@@ -296,12 +222,12 @@ func TestCodexProvider_Execute_ModelPriority(t *testing.T) {
 	options := map[string]any{
 		"model":       "gpt-4o",
 		"language":    "go",
-		"max_tokens":  100, // Should NOT be passed
-		"temperature": 0.7, // Should NOT be passed
-		"quiet":       true,
+		"max_tokens":  100,  // Should NOT be passed
+		"temperature": 0.7,  // Should NOT be passed
+		"quiet":       true, // Should NOT be passed (removed from Codex CLI)
 	}
 
-	_, err := provider.Execute(context.Background(), "test", options)
+	_, err := provider.Execute(context.Background(), "test", options, nil, nil)
 
 	require.NoError(t, err)
 	calls := mockExec.GetCalls()
@@ -309,13 +235,9 @@ func TestCodexProvider_Execute_ModelPriority(t *testing.T) {
 
 	args := calls[0].Args
 
-	// Flags with values require checking the preceding arg
-	hasModel := slices.Contains(args, "--model")
-	hasLanguage := slices.Contains(args, "--language")
-
-	assert.True(t, hasModel, "--model should be passed when provided")
-	assert.True(t, hasLanguage, "--language should be passed when provided")
-	assert.True(t, slices.Contains(args, "--quiet"), "--quiet should be passed when true")
+	assert.True(t, slices.Contains(args, "--model"), "--model should be passed when provided")
+	assert.True(t, slices.Contains(args, "--language"), "--language should be passed when provided")
+	assert.False(t, slices.Contains(args, "--quiet"), "--quiet should NOT be passed (removed from Codex CLI)")
 	assert.False(t, slices.Contains(args, "--max-tokens"), "--max-tokens should NOT be passed")
 	assert.False(t, slices.Contains(args, "--temperature"), "--temperature should NOT be passed")
 }
@@ -338,7 +260,7 @@ func TestCodexProvider_ExecuteConversation_NoUnsupportedFlags(t *testing.T) {
 		"language":    "python",
 	}
 
-	_, err := provider.ExecuteConversation(context.Background(), state, "prompt", options)
+	_, err := provider.ExecuteConversation(context.Background(), state, "prompt", options, nil, nil)
 
 	require.NoError(t, err)
 	calls := mockExec.GetCalls()

--- a/internal/infrastructure/agents/codex_provider_resume_test.go
+++ b/internal/infrastructure/agents/codex_provider_resume_test.go
@@ -1,0 +1,359 @@
+package agents
+
+import (
+	"context"
+	"testing"
+
+	"github.com/awf-project/cli/internal/domain/workflow"
+	"github.com/awf-project/cli/internal/testutil/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// F078 Tests: Fix CLI Provider Invocations - Codex provider subcommand and output format corrections
+
+// T005: ExecuteConversation first turn uses `exec --json` subcommand
+func TestCodexProvider_ExecuteConversation_T005_FirstTurnExecSubcommand(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	mockExec.SetOutput([]byte("Session: codex-sess-123\nGenerated code"), nil)
+	provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+
+	state := workflow.NewConversationState("system")
+	result, err := provider.ExecuteConversation(context.Background(), state, "write hello function", nil, nil, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	calls := mockExec.GetCalls()
+	require.Len(t, calls, 1)
+	call := calls[0]
+
+	assert.Equal(t, "codex", call.Name)
+	assert.GreaterOrEqual(t, len(call.Args), 3)
+	assert.Equal(t, "exec", call.Args[0], "first turn should use exec subcommand")
+	assert.Equal(t, "--json", call.Args[1], "exec should have --json flag")
+	assert.Equal(t, "write hello function", call.Args[2], "prompt should follow --json")
+}
+
+// T005: ExecuteConversation resume turn uses `resume <sessionID> --json` subcommand
+func TestCodexProvider_ExecuteConversation_T005_ResumeTurnResumeSubcommand(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	mockExec.SetOutput([]byte("Session: codex-sess-456\nContinued response"), nil)
+	provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+
+	state := workflow.NewConversationState("system")
+	state.SessionID = "codex-sess-123"
+	result, err := provider.ExecuteConversation(context.Background(), state, "add error handling", nil, nil, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	calls := mockExec.GetCalls()
+	require.Len(t, calls, 1)
+	call := calls[0]
+
+	assert.Equal(t, "codex", call.Name)
+	assert.GreaterOrEqual(t, len(call.Args), 4)
+	assert.Equal(t, "resume", call.Args[0], "resume turn should use resume subcommand")
+	assert.Equal(t, "codex-sess-123", call.Args[1], "session ID should be args[1]")
+	assert.Equal(t, "--json", call.Args[2], "resume should have --json flag after session ID")
+	assert.Equal(t, "add error handling", call.Args[3], "prompt should follow --json")
+}
+
+// T005: ExecuteConversation correctly handles non-codex-prefixed session IDs (fallback to exec)
+func TestCodexProvider_ExecuteConversation_T005_NonCodexPrefixedSessionIDFallback(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	mockExec.SetOutput([]byte("Session: codex-new\nResponse"), nil)
+	provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+
+	state := workflow.NewConversationState("system")
+	state.SessionID = "non-codex-prefixed-id"
+	result, err := provider.ExecuteConversation(context.Background(), state, "continue", nil, nil, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	calls := mockExec.GetCalls()
+	require.Len(t, calls, 1)
+	call := calls[0]
+
+	assert.Equal(t, "exec", call.Args[0], "non-codex-prefixed ID should fall back to exec")
+	assert.Equal(t, "--json", call.Args[1])
+	assert.Equal(t, "continue", call.Args[2])
+}
+
+// T005: Quiet flag is NOT passed (replaced by --json on exec/resume)
+func TestCodexProvider_ExecuteConversation_T005_QuietFlagRemoved(t *testing.T) {
+	tests := []struct {
+		name    string
+		options map[string]any
+	}{
+		{
+			name:    "quiet true - should omit --quiet",
+			options: map[string]any{"quiet": true},
+		},
+		{
+			name:    "quiet false - should omit --quiet",
+			options: map[string]any{"quiet": false},
+		},
+		{
+			name:    "no quiet option - should omit --quiet",
+			options: map[string]any{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			mockExec.SetOutput([]byte("Session: codex-sess\nResponse"), nil)
+			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+
+			state := workflow.NewConversationState("system")
+			_, err := provider.ExecuteConversation(context.Background(), state, "test", tt.options, nil, nil)
+			require.NoError(t, err)
+
+			calls := mockExec.GetCalls()
+			require.Len(t, calls, 1)
+			call := calls[0]
+
+			// Verify --quiet is NOT present
+			for _, arg := range call.Args {
+				assert.NotEqual(t, "--quiet", arg, "quiet flag should be removed")
+			}
+			// Verify --json IS present
+			assert.Contains(t, call.Args, "--json")
+		})
+	}
+}
+
+// T005: Execute uses new `exec --json` subcommand (not --prompt)
+func TestCodexProvider_Execute_T005_ExecSubcommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		prompt  string
+		options map[string]any
+	}{
+		{
+			name:    "minimal execute",
+			prompt:  "generate code",
+			options: nil,
+		},
+		{
+			name:    "with language",
+			prompt:  "write function",
+			options: map[string]any{"language": "go"},
+		},
+		{
+			name:    "with model",
+			prompt:  "test",
+			options: map[string]any{"model": "gpt-4"},
+		},
+		{
+			name:    "with dangerously_skip_permissions",
+			prompt:  "risky",
+			options: map[string]any{"dangerously_skip_permissions": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			mockExec.SetOutput([]byte("result"), nil)
+			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+
+			_, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
+			require.NoError(t, err)
+
+			calls := mockExec.GetCalls()
+			require.Len(t, calls, 1)
+			call := calls[0]
+
+			assert.Equal(t, "codex", call.Name)
+			assert.GreaterOrEqual(t, len(call.Args), 3)
+			assert.Equal(t, "exec", call.Args[0], "Execute should use exec subcommand")
+			assert.Equal(t, "--json", call.Args[1], "exec should have --json flag")
+			assert.Equal(t, tt.prompt, call.Args[2], "prompt should follow --json")
+
+			// Verify no --prompt flag
+			for _, arg := range call.Args {
+				assert.NotEqual(t, "--prompt", arg, "--prompt flag should not be used")
+			}
+		})
+	}
+}
+
+// T005: Options (model, language, dangerously_skip_permissions) work with exec/resume subcommands
+func TestCodexProvider_ExecuteConversation_T005_OptionsWithSubcommands(t *testing.T) {
+	tests := []struct {
+		name             string
+		sessionID        string
+		options          map[string]any
+		expectedSubcmd   string
+		shouldHaveOption bool
+	}{
+		{
+			name:             "first turn with model",
+			sessionID:        "",
+			options:          map[string]any{"model": "gpt-4o"},
+			expectedSubcmd:   "exec",
+			shouldHaveOption: true,
+		},
+		{
+			name:             "resume turn with language",
+			sessionID:        "codex-sess-abc",
+			options:          map[string]any{"language": "python"},
+			expectedSubcmd:   "resume",
+			shouldHaveOption: true,
+		},
+		{
+			name:             "first turn with yolo",
+			sessionID:        "",
+			options:          map[string]any{"dangerously_skip_permissions": true},
+			expectedSubcmd:   "exec",
+			shouldHaveOption: true,
+		},
+		{
+			name:             "resume turn with yolo",
+			sessionID:        "codex-sess-xyz",
+			options:          map[string]any{"dangerously_skip_permissions": true},
+			expectedSubcmd:   "resume",
+			shouldHaveOption: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			mockExec.SetOutput([]byte("Session: codex-result\nResponse"), nil)
+			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+
+			state := workflow.NewConversationState("system")
+			state.SessionID = tt.sessionID
+			_, err := provider.ExecuteConversation(context.Background(), state, "prompt", tt.options, nil, nil)
+			require.NoError(t, err)
+
+			calls := mockExec.GetCalls()
+			require.Len(t, calls, 1)
+			call := calls[0]
+
+			assert.Equal(t, tt.expectedSubcmd, call.Args[0])
+			// Verify options are passed when shouldHaveOption is true
+			if tt.shouldHaveOption {
+				optionPresent := false
+				for _, arg := range call.Args {
+					if arg == "--model" || arg == "--language" || arg == "--yolo" {
+						optionPresent = true
+						break
+					}
+				}
+				assert.True(t, optionPresent, "option should be in args")
+			}
+		})
+	}
+}
+
+// T005: Session ID extraction works with new output format
+func TestCodexProvider_ExecuteConversation_T005_SessionIDExtraction(t *testing.T) {
+	tests := []struct {
+		name          string
+		mockOutput    []byte
+		wantSessionID string
+	}{
+		{
+			name:          "session extracted from Session: line",
+			mockOutput:    []byte("Session: codex-abc-123\nGenerated code"),
+			wantSessionID: "codex-abc-123",
+		},
+		{
+			name:          "malformed output - empty session ID",
+			mockOutput:    []byte("Session:\nNo ID"),
+			wantSessionID: "",
+		},
+		{
+			name:          "no session line - extraction fails gracefully",
+			mockOutput:    []byte("Just output\nNo session info"),
+			wantSessionID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			mockExec.SetOutput(tt.mockOutput, nil)
+			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+
+			state := workflow.NewConversationState("system")
+			result, err := provider.ExecuteConversation(context.Background(), state, "test", nil, nil, nil)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSessionID, result.State.SessionID)
+		})
+	}
+}
+
+// T005: System prompt only passed on first turn (exec), not on resume
+func TestCodexProvider_ExecuteConversation_T005_SystemPromptHandling(t *testing.T) {
+	tests := []struct {
+		name                 string
+		sessionID            string
+		hasSystemPrompt      bool
+		expectedSubcmd       string
+		shouldHavePromptFlag bool
+	}{
+		{
+			name:                 "first turn with system prompt",
+			sessionID:            "",
+			hasSystemPrompt:      true,
+			expectedSubcmd:       "exec",
+			shouldHavePromptFlag: true,
+		},
+		{
+			name:                 "first turn without system prompt",
+			sessionID:            "",
+			hasSystemPrompt:      false,
+			expectedSubcmd:       "exec",
+			shouldHavePromptFlag: false,
+		},
+		{
+			name:                 "resume turn with system prompt (should ignore)",
+			sessionID:            "codex-sess-abc",
+			hasSystemPrompt:      true,
+			expectedSubcmd:       "resume",
+			shouldHavePromptFlag: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			mockExec.SetOutput([]byte("Session: codex-new\nResponse"), nil)
+			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+
+			state := workflow.NewConversationState("system")
+			state.SessionID = tt.sessionID
+			options := map[string]any{}
+			if tt.hasSystemPrompt {
+				options["system_prompt"] = "You are a code generator"
+			}
+
+			_, err := provider.ExecuteConversation(context.Background(), state, "test", options, nil, nil)
+			require.NoError(t, err)
+
+			calls := mockExec.GetCalls()
+			require.Len(t, calls, 1)
+			call := calls[0]
+
+			assert.Equal(t, tt.expectedSubcmd, call.Args[0])
+
+			// Check for --system-prompt flag
+			hasPromptFlag := false
+			for _, arg := range call.Args {
+				if arg == "--system-prompt" {
+					hasPromptFlag = true
+					break
+				}
+			}
+			assert.Equal(t, tt.shouldHavePromptFlag, hasPromptFlag)
+		})
+	}
+}

--- a/internal/infrastructure/agents/codex_provider_session_test.go
+++ b/internal/infrastructure/agents/codex_provider_session_test.go
@@ -76,19 +76,22 @@ func TestCodexProvider_extractSessionID(t *testing.T) {
 
 func TestCodexProvider_ExecuteConversation_ResumeFlag(t *testing.T) {
 	tests := []struct {
-		name           string
-		sessionID      string
-		wantResumeFlag bool
+		name            string
+		sessionID       string
+		wantResumeFlag  bool
+		wantExecCommand bool
 	}{
 		{
-			name:           "turn 2+ with session ID uses resume subcommand",
-			sessionID:      "codex-session-abc",
-			wantResumeFlag: true,
+			name:            "turn 2+ with session ID uses resume subcommand",
+			sessionID:       "codex-session-abc",
+			wantResumeFlag:  true,
+			wantExecCommand: false,
 		},
 		{
-			name:           "turn 1 without session ID omits resume",
-			sessionID:      "",
-			wantResumeFlag: false,
+			name:            "turn 1 without session ID uses exec subcommand",
+			sessionID:       "",
+			wantResumeFlag:  false,
+			wantExecCommand: true,
 		},
 	}
 
@@ -101,7 +104,7 @@ func TestCodexProvider_ExecuteConversation_ResumeFlag(t *testing.T) {
 			state := workflow.NewConversationState("system")
 			state.SessionID = tt.sessionID
 
-			result, err := provider.ExecuteConversation(context.Background(), state, "write a function", nil)
+			result, err := provider.ExecuteConversation(context.Background(), state, "write a function", nil, nil, nil)
 			require.NoError(t, err)
 			require.NotNil(t, result)
 
@@ -109,6 +112,7 @@ func TestCodexProvider_ExecuteConversation_ResumeFlag(t *testing.T) {
 			require.Len(t, calls, 1)
 
 			hasResumeSubcommand := false
+			hasExecSubcommand := false
 			for i, arg := range calls[0].Args {
 				if arg == "resume" && i+1 < len(calls[0].Args) {
 					hasResumeSubcommand = true
@@ -116,8 +120,14 @@ func TestCodexProvider_ExecuteConversation_ResumeFlag(t *testing.T) {
 						assert.Equal(t, tt.sessionID, calls[0].Args[i+1])
 					}
 				}
+				if arg == "exec" {
+					hasExecSubcommand = true
+				}
 			}
 			assert.Equal(t, tt.wantResumeFlag, hasResumeSubcommand)
+			assert.Equal(t, tt.wantExecCommand, hasExecSubcommand)
+			// Both paths should include --json
+			assert.Contains(t, calls[0].Args, "--json")
 		})
 	}
 }
@@ -156,7 +166,7 @@ func TestCodexProvider_ExecuteConversation_SessionIDExtracted(t *testing.T) {
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
 			state := workflow.NewConversationState("system")
-			result, err := provider.ExecuteConversation(context.Background(), state, "test", nil)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test", nil, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -174,11 +184,13 @@ func TestCodexProvider_ExecuteConversation_SystemPromptOnFirstTurn(t *testing.T)
 	state := workflow.NewConversationState("")
 	options := map[string]any{"system_prompt": "You are a code generator"}
 
-	_, err := provider.ExecuteConversation(context.Background(), state, "Generate a hello world", options)
+	_, err := provider.ExecuteConversation(context.Background(), state, "Generate a hello world", options, nil, nil)
 	require.NoError(t, err)
 
 	calls := mockExec.GetCalls()
 	require.Len(t, calls, 1)
+	assert.Contains(t, calls[0].Args, "exec")
+	assert.Contains(t, calls[0].Args, "--json")
 	assert.Contains(t, calls[0].Args, "--system-prompt")
 	assert.Contains(t, calls[0].Args, "You are a code generator")
 }
@@ -192,7 +204,7 @@ func TestCodexProvider_ExecuteConversation_NoSystemPromptOnResumeTurn(t *testing
 	state.SessionID = "existing-session-id"
 	options := map[string]any{"system_prompt": "You are a code generator"}
 
-	_, err := provider.ExecuteConversation(context.Background(), state, "Continue", options)
+	_, err := provider.ExecuteConversation(context.Background(), state, "Continue", options, nil, nil)
 	require.NoError(t, err)
 
 	calls := mockExec.GetCalls()
@@ -226,7 +238,7 @@ func TestCodexProvider_ExecuteConversation_GracefulFallback(t *testing.T) {
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
 			state := workflow.NewConversationState("system")
-			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", nil)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", nil, nil, nil)
 
 			require.NoError(t, err, "extraction failure must not cause error (graceful fallback)")
 			require.NotNil(t, result)
@@ -246,7 +258,7 @@ func TestCodexProvider_ExecuteConversation_ResumeFallback_NonPrefixedSessionID(t
 	// isResume = false and the resume subcommand is never added to args.
 	state.SessionID = "previous-session"
 
-	result, err := provider.ExecuteConversation(context.Background(), state, "prompt", nil)
+	result, err := provider.ExecuteConversation(context.Background(), state, "prompt", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -254,13 +266,18 @@ func TestCodexProvider_ExecuteConversation_ResumeFallback_NonPrefixedSessionID(t
 	require.Len(t, calls, 1)
 
 	hasResumeSubcommand := false
+	hasExecSubcommand := false
 	for _, arg := range calls[0].Args {
 		if arg == "resume" {
 			hasResumeSubcommand = true
-			break
+		}
+		if arg == "exec" {
+			hasExecSubcommand = true
 		}
 	}
 	assert.False(t, hasResumeSubcommand, "resume subcommand must be absent when session ID lacks codex- prefix")
+	assert.True(t, hasExecSubcommand, "exec subcommand must be used when session ID lacks prefix")
+	assert.Contains(t, calls[0].Args, "--json", "--json flag must be present in exec subcommand")
 }
 
 func TestCodexProvider_ExecuteConversation_ResumeFallback_ExtractionFailure(t *testing.T) {
@@ -274,7 +291,7 @@ func TestCodexProvider_ExecuteConversation_ResumeFallback_ExtractionFailure(t *t
 	state := workflow.NewConversationState("system")
 	state.SessionID = "codex-valid-prefix"
 
-	result, err := provider.ExecuteConversation(context.Background(), state, "prompt", nil)
+	result, err := provider.ExecuteConversation(context.Background(), state, "prompt", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)

--- a/internal/infrastructure/agents/codex_provider_unit_test.go
+++ b/internal/infrastructure/agents/codex_provider_unit_test.go
@@ -63,7 +63,7 @@ func TestCodexProvider_Execute_Success(t *testing.T) {
 			mockExec.SetOutput(tt.mockStdout, nil)
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), tt.prompt, tt.options)
+			result, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -92,56 +92,56 @@ func TestCodexProvider_Execute_WithOptions(t *testing.T) {
 			prompt:      "test",
 			options:     map[string]any{"model": "gpt-4o"},
 			mockStdout:  []byte("code"),
-			wantCLIArgs: []string{"--prompt", "test", "--model", "gpt-4o"},
+			wantCLIArgs: []string{"exec", "--json", "test", "--model", "gpt-4o"},
 		},
 		{
 			name:        "language option",
 			prompt:      "test",
 			options:     map[string]any{"language": "python"},
 			mockStdout:  []byte("code"),
-			wantCLIArgs: []string{"--prompt", "test", "--language", "python"},
+			wantCLIArgs: []string{"exec", "--json", "test", "--language", "python"},
 		},
 		{
 			name:        "quiet option true",
 			prompt:      "test",
 			options:     map[string]any{"quiet": true},
 			mockStdout:  []byte("code"),
-			wantCLIArgs: []string{"--prompt", "test", "--quiet"},
+			wantCLIArgs: []string{"exec", "--json", "test"},
 		},
 		{
 			name:        "quiet option false",
 			prompt:      "test",
 			options:     map[string]any{"quiet": false},
 			mockStdout:  []byte("code"),
-			wantCLIArgs: []string{"--prompt", "test"},
+			wantCLIArgs: []string{"exec", "--json", "test"},
 		},
 		{
 			name:        "multiple options",
 			prompt:      "complex task",
 			options:     map[string]any{"language": "go", "quiet": true},
 			mockStdout:  []byte("code"),
-			wantCLIArgs: []string{"--prompt", "complex task", "--language", "go", "--quiet"},
+			wantCLIArgs: []string{"exec", "--json", "complex task", "--language", "go"},
 		},
 		{
 			name:        "no options",
 			prompt:      "simple",
 			options:     nil,
 			mockStdout:  []byte("code"),
-			wantCLIArgs: []string{"--prompt", "simple"},
+			wantCLIArgs: []string{"exec", "--json", "simple"},
 		},
 		{
 			name:        "dangerously_skip_permissions true maps to --yolo",
 			prompt:      "test",
 			options:     map[string]any{"dangerously_skip_permissions": true},
 			mockStdout:  []byte("code"),
-			wantCLIArgs: []string{"--prompt", "test", "--yolo"},
+			wantCLIArgs: []string{"exec", "--json", "test", "--yolo"},
 		},
 		{
 			name:        "dangerously_skip_permissions false omits --yolo",
 			prompt:      "test",
 			options:     map[string]any{"dangerously_skip_permissions": false},
 			mockStdout:  []byte("code"),
-			wantCLIArgs: []string{"--prompt", "test"},
+			wantCLIArgs: []string{"exec", "--json", "test"},
 		},
 	}
 
@@ -151,7 +151,7 @@ func TestCodexProvider_Execute_WithOptions(t *testing.T) {
 			mockExec.SetOutput(tt.mockStdout, nil)
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
-			_, err := provider.Execute(context.Background(), tt.prompt, tt.options)
+			_, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
 
 			require.NoError(t, err)
 			calls := mockExec.GetCalls()
@@ -191,7 +191,7 @@ func TestCodexProvider_Execute_EmptyPrompt(t *testing.T) {
 			mockExec.SetOutput([]byte("code"), nil)
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), tt.prompt, nil)
+			result, err := provider.Execute(context.Background(), tt.prompt, nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -236,7 +236,7 @@ func TestCodexProvider_Execute_ValidationErrors(t *testing.T) {
 			mockExec.SetOutput([]byte("code"), nil)
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), tt.prompt, tt.options)
+			result, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
 
 			if tt.wantErr != "" {
 				assert.Error(t, err)
@@ -284,7 +284,7 @@ func TestCodexProvider_Execute_ContextErrors(t *testing.T) {
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
 			ctx := tt.ctxFunc()
-			result, err := provider.Execute(ctx, "test prompt", nil)
+			result, err := provider.Execute(ctx, "test prompt", nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -327,7 +327,7 @@ func TestCodexProvider_Execute_CLIErrors(t *testing.T) {
 			mockExec.SetError(tt.mockErr)
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "test", nil)
+			result, err := provider.Execute(context.Background(), "test", nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -388,7 +388,7 @@ func TestCodexProvider_Execute_StdoutStderrCombination(t *testing.T) {
 			mockExec.SetOutput(tt.stdout, tt.stderr)
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "test", nil)
+			result, err := provider.Execute(context.Background(), "test", nil, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -431,7 +431,7 @@ func TestCodexProvider_Execute_TokenEstimation(t *testing.T) {
 			mockExec.SetOutput(tt.mockStdout, nil)
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "test", nil)
+			result, err := provider.Execute(context.Background(), "test", nil, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -445,7 +445,7 @@ func TestCodexProvider_Execute_TimestampOrdering(t *testing.T) {
 	mockExec.SetOutput([]byte("code"), nil)
 	provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
-	result, err := provider.Execute(context.Background(), "test", nil)
+	result, err := provider.Execute(context.Background(), "test", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -459,7 +459,7 @@ func TestCodexProvider_Execute_ProviderName(t *testing.T) {
 	mockExec.SetOutput([]byte("code"), nil)
 	provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
-	result, err := provider.Execute(context.Background(), "test", nil)
+	result, err := provider.Execute(context.Background(), "test", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -506,7 +506,7 @@ func TestCodexProvider_ExecuteConversation_Success(t *testing.T) {
 			mockExec.SetOutput(tt.mockStdout, nil)
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
-			result, err := provider.ExecuteConversation(context.Background(), tt.state, tt.prompt, tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), tt.state, tt.prompt, tt.options, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -525,7 +525,7 @@ func TestCodexProvider_ExecuteConversation_NilState(t *testing.T) {
 	mockExec.SetOutput([]byte("code"), nil)
 	provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 
-	result, err := provider.ExecuteConversation(context.Background(), nil, "test", nil)
+	result, err := provider.ExecuteConversation(context.Background(), nil, "test", nil, nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "conversation state cannot be nil")
@@ -557,7 +557,7 @@ func TestCodexProvider_ExecuteConversation_EmptyPrompt(t *testing.T) {
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 			state := workflow.NewConversationState("")
 
-			result, err := provider.ExecuteConversation(context.Background(), state, tt.prompt, nil)
+			result, err := provider.ExecuteConversation(context.Background(), state, tt.prompt, nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -576,7 +576,7 @@ func TestCodexProvider_ExecuteConversation_WithHistory(t *testing.T) {
 	state.AddTurn(workflow.NewTurn(workflow.TurnRoleUser, "first question"))
 	state.AddTurn(workflow.NewTurn(workflow.TurnRoleAssistant, "first answer"))
 
-	result, err := provider.ExecuteConversation(context.Background(), state, "second question", nil)
+	result, err := provider.ExecuteConversation(context.Background(), state, "second question", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -598,7 +598,7 @@ func TestCodexProvider_ExecuteConversation_StatePreservation(t *testing.T) {
 	originalState := workflow.NewConversationState("")
 	originalState.AddTurn(workflow.NewTurn(workflow.TurnRoleUser, "initial"))
 
-	result, err := provider.ExecuteConversation(context.Background(), originalState, "test", nil)
+	result, err := provider.ExecuteConversation(context.Background(), originalState, "test", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -618,7 +618,7 @@ func TestCodexProvider_ExecuteConversation_TokenCounting(t *testing.T) {
 	state := workflow.NewConversationState("")
 	state.AddTurn(workflow.NewTurn(workflow.TurnRoleUser, "previous")) // 8 chars = 2 tokens
 
-	result, err := provider.ExecuteConversation(context.Background(), state, "current", nil) // 7 chars = 1 token (will be added to input)
+	result, err := provider.ExecuteConversation(context.Background(), state, "current", nil, nil, nil) // 7 chars = 1 token (will be added to input)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -662,7 +662,7 @@ func TestCodexProvider_ExecuteConversation_ValidationErrors(t *testing.T) {
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 			state := workflow.NewConversationState("")
 
-			result, err := provider.ExecuteConversation(context.Background(), state, "test", tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test", tt.options, nil, nil)
 
 			if tt.wantErr != "" {
 				assert.Error(t, err)
@@ -711,7 +711,7 @@ func TestCodexProvider_ExecuteConversation_ContextErrors(t *testing.T) {
 			state := workflow.NewConversationState("")
 
 			ctx := tt.ctxFunc()
-			result, err := provider.ExecuteConversation(ctx, state, "test", nil)
+			result, err := provider.ExecuteConversation(ctx, state, "test", nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -745,7 +745,7 @@ func TestCodexProvider_ExecuteConversation_CLIErrors(t *testing.T) {
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 			state := workflow.NewConversationState("")
 
-			result, err := provider.ExecuteConversation(context.Background(), state, "test", nil)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test", nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -763,32 +763,32 @@ func TestCodexProvider_ExecuteConversation_OptionsCLIArgumentConstruction(t *tes
 		{
 			name:        "model option",
 			options:     map[string]any{"model": "codex-002"},
-			wantCLIArgs: []string{"--prompt", "test", "--model", "codex-002"},
+			wantCLIArgs: []string{"exec", "--json", "test", "--model", "codex-002"},
 		},
 		{
 			name:        "language option",
 			options:     map[string]any{"language": "python"},
-			wantCLIArgs: []string{"--prompt", "test", "--language", "python"},
+			wantCLIArgs: []string{"exec", "--json", "test", "--language", "python"},
 		},
 		{
 			name:        "quiet option",
 			options:     map[string]any{"quiet": true},
-			wantCLIArgs: []string{"--prompt", "test", "--quiet"},
+			wantCLIArgs: []string{"exec", "--json", "test"},
 		},
 		{
 			name:        "multiple options",
 			options:     map[string]any{"model": "codex-002", "language": "go", "quiet": true},
-			wantCLIArgs: []string{"--prompt", "test", "--model", "codex-002", "--language", "go", "--quiet"},
+			wantCLIArgs: []string{"exec", "--json", "test", "--model", "codex-002", "--language", "go"},
 		},
 		{
 			name:        "dangerously_skip_permissions true maps to --yolo",
 			options:     map[string]any{"dangerously_skip_permissions": true},
-			wantCLIArgs: []string{"--prompt", "test", "--yolo"},
+			wantCLIArgs: []string{"exec", "--json", "test", "--yolo"},
 		},
 		{
 			name:        "dangerously_skip_permissions false omits --yolo",
 			options:     map[string]any{"dangerously_skip_permissions": false},
-			wantCLIArgs: []string{"--prompt", "test"},
+			wantCLIArgs: []string{"exec", "--json", "test"},
 		},
 	}
 
@@ -799,7 +799,7 @@ func TestCodexProvider_ExecuteConversation_OptionsCLIArgumentConstruction(t *tes
 			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 			state := workflow.NewConversationState("")
 
-			_, err := provider.ExecuteConversation(context.Background(), state, "test", tt.options)
+			_, err := provider.ExecuteConversation(context.Background(), state, "test", tt.options, nil, nil)
 
 			require.NoError(t, err)
 			calls := mockExec.GetCalls()
@@ -833,7 +833,144 @@ func TestCodexProvider_NewCodexProvider_DefaultExecutor(t *testing.T) {
 	provider := NewCodexProvider()
 	assert.NotNil(t, provider)
 	assert.NotNil(t, provider.executor)
-	// Default executor should be ExecCLIExecutor
 	_, ok := provider.executor.(*ExecCLIExecutor)
 	assert.True(t, ok, "default executor should be ExecCLIExecutor")
+}
+
+// T008: Explicit tests for `exec --json` arg structure assertion
+func TestCodexProvider_Execute_ExecJSONStructure(t *testing.T) {
+	tests := []struct {
+		name        string
+		prompt      string
+		options     map[string]any
+		mockStdout  []byte
+		wantCLIArgs []string
+	}{
+		{
+			name:        "basic exec --json structure",
+			prompt:      "hello",
+			options:     nil,
+			mockStdout:  []byte("output"),
+			wantCLIArgs: []string{"exec", "--json", "hello"},
+		},
+		{
+			name:        "exec --json with model",
+			prompt:      "code",
+			options:     map[string]any{"model": "gpt-4"},
+			mockStdout:  []byte("result"),
+			wantCLIArgs: []string{"exec", "--json", "code", "--model", "gpt-4"},
+		},
+		{
+			name:        "exec --json with language",
+			prompt:      "write go",
+			options:     map[string]any{"language": "go"},
+			mockStdout:  []byte("code"),
+			wantCLIArgs: []string{"exec", "--json", "write go", "--language", "go"},
+		},
+		{
+			name:        "quiet true does NOT add --quiet flag",
+			prompt:      "test",
+			options:     map[string]any{"quiet": true},
+			mockStdout:  []byte("output"),
+			wantCLIArgs: []string{"exec", "--json", "test"},
+		},
+		{
+			name:        "quiet false does NOT add --quiet flag",
+			prompt:      "test",
+			options:     map[string]any{"quiet": false},
+			mockStdout:  []byte("output"),
+			wantCLIArgs: []string{"exec", "--json", "test"},
+		},
+		{
+			name:        "quiet is silently ignored with other options",
+			prompt:      "test",
+			options:     map[string]any{"quiet": true, "language": "python"},
+			mockStdout:  []byte("code"),
+			wantCLIArgs: []string{"exec", "--json", "test", "--language", "python"},
+		},
+		{
+			name:        "dangerously_skip_permissions adds --yolo",
+			prompt:      "test",
+			options:     map[string]any{"dangerously_skip_permissions": true},
+			mockStdout:  []byte("output"),
+			wantCLIArgs: []string{"exec", "--json", "test", "--yolo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			mockExec.SetOutput(tt.mockStdout, nil)
+			provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+
+			_, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
+
+			require.NoError(t, err)
+			calls := mockExec.GetCalls()
+			require.Len(t, calls, 1, "executor should be called once")
+			assert.Equal(t, "codex", calls[0].Name)
+			assert.Equal(t, tt.wantCLIArgs, calls[0].Args, "args must match exactly")
+		})
+	}
+}
+
+// T008: Verify --json flag is first arg after exec subcommand
+func TestCodexProvider_Execute_JSONFlagPosition(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	mockExec.SetOutput([]byte("result"), nil)
+	provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+
+	_, err := provider.Execute(context.Background(), "test prompt", nil, nil, nil)
+
+	require.NoError(t, err)
+	calls := mockExec.GetCalls()
+	require.Len(t, calls, 1)
+	args := calls[0].Args
+
+	require.Len(t, args, 3, "should have 3 args: exec, --json, prompt")
+	assert.Equal(t, "exec", args[0])
+	assert.Equal(t, "--json", args[1])
+	assert.Equal(t, "test prompt", args[2])
+}
+
+// T008: ExecuteConversation uses exec --json on first turn
+func TestCodexProvider_ExecuteConversation_FirstTurnExecJSON(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	mockExec.SetOutput([]byte("response"), nil)
+	provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+
+	state := workflow.NewConversationState("")
+	_, err := provider.ExecuteConversation(context.Background(), state, "first prompt", nil, nil, nil)
+
+	require.NoError(t, err)
+	calls := mockExec.GetCalls()
+	require.Len(t, calls, 1)
+	args := calls[0].Args
+
+	require.Len(t, args, 3, "first turn should have exec, --json, prompt")
+	assert.Equal(t, "exec", args[0], "first arg should be exec subcommand")
+	assert.Equal(t, "--json", args[1], "second arg should be --json flag")
+	assert.Equal(t, "first prompt", args[2], "third arg should be prompt")
+}
+
+// T008: ExecuteConversation uses resume subcommand on resume turn
+func TestCodexProvider_ExecuteConversation_ResumeJSONStructure(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	mockExec.SetOutput([]byte("response"), nil)
+	provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
+
+	state := workflow.NewConversationState("")
+	state.SessionID = "codex-abc123def456"
+	_, err := provider.ExecuteConversation(context.Background(), state, "follow up", nil, nil, nil)
+
+	require.NoError(t, err)
+	calls := mockExec.GetCalls()
+	require.Len(t, calls, 1)
+	args := calls[0].Args
+
+	require.Len(t, args, 4, "resume turn should have resume, sessionID, --json, prompt")
+	assert.Equal(t, "resume", args[0], "first arg should be resume subcommand")
+	assert.Equal(t, "codex-abc123def456", args[1], "second arg should be session ID")
+	assert.Equal(t, "--json", args[2], "third arg should be --json flag")
+	assert.Equal(t, "follow up", args[3], "fourth arg should be prompt")
 }

--- a/internal/infrastructure/agents/gemini_provider.go
+++ b/internal/infrastructure/agents/gemini_provider.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os/exec"
 	"slices"
 	"strings"
@@ -36,7 +37,7 @@ func NewGeminiProviderWithOptions(opts ...GeminiProviderOption) *GeminiProvider 
 	return p
 }
 
-func (p *GeminiProvider) Execute(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+func (p *GeminiProvider) Execute(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 	startedAt := time.Now()
 
 	if strings.TrimSpace(prompt) == "" {
@@ -57,13 +58,16 @@ func (p *GeminiProvider) Execute(ctx context.Context, prompt string, options map
 		args = append([]string{"--model", model}, args...)
 	}
 	if outputFormat, ok := getStringOption(options, "output_format"); ok {
+		if outputFormat == "json" {
+			outputFormat = "stream-json"
+		}
 		args = append([]string{"--output-format", outputFormat}, args...)
 	}
 	if skipPerms, ok := getBoolOption(options, "dangerously_skip_permissions"); ok && skipPerms {
 		args = append([]string{"--approval-mode=yolo"}, args...)
 	}
 
-	stdout, stderr, err := p.executor.Run(ctx, "gemini", args...)
+	stdoutBytes, stderrBytes, err := p.executor.Run(ctx, "gemini", stdout, stderr, args...)
 	completedAt := time.Now()
 
 	if err != nil {
@@ -71,9 +75,9 @@ func (p *GeminiProvider) Execute(ctx context.Context, prompt string, options map
 	}
 
 	// Combine stdout and stderr like CombinedOutput()
-	output := make([]byte, 0, len(stdout)+len(stderr))
-	output = append(output, stdout...)
-	output = append(output, stderr...)
+	output := make([]byte, 0, len(stdoutBytes)+len(stderrBytes))
+	output = append(output, stdoutBytes...)
+	output = append(output, stderrBytes...)
 	outputStr := string(output)
 	result := &workflow.AgentResult{
 		Provider:    "gemini",
@@ -91,7 +95,7 @@ func (p *GeminiProvider) Execute(ctx context.Context, prompt string, options map
 	return result, nil
 }
 
-func (p *GeminiProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+func (p *GeminiProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 	startedAt := time.Now()
 
 	if state == nil {
@@ -132,22 +136,25 @@ func (p *GeminiProvider) ExecuteConversation(ctx context.Context, state *workflo
 		args = append([]string{"--model", model}, args...)
 	}
 	if outputFormat, ok := getStringOption(options, "output_format"); ok {
+		if outputFormat == "json" {
+			outputFormat = "stream-json"
+		}
 		args = append([]string{"--output-format", outputFormat}, args...)
 	}
 	if skipPerms, ok := getBoolOption(options, "dangerously_skip_permissions"); ok && skipPerms {
 		args = append([]string{"--approval-mode=yolo"}, args...)
 	}
 
-	stdout, stderr, err := p.executor.Run(ctx, "gemini", args...)
+	stdoutBytes, stderrBytes, err := p.executor.Run(ctx, "gemini", stdout, stderr, args...)
 	completedAt := time.Now()
 
 	if err != nil {
 		return nil, fmt.Errorf("gemini execution failed: %w", err)
 	}
 
-	output := make([]byte, 0, len(stdout)+len(stderr))
-	output = append(output, stdout...)
-	output = append(output, stderr...)
+	output := make([]byte, 0, len(stdoutBytes)+len(stderrBytes))
+	output = append(output, stdoutBytes...)
+	output = append(output, stderrBytes...)
 	outputStr := string(output)
 	if outputStr == "" {
 		outputStr = " "

--- a/internal/infrastructure/agents/gemini_provider_session_test.go
+++ b/internal/infrastructure/agents/gemini_provider_session_test.go
@@ -101,7 +101,7 @@ func TestGeminiProvider_ExecuteConversation_ResumeFlag(t *testing.T) {
 			state := workflow.NewConversationState("system")
 			state.SessionID = tt.sessionID
 
-			result, err := provider.ExecuteConversation(context.Background(), state, "write a poem", nil)
+			result, err := provider.ExecuteConversation(context.Background(), state, "write a poem", nil, nil, nil)
 			require.NoError(t, err)
 			require.NotNil(t, result)
 
@@ -156,7 +156,7 @@ func TestGeminiProvider_ExecuteConversation_SessionIDExtracted(t *testing.T) {
 			provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
 			state := workflow.NewConversationState("system")
-			result, err := provider.ExecuteConversation(context.Background(), state, "test", nil)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test", nil, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -174,7 +174,7 @@ func TestGeminiProvider_ExecuteConversation_SystemPromptOnFirstTurn(t *testing.T
 	state := workflow.NewConversationState("")
 	options := map[string]any{"system_prompt": "You are a helpful assistant"}
 
-	_, err := provider.ExecuteConversation(context.Background(), state, "Generate a hello world", options)
+	_, err := provider.ExecuteConversation(context.Background(), state, "Generate a hello world", options, nil, nil)
 	require.NoError(t, err)
 
 	calls := mockExec.GetCalls()
@@ -192,7 +192,7 @@ func TestGeminiProvider_ExecuteConversation_NoSystemPromptOnResumeTurn(t *testin
 	state.SessionID = "existing-session-id"
 	options := map[string]any{"system_prompt": "You are a helpful assistant"}
 
-	_, err := provider.ExecuteConversation(context.Background(), state, "Continue", options)
+	_, err := provider.ExecuteConversation(context.Background(), state, "Continue", options, nil, nil)
 	require.NoError(t, err)
 
 	calls := mockExec.GetCalls()
@@ -226,7 +226,7 @@ func TestGeminiProvider_ExecuteConversation_GracefulFallback(t *testing.T) {
 			provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
 			state := workflow.NewConversationState("system")
-			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", nil)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", nil, nil, nil)
 
 			require.NoError(t, err, "extraction failure must not cause error (graceful fallback)")
 			require.NotNil(t, result)
@@ -242,7 +242,7 @@ func TestGeminiProvider_ExecuteConversation_EmptyOutputHandling(t *testing.T) {
 	provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
 	state := workflow.NewConversationState("system")
-	result, err := provider.ExecuteConversation(context.Background(), state, "test", nil)
+	result, err := provider.ExecuteConversation(context.Background(), state, "test", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -253,7 +253,7 @@ func TestGeminiProvider_ExecuteConversation_InvalidPrompt(t *testing.T) {
 	provider := NewGeminiProvider()
 	state := workflow.NewConversationState("")
 
-	_, err := provider.ExecuteConversation(context.Background(), state, "   ", nil)
+	_, err := provider.ExecuteConversation(context.Background(), state, "   ", nil, nil, nil)
 
 	assert.Error(t, err)
 }
@@ -261,7 +261,7 @@ func TestGeminiProvider_ExecuteConversation_InvalidPrompt(t *testing.T) {
 func TestGeminiProvider_ExecuteConversation_NilState(t *testing.T) {
 	provider := NewGeminiProvider()
 
-	_, err := provider.ExecuteConversation(context.Background(), nil, "test", nil)
+	_, err := provider.ExecuteConversation(context.Background(), nil, "test", nil, nil, nil)
 
 	assert.Error(t, err)
 }

--- a/internal/infrastructure/agents/gemini_provider_unit_test.go
+++ b/internal/infrastructure/agents/gemini_provider_unit_test.go
@@ -63,7 +63,7 @@ func TestGeminiProvider_Execute_Success(t *testing.T) {
 			mockExec.SetOutput(tt.mockStdout, nil)
 			provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), tt.prompt, tt.options)
+			result, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -113,7 +113,7 @@ func TestGeminiProvider_Execute_JSONParsing(t *testing.T) {
 			mockExec.SetOutput(tt.mockStdout, nil)
 			provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "test", nil)
+			result, err := provider.Execute(context.Background(), "test", nil, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -176,7 +176,7 @@ func TestGeminiProvider_Execute_ValidationErrors(t *testing.T) {
 			mockExec.SetOutput([]byte("response"), nil)
 			provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), tt.prompt, tt.options)
+			result, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
 
 			if tt.wantErr != "" {
 				assert.Error(t, err)
@@ -224,7 +224,7 @@ func TestGeminiProvider_Execute_ContextErrors(t *testing.T) {
 			provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
 			ctx := tt.ctxFunc()
-			result, err := provider.Execute(ctx, "test prompt", nil)
+			result, err := provider.Execute(ctx, "test prompt", nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -262,7 +262,7 @@ func TestGeminiProvider_Execute_CLIErrors(t *testing.T) {
 			mockExec.SetError(tt.mockErr)
 			provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "test prompt", nil)
+			result, err := provider.Execute(context.Background(), "test prompt", nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -310,7 +310,7 @@ func TestGeminiProvider_Execute_StdoutStderrCombination(t *testing.T) {
 			mockExec.SetOutput(tt.stdout, tt.stderr)
 			provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "test", nil)
+			result, err := provider.Execute(context.Background(), "test", nil, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -346,14 +346,14 @@ func TestGeminiProvider_Execute_CLIArgumentConstruction(t *testing.T) {
 			prompt:       "test",
 			options:      map[string]any{"output_format": "json"},
 			mockOutput:   []byte(`{"result":"ok"}`),
-			wantContains: []string{"--output-format", "json", "test"},
+			wantContains: []string{"--output-format", "stream-json", "test"},
 		},
 		{
 			name:         "with multiple options",
 			prompt:       "test",
 			options:      map[string]any{"model": "gemini-ultra", "output_format": "json"},
 			mockOutput:   []byte("ok"),
-			wantContains: []string{"--model", "gemini-ultra", "--output-format", "json", "test"},
+			wantContains: []string{"--model", "gemini-ultra", "--output-format", "stream-json", "test"},
 		},
 	}
 
@@ -363,7 +363,7 @@ func TestGeminiProvider_Execute_CLIArgumentConstruction(t *testing.T) {
 			mockExec.SetOutput(tt.mockOutput, nil)
 			provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
-			_, err := provider.Execute(context.Background(), tt.prompt, tt.options)
+			_, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
 			require.NoError(t, err)
 
 			calls := mockExec.GetCalls()
@@ -440,7 +440,7 @@ func TestGeminiProvider_ExecuteConversation_Success(t *testing.T) {
 			provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
 			state := tt.stateSetup()
-			result, err := provider.ExecuteConversation(context.Background(), state, tt.prompt, tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), state, tt.prompt, tt.options, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -508,7 +508,7 @@ func TestGeminiProvider_ExecuteConversation_ValidationErrors(t *testing.T) {
 			mockExec.SetOutput([]byte("response"), nil)
 			provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
-			result, err := provider.ExecuteConversation(context.Background(), tt.state, tt.prompt, tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), tt.state, tt.prompt, tt.options, nil, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -552,7 +552,7 @@ func TestGeminiProvider_ExecuteConversation_ContextErrors(t *testing.T) {
 
 			state := workflow.NewConversationState("system")
 			ctx := tt.ctxFunc()
-			result, err := provider.ExecuteConversation(ctx, state, "test", nil)
+			result, err := provider.ExecuteConversation(ctx, state, "test", nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -586,7 +586,7 @@ func TestGeminiProvider_ExecuteConversation_CLIErrors(t *testing.T) {
 			provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
 			state := workflow.NewConversationState("system")
-			result, err := provider.ExecuteConversation(context.Background(), state, "test", nil)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test", nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -614,7 +614,7 @@ func TestGeminiProvider_ExecuteConversation_StatePreservation(t *testing.T) {
 	initialTotalTurns := initialState.TotalTurns
 	initialTotalTokens := initialState.TotalTokens
 
-	result, err := provider.ExecuteConversation(context.Background(), initialState, "How are you?", nil)
+	result, err := provider.ExecuteConversation(context.Background(), initialState, "How are you?", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -636,7 +636,7 @@ func TestGeminiProvider_ExecuteConversation_TokenCounting(t *testing.T) {
 	provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
 	state := workflow.NewConversationState("You are helpful")
-	result, err := provider.ExecuteConversation(context.Background(), state, "Hello", nil)
+	result, err := provider.ExecuteConversation(context.Background(), state, "Hello", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -676,7 +676,7 @@ func TestGeminiProvider_ExecuteConversation_JSONParsing(t *testing.T) {
 			provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
 			state := workflow.NewConversationState("system")
-			result, err := provider.ExecuteConversation(context.Background(), state, "test", tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test", tt.options, nil, nil)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -717,7 +717,7 @@ func TestGeminiProvider_Execute_EmptyState(t *testing.T) {
 	provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
 	state := &workflow.ConversationState{}
-	result, err := provider.ExecuteConversation(context.Background(), state, "test", nil)
+	result, err := provider.ExecuteConversation(context.Background(), state, "test", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -729,7 +729,7 @@ func TestGeminiProvider_Execute_OptionsNil(t *testing.T) {
 	mockExec.SetOutput([]byte("response"), nil)
 	provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
-	result, err := provider.Execute(context.Background(), "test", nil)
+	result, err := provider.Execute(context.Background(), "test", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -746,7 +746,7 @@ func TestGeminiProvider_Execute_MultipleOptions(t *testing.T) {
 		"output_format": "text",
 	}
 
-	result, err := provider.Execute(context.Background(), "test", options)
+	result, err := provider.Execute(context.Background(), "test", options, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -842,13 +842,13 @@ func TestGeminiProvider_Execute_DangerouslySkipPermissions(t *testing.T) {
 			name:         "skip permissions with output format",
 			options:      map[string]any{"dangerously_skip_permissions": true, "output_format": "json"},
 			mockOutput:   []byte(`{"result":"ok"}`),
-			wantContains: []string{"--approval-mode=yolo", "--output-format", "json"},
+			wantContains: []string{"--approval-mode=yolo", "--output-format", "stream-json"},
 		},
 		{
 			name:         "skip permissions with all options",
 			options:      map[string]any{"dangerously_skip_permissions": true, "model": "gemini-ultra", "output_format": "json"},
 			mockOutput:   []byte(`{"result":"ok"}`),
-			wantContains: []string{"--approval-mode=yolo", "--model", "gemini-ultra", "--output-format", "json"},
+			wantContains: []string{"--approval-mode=yolo", "--model", "gemini-ultra", "--output-format", "stream-json"},
 		},
 		{
 			name:       "skip permissions as string value",
@@ -870,7 +870,7 @@ func TestGeminiProvider_Execute_DangerouslySkipPermissions(t *testing.T) {
 			mockExec.SetOutput(tt.mockOutput, nil)
 			provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "test prompt", tt.options)
+			result, err := provider.Execute(context.Background(), "test prompt", tt.options, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -927,7 +927,7 @@ func TestGeminiProvider_ExecuteConversation_DangerouslySkipPermissions(t *testin
 			name:         "skip permissions with model and format",
 			options:      map[string]any{"dangerously_skip_permissions": true, "model": "gemini-pro", "output_format": "json"},
 			mockOutput:   []byte(`{"result":"ok"}`),
-			wantContains: []string{"--approval-mode=yolo", "--model", "gemini-pro", "--output-format", "json"},
+			wantContains: []string{"--approval-mode=yolo", "--model", "gemini-pro", "--output-format", "stream-json"},
 		},
 		{
 			name:         "skip permissions with existing session",
@@ -947,7 +947,7 @@ func TestGeminiProvider_ExecuteConversation_DangerouslySkipPermissions(t *testin
 			state := workflow.NewConversationState("You are helpful")
 			state.SessionID = tt.sessionID
 
-			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", tt.options, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -963,6 +963,148 @@ func TestGeminiProvider_ExecuteConversation_DangerouslySkipPermissions(t *testin
 			for _, notWant := range tt.wantNotIn {
 				assert.NotContains(t, calls[0].Args, notWant, "unexpected arg %q found in %v", notWant, calls[0].Args)
 			}
+		})
+	}
+}
+
+// TestGeminiProvider_Execute_OutputFormatMapping_T002
+// T002: Map output_format: json → stream-json in Execute
+// Requirement: System MUST invoke Gemini CLI with `--output-format stream-json`
+// when `output_format` is `json` or `stream-json` in step options
+func TestGeminiProvider_Execute_OutputFormatMapping_T002(t *testing.T) {
+	tests := []struct {
+		name            string
+		inputFormat     string
+		expectedCLIFlag string
+		description     string
+	}{
+		{
+			name:            "json maps to stream-json",
+			inputFormat:     "json",
+			expectedCLIFlag: "stream-json",
+			description:     "when output_format is json, CLI must receive stream-json",
+		},
+		{
+			name:            "stream-json stays as stream-json",
+			inputFormat:     "stream-json",
+			expectedCLIFlag: "stream-json",
+			description:     "when output_format is already stream-json, it should stay unchanged",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			mockExec.SetOutput([]byte("test response"), nil)
+			provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
+
+			options := map[string]any{"output_format": tt.inputFormat}
+			result, err := provider.Execute(context.Background(), "test prompt", options, nil, nil)
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, "test response", result.Output)
+
+			// Verify the CLI was invoked with the correct output-format flag
+			calls := mockExec.GetCalls()
+			require.Len(t, calls, 1, "expected exactly one CLI call")
+			require.Equal(t, "gemini", calls[0].Name)
+
+			// Find --output-format flag in args and verify its value
+			foundFlag := false
+			for i, arg := range calls[0].Args {
+				if arg != "--output-format" {
+					continue
+				}
+				require.Less(t, i+1, len(calls[0].Args), "--output-format must have a value")
+				actualValue := calls[0].Args[i+1]
+				assert.Equal(t, tt.expectedCLIFlag, actualValue,
+					"T002: %s - expected CLI flag value %q but got %q",
+					tt.description, tt.expectedCLIFlag, actualValue)
+				foundFlag = true
+				break
+			}
+			assert.True(t, foundFlag, "T002: --output-format flag not found in CLI arguments")
+		})
+	}
+}
+
+// TestGeminiProvider_ExecuteConversation_OutputFormatMapping_T002
+// T002: Map output_format: json → stream-json in ExecuteConversation
+// Requirement: System MUST force `--output-format stream-json` (instead of `json`)
+// in Gemini's ExecuteConversation for session ID extraction
+func TestGeminiProvider_ExecuteConversation_OutputFormatMapping_T002(t *testing.T) {
+	tests := []struct {
+		name            string
+		inputFormat     string
+		expectedCLIFlag string
+		mockOutput      []byte
+		description     string
+		isFirstTurn     bool
+	}{
+		{
+			name:            "first turn: json maps to stream-json",
+			inputFormat:     "json",
+			expectedCLIFlag: "stream-json",
+			mockOutput:      []byte(`{"session_id":"abc123","result":"Assistant response"}`),
+			description:     "first turn: when output_format is json, CLI must receive stream-json",
+			isFirstTurn:     true,
+		},
+		{
+			name:            "first turn: stream-json stays as stream-json",
+			inputFormat:     "stream-json",
+			expectedCLIFlag: "stream-json",
+			mockOutput:      []byte(`{"session_id":"abc123","result":"Assistant response"}`),
+			description:     "first turn: when output_format is already stream-json, it should stay unchanged",
+			isFirstTurn:     true,
+		},
+		{
+			name:            "resume turn: json maps to stream-json",
+			inputFormat:     "json",
+			expectedCLIFlag: "stream-json",
+			mockOutput:      []byte(`{"session_id":"abc123","result":"Continued response"}`),
+			description:     "resume turn: when output_format is json, CLI must receive stream-json",
+			isFirstTurn:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			mockExec.SetOutput(tt.mockOutput, nil)
+			provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
+
+			state := workflow.NewConversationState("You are helpful")
+			if !tt.isFirstTurn {
+				state.SessionID = "abc123"
+			}
+
+			options := map[string]any{"output_format": tt.inputFormat}
+			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", options, nil, nil)
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			// Verify the CLI was invoked with the correct output-format flag
+			calls := mockExec.GetCalls()
+			require.Len(t, calls, 1, "expected exactly one CLI call")
+			require.Equal(t, "gemini", calls[0].Name)
+
+			// Find --output-format flag in args and verify its value
+			foundFlag := false
+			for i, arg := range calls[0].Args {
+				if arg != "--output-format" {
+					continue
+				}
+				require.Less(t, i+1, len(calls[0].Args), "--output-format must have a value")
+				actualValue := calls[0].Args[i+1]
+				assert.Equal(t, tt.expectedCLIFlag, actualValue,
+					"T002: %s - expected CLI flag value %q but got %q",
+					tt.description, tt.expectedCLIFlag, actualValue)
+				foundFlag = true
+				break
+			}
+			assert.True(t, foundFlag, "T002: --output-format flag not found in CLI arguments")
 		})
 	}
 }

--- a/internal/infrastructure/agents/helpers.go
+++ b/internal/infrastructure/agents/helpers.go
@@ -1,7 +1,6 @@
 package agents
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -60,27 +59,6 @@ func getBoolOption(options map[string]any, key string) (value, found bool) {
 	}
 	val, ok := options[key].(bool)
 	return val, ok
-}
-
-func validatePrompt(prompt string) error {
-	if strings.TrimSpace(prompt) == "" {
-		return fmt.Errorf("prompt cannot be empty")
-	}
-	return nil
-}
-
-func validateContext(ctx context.Context, providerName string) error {
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("%s provider: %w", providerName, err)
-	}
-	return nil
-}
-
-func validateState(state *workflow.ConversationState) error {
-	if state == nil {
-		return fmt.Errorf("conversation state cannot be nil")
-	}
-	return nil
 }
 
 func estimateInputTokens(turns []workflow.Turn, excludeLastN int) int {

--- a/internal/infrastructure/agents/helpers_test.go
+++ b/internal/infrastructure/agents/helpers_test.go
@@ -1,7 +1,6 @@
 package agents
 
 import (
-	"context"
 	"testing"
 
 	"github.com/awf-project/cli/internal/domain/workflow"
@@ -297,123 +296,6 @@ func TestGetBoolOption(t *testing.T) {
 			value, ok := getBoolOption(tt.options, tt.key)
 			assert.Equal(t, tt.wantValue, value)
 			assert.Equal(t, tt.wantOK, ok)
-		})
-	}
-}
-
-func TestValidatePrompt(t *testing.T) {
-	tests := []struct {
-		name    string
-		prompt  string
-		wantErr bool
-	}{
-		{
-			name:    "valid_prompt",
-			prompt:  "Test prompt",
-			wantErr: false,
-		},
-		{
-			name:    "empty_prompt",
-			prompt:  "",
-			wantErr: true,
-		},
-		{
-			name:    "whitespace_only",
-			prompt:  "   \t\n",
-			wantErr: true,
-		},
-		{
-			name:    "prompt_with_whitespace",
-			prompt:  "  Test  ",
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validatePrompt(tt.prompt)
-			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), "prompt")
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestValidateContext(t *testing.T) {
-	tests := []struct {
-		name         string
-		ctx          context.Context
-		providerName string
-		wantErr      bool
-	}{
-		{
-			name:         "valid_context",
-			ctx:          context.Background(),
-			providerName: "claude",
-			wantErr:      false,
-		},
-		{
-			name: "cancelled_context",
-			ctx: func() context.Context {
-				ctx, cancel := context.WithCancel(context.Background())
-				cancel()
-				return ctx
-			}(),
-			providerName: "claude",
-			wantErr:      true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateContext(tt.ctx, tt.providerName)
-			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tt.providerName)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestValidateState(t *testing.T) {
-	tests := []struct {
-		name    string
-		state   *workflow.ConversationState
-		wantErr bool
-	}{
-		{
-			name:    "nil_state",
-			state:   nil,
-			wantErr: true,
-		},
-		{
-			name:    "valid_empty_state",
-			state:   &workflow.ConversationState{},
-			wantErr: false,
-		},
-		{
-			name: "valid_state_with_turns",
-			state: &workflow.ConversationState{
-				Turns: []workflow.Turn{{Role: "user", Content: "Hello"}},
-			},
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateState(tt.state)
-			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), "state")
-			} else {
-				assert.NoError(t, err)
-			}
 		})
 	}
 }

--- a/internal/infrastructure/agents/mock_provider.go
+++ b/internal/infrastructure/agents/mock_provider.go
@@ -3,6 +3,7 @@ package agents
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 	"time"
@@ -81,7 +82,7 @@ func (m *MockProvider) WithValidateError(err error) *MockProvider {
 }
 
 // Execute implements ports.AgentProvider.
-func (m *MockProvider) Execute(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+func (m *MockProvider) Execute(ctx context.Context, prompt string, options map[string]any, _, _ io.Writer) (*workflow.AgentResult, error) {
 	m.mu.Lock()
 	m.calls = append(m.calls, MockCall{
 		Method:  "Execute",
@@ -120,7 +121,7 @@ func (m *MockProvider) Execute(ctx context.Context, prompt string, options map[s
 }
 
 // ExecuteConversation implements ports.AgentProvider.
-func (m *MockProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+func (m *MockProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, _, _ io.Writer) (*workflow.ConversationResult, error) {
 	m.mu.Lock()
 	m.calls = append(m.calls, MockCall{
 		Method:  "ExecuteConversation",

--- a/internal/infrastructure/agents/mock_provider_test.go
+++ b/internal/infrastructure/agents/mock_provider_test.go
@@ -53,7 +53,7 @@ func TestMockProvider_Execute_DefaultResponse(t *testing.T) {
 	mock := NewMockProvider("claude")
 	ctx := context.Background()
 
-	result, err := mock.Execute(ctx, "What is 2+2?", nil)
+	result, err := mock.Execute(ctx, "What is 2+2?", nil, nil, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, "claude", result.Provider)
@@ -71,7 +71,7 @@ func TestMockProvider_Execute_PatternMatch(t *testing.T) {
 	mock := NewMockProvider("claude").WithResponse("2+2", expected)
 	ctx := context.Background()
 
-	result, err := mock.Execute(ctx, "What is 2+2?", nil)
+	result, err := mock.Execute(ctx, "What is 2+2?", nil, nil, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, "The answer is 4", result.Output)
@@ -89,11 +89,11 @@ func TestMockProvider_Execute_MultiplePatterns(t *testing.T) {
 	ctx := context.Background()
 
 	// First pattern
-	r1, _ := mock.Execute(ctx, "calculate 5+5", nil)
+	r1, _ := mock.Execute(ctx, "calculate 5+5", nil, nil, nil)
 	assert.Equal(t, "math answer", r1.Output)
 
 	// Second pattern
-	r2, _ := mock.Execute(ctx, "review this code", nil)
+	r2, _ := mock.Execute(ctx, "review this code", nil, nil, nil)
 	assert.Equal(t, "code review", r2.Output)
 
 	assert.Equal(t, 2, mock.CallCount())
@@ -106,7 +106,7 @@ func TestMockProvider_Execute_ContextCancellation(t *testing.T) {
 	// Cancel immediately
 	cancel()
 
-	result, err := mock.Execute(ctx, "test", nil)
+	result, err := mock.Execute(ctx, "test", nil, nil, nil)
 
 	assert.Nil(t, result)
 	assert.ErrorIs(t, err, context.Canceled)
@@ -117,8 +117,8 @@ func TestMockProvider_Execute_RecordsCalls(t *testing.T) {
 	ctx := context.Background()
 	opts := map[string]any{"model": "sonnet"}
 
-	_, _ = mock.Execute(ctx, "prompt 1", nil)
-	_, _ = mock.Execute(ctx, "prompt 2", opts)
+	_, _ = mock.Execute(ctx, "prompt 1", nil, nil, nil)
+	_, _ = mock.Execute(ctx, "prompt 2", opts, nil, nil)
 
 	calls := mock.Calls()
 	require.Len(t, calls, 2)
@@ -137,7 +137,7 @@ func TestMockProvider_ExecuteConversation_DefaultResponse(t *testing.T) {
 	ctx := context.Background()
 	state := workflow.NewConversationState("You are helpful")
 
-	result, err := mock.ExecuteConversation(ctx, state, "Hello", nil)
+	result, err := mock.ExecuteConversation(ctx, state, "Hello", nil, nil, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, "mock conversation response", result.Output)
@@ -154,7 +154,7 @@ func TestMockProvider_ExecuteConversation_PatternMatch(t *testing.T) {
 	ctx := context.Background()
 	state := workflow.NewConversationState("You are a reviewer")
 
-	result, err := mock.ExecuteConversation(ctx, state, "Please review this", nil)
+	result, err := mock.ExecuteConversation(ctx, state, "Please review this", nil, nil, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, "Code looks good. APPROVED", result.Output)
@@ -165,7 +165,7 @@ func TestMockProvider_ExecuteConversation_NilState(t *testing.T) {
 	mock := NewMockProvider("claude")
 	ctx := context.Background()
 
-	result, err := mock.ExecuteConversation(ctx, nil, "Hello", nil)
+	result, err := mock.ExecuteConversation(ctx, nil, "Hello", nil, nil, nil)
 
 	require.NoError(t, err)
 	assert.NotNil(t, result.State)
@@ -176,7 +176,7 @@ func TestMockProvider_Reset(t *testing.T) {
 	mock := NewMockProvider("claude")
 	ctx := context.Background()
 
-	_, _ = mock.Execute(ctx, "test", nil)
+	_, _ = mock.Execute(ctx, "test", nil, nil, nil)
 	assert.Equal(t, 1, mock.CallCount())
 
 	mock.Reset()
@@ -189,9 +189,9 @@ func TestMockProvider_CallCounters(t *testing.T) {
 	ctx := context.Background()
 	state := workflow.NewConversationState("")
 
-	_, _ = mock.Execute(ctx, "exec 1", nil)
-	_, _ = mock.Execute(ctx, "exec 2", nil)
-	_, _ = mock.ExecuteConversation(ctx, state, "conv 1", nil)
+	_, _ = mock.Execute(ctx, "exec 1", nil, nil, nil)
+	_, _ = mock.Execute(ctx, "exec 2", nil, nil, nil)
+	_, _ = mock.ExecuteConversation(ctx, state, "conv 1", nil, nil, nil)
 
 	assert.Equal(t, 3, mock.CallCount())
 	assert.Equal(t, 2, mock.ExecuteCallCount())
@@ -207,7 +207,7 @@ func TestMockProvider_WithDefaultResponse(t *testing.T) {
 	mock := NewMockProvider("claude").WithDefaultResponse(defaultResult)
 	ctx := context.Background()
 
-	result, err := mock.Execute(ctx, "any prompt", nil)
+	result, err := mock.Execute(ctx, "any prompt", nil, nil, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, "default output", result.Output)
@@ -222,7 +222,7 @@ func TestMockProvider_ConcurrentCalls(t *testing.T) {
 	done := make(chan bool, 10)
 	for i := 0; i < 10; i++ {
 		go func() {
-			_, _ = mock.Execute(ctx, "concurrent test", nil)
+			_, _ = mock.Execute(ctx, "concurrent test", nil, nil, nil)
 			done <- true
 		}()
 	}

--- a/internal/infrastructure/agents/openai_compatible_provider.go
+++ b/internal/infrastructure/agents/openai_compatible_provider.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -83,7 +84,7 @@ func (p *OpenAICompatibleProvider) Validate() error {
 	return nil
 }
 
-func (p *OpenAICompatibleProvider) Execute(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+func (p *OpenAICompatibleProvider) Execute(ctx context.Context, prompt string, options map[string]any, _, _ io.Writer) (*workflow.AgentResult, error) {
 	if strings.TrimSpace(prompt) == "" {
 		return nil, errors.New("prompt cannot be empty")
 	}
@@ -133,7 +134,7 @@ func (p *OpenAICompatibleProvider) parseJSONResponse(output string) (map[string]
 	return parsed, nil
 }
 
-func (p *OpenAICompatibleProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+func (p *OpenAICompatibleProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, _, _ io.Writer) (*workflow.ConversationResult, error) {
 	if state == nil {
 		return nil, fmt.Errorf("openai_compatible: conversation state cannot be nil")
 	}

--- a/internal/infrastructure/agents/openai_compatible_provider_test.go
+++ b/internal/infrastructure/agents/openai_compatible_provider_test.go
@@ -61,7 +61,7 @@ func TestOpenAICompatibleProvider_SingleTurnHappyPath_Integration(t *testing.T) 
 	result, err := provider.Execute(ctx, "What is 2+2?", map[string]any{
 		"base_url": server.URL,
 		"model":    "test-model",
-	})
+	}, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -123,7 +123,7 @@ func TestOpenAICompatibleProvider_SingleTurnWithOptions_Integration(t *testing.T
 		"model":       "gpt-3.5-turbo",
 		"temperature": 1.5,
 		"max_tokens":  100,
-	})
+	}, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -207,7 +207,7 @@ func TestOpenAICompatibleProvider_Conversation_Integration(t *testing.T) {
 		"base_url":      server.URL,
 		"model":         "test-model",
 		"system_prompt": "You are a helpful assistant.",
-	})
+	}, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -260,7 +260,7 @@ func TestOpenAICompatibleProvider_HTTP401Unauthorized_Integration(t *testing.T) 
 		"base_url": server.URL,
 		"model":    "test-model",
 		"api_key":  "sk-secret-key-value-1234",
-	})
+	}, nil, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "authentication failed")
@@ -296,7 +296,7 @@ func TestOpenAICompatibleProvider_HTTP429RateLimit_Integration(t *testing.T) {
 	_, err := provider.Execute(ctx, "Test prompt", map[string]any{
 		"base_url": server.URL,
 		"model":    "test-model",
-	})
+	}, nil, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rate limited")
@@ -329,7 +329,7 @@ func TestOpenAICompatibleProvider_HTTP500ServerError_Integration(t *testing.T) {
 	_, err := provider.Execute(ctx, "Test prompt", map[string]any{
 		"base_url": server.URL,
 		"model":    "test-model",
-	})
+	}, nil, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "server error")
@@ -387,7 +387,7 @@ func TestOpenAICompatibleProvider_RequestBodyValidation_Integration(t *testing.T
 		"temperature": 0.7,
 		"max_tokens":  1024,
 		"top_p":       0.9,
-	})
+	}, nil, nil)
 
 	require.NoError(t, err)
 
@@ -446,7 +446,7 @@ func TestOpenAICompatibleProvider_JSONOutput_Integration(t *testing.T) {
 		"base_url":      server.URL,
 		"model":         "test-model",
 		"output_format": "json",
-	})
+	}, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -507,7 +507,7 @@ func TestOpenAICompatibleProvider_BaseURLNormalization_Integration(t *testing.T)
 	_, err := provider.Execute(ctx, "Test", map[string]any{
 		"base_url": baseURLWithSlash,
 		"model":    "test-model",
-	})
+	}, nil, nil)
 
 	require.NoError(t, err)
 	assert.True(t, handlerCalled, "handler should be called with normalized URL")
@@ -573,7 +573,7 @@ func TestOpenAICompatibleProvider_ConversationWithSystemPrompt_Integration(t *te
 		"base_url":      server.URL,
 		"model":         "test-model",
 		"system_prompt": "You are an expert assistant.",
-	})
+	}, nil, nil)
 
 	require.NoError(t, err)
 

--- a/internal/infrastructure/agents/openai_compatible_provider_unit_test.go
+++ b/internal/infrastructure/agents/openai_compatible_provider_unit_test.go
@@ -80,7 +80,7 @@ func TestOpenAICompatibleProvider_Execute_Success(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := NewOpenAICompatibleProvider()
 
-			result, err := provider.Execute(context.Background(), tt.prompt, tt.options)
+			result, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
 
 			// Real implementation must not error and must return AgentResult
 			assert.NoError(t, err, "should execute successfully")
@@ -127,7 +127,7 @@ func TestOpenAICompatibleProvider_Execute_EmptyPrompt(t *testing.T) {
 			}
 			provider := NewOpenAICompatibleProvider()
 
-			result, err := provider.Execute(context.Background(), tt.prompt, options)
+			result, err := provider.Execute(context.Background(), tt.prompt, options, nil, nil)
 			require.Error(t, err, "should return error for empty prompt")
 			assert.Contains(t, err.Error(), tt.wantErr)
 			assert.Nil(t, result)
@@ -214,7 +214,7 @@ func TestOpenAICompatibleProvider_Validate(t *testing.T) {
 			t.Setenv("OPENAI_MODEL", "")
 
 			provider := NewOpenAICompatibleProvider()
-			_, err := provider.Execute(context.Background(), "test prompt", tt.options)
+			_, err := provider.Execute(context.Background(), "test prompt", tt.options, nil, nil)
 			require.Error(t, err, "should return error for invalid options")
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
@@ -277,7 +277,7 @@ func TestOpenAICompatibleProvider_ExecuteConversation_Success(t *testing.T) {
 			provider := NewOpenAICompatibleProvider()
 			state := tt.stateSetup()
 
-			result, err := provider.ExecuteConversation(context.Background(), state, tt.prompt, tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), state, tt.prompt, tt.options, nil, nil)
 
 			require.NoError(t, err, "should execute conversation successfully")
 			require.NotNil(t, result, "should return ConversationResult")
@@ -296,7 +296,7 @@ func TestOpenAICompatibleProvider_ExecuteConversation_Success(t *testing.T) {
 func TestOpenAICompatibleProvider_ExecuteConversation_NilState(t *testing.T) {
 	provider := NewOpenAICompatibleProvider()
 
-	result, err := provider.ExecuteConversation(context.Background(), nil, "test", nil)
+	result, err := provider.ExecuteConversation(context.Background(), nil, "test", nil, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "conversation state cannot be nil")
 	assert.Nil(t, result)
@@ -325,7 +325,7 @@ func TestOpenAICompatibleProvider_ExecuteConversation_EmptyPrompt(t *testing.T) 
 			provider := NewOpenAICompatibleProvider()
 			state := workflow.NewConversationState("system")
 
-			result, err := provider.ExecuteConversation(context.Background(), state, tt.prompt, nil)
+			result, err := provider.ExecuteConversation(context.Background(), state, tt.prompt, nil, nil, nil)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
 			assert.Nil(t, result)
@@ -349,7 +349,7 @@ func TestOpenAICompatibleProvider_ExecuteConversation_StatePreservation(t *testi
 	initialTotalTurns := initialState.TotalTurns
 	initialTotalTokens := initialState.TotalTokens
 
-	result, err := provider.ExecuteConversation(context.Background(), initialState, "How are you?", nil)
+	result, err := provider.ExecuteConversation(context.Background(), initialState, "How are you?", nil, nil, nil)
 
 	require.NoError(t, err, "should execute without error")
 	require.NotNil(t, result, "should return result")
@@ -390,7 +390,7 @@ func TestOpenAICompatibleProvider_APIKeyNeverInErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := NewOpenAICompatibleProvider()
 
-			result, err := provider.Execute(context.Background(), "test", tt.options)
+			result, err := provider.Execute(context.Background(), "test", tt.options, nil, nil)
 			if err != nil {
 				errMsg := err.Error()
 				assert.NotContains(t, errMsg, tt.apiKey, "API key should never appear in error message")
@@ -497,7 +497,7 @@ func TestOpenAICompatibleProvider_ValidationErrors(t *testing.T) {
 
 			provider := NewOpenAICompatibleProvider()
 
-			result, err := provider.Execute(context.Background(), "test prompt", tt.options)
+			result, err := provider.Execute(context.Background(), "test prompt", tt.options, nil, nil)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
 			assert.Nil(t, result)
@@ -578,7 +578,7 @@ func TestOpenAICompatibleProvider_MaxCompletionTokensMigration(t *testing.T) {
 			t.Setenv("OPENAI_MODEL", "")
 
 			provider := NewOpenAICompatibleProvider()
-			_, err := provider.Execute(context.Background(), "test prompt", tt.options)
+			_, err := provider.Execute(context.Background(), "test prompt", tt.options, nil, nil)
 
 			if tt.wantErr {
 				require.Error(t, err, "expected error for %s", tt.name)
@@ -672,7 +672,7 @@ func TestOpenAICompatibleProvider_Execute_TokenTracking(t *testing.T) {
 			"model":    "llama",
 		}
 
-		result, err := provider.Execute(context.Background(), "test", options)
+		result, err := provider.Execute(context.Background(), "test", options, nil, nil)
 
 		require.NoError(t, err, "should execute without error")
 		require.NotNil(t, result, "should return result")
@@ -687,7 +687,7 @@ func TestOpenAICompatibleProvider_ExecuteConversation_TokenTracking(t *testing.T
 		provider := NewOpenAICompatibleProvider()
 		state := workflow.NewConversationState("You are helpful")
 
-		result, err := provider.ExecuteConversation(context.Background(), state, "test", nil)
+		result, err := provider.ExecuteConversation(context.Background(), state, "test", nil, nil, nil)
 
 		require.NoError(t, err, "should execute without error")
 		require.NotNil(t, result, "should return result")
@@ -731,7 +731,7 @@ func TestOpenAICompatibleProvider_BaseURLNormalization(t *testing.T) {
 				"model":    "llama",
 			}
 
-			result, err := provider.Execute(context.Background(), "test", options)
+			result, err := provider.Execute(context.Background(), "test", options, nil, nil)
 
 			// Should normalize URL regardless of trailing slash — no error expected.
 			assert.NoError(t, err)
@@ -809,7 +809,7 @@ func TestOpenAICompatibleProvider_Execute_WithOptionsMap(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := NewOpenAICompatibleProvider()
 
-			result, err := provider.Execute(context.Background(), "test prompt", tt.options)
+			result, err := provider.Execute(context.Background(), "test prompt", tt.options, nil, nil)
 			require.NoError(t, err)
 			require.NotNil(t, result)
 		})
@@ -827,7 +827,7 @@ func TestOpenAICompatibleProvider_ExecuteConversation_WithHistory(t *testing.T) 
 	state.TotalTurns = 2
 	state.TotalTokens = 30
 
-	result, err := provider.ExecuteConversation(context.Background(), state, "Tell me more", nil)
+	result, err := provider.ExecuteConversation(context.Background(), state, "Tell me more", nil, nil, nil)
 
 	require.NoError(t, err, "should execute without error")
 	require.NotNil(t, result, "should return result")
@@ -871,7 +871,7 @@ func TestOpenAICompatibleProvider_Execute_JSONOutputFormat(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := NewOpenAICompatibleProvider()
 
-			result, err := provider.Execute(context.Background(), "Return valid JSON", tt.options)
+			result, err := provider.Execute(context.Background(), "Return valid JSON", tt.options, nil, nil)
 
 			if tt.shouldFail {
 				// Should fail because mock server returns plain text, not json
@@ -905,7 +905,7 @@ func TestOpenAICompatibleProvider_Execute_JSONParsing_InvalidJSON(t *testing.T) 
 
 		// The mock server returns plain text "This is a mock response..."
 		// When output_format is "json", parseJSONResponse should fail on non-JSON
-		result, err := provider.Execute(context.Background(), "Return invalid json: {broken", options)
+		result, err := provider.Execute(context.Background(), "Return invalid json: {broken", options, nil, nil)
 
 		// parseJSONResponse should return an error when response is not valid JSON
 		require.Error(t, err, "should error when response cannot be parsed as json")
@@ -922,7 +922,7 @@ func TestOpenAICompatibleProvider_Execute_NoJSONOutputFormat(t *testing.T) {
 			"model":    "llama",
 		}
 
-		result, err := provider.Execute(context.Background(), "test prompt", options)
+		result, err := provider.Execute(context.Background(), "test prompt", options, nil, nil)
 
 		require.NoError(t, err, "should execute without error")
 		require.NotNil(t, result, "should return AgentResult")
@@ -945,7 +945,7 @@ func TestOpenAICompatibleProvider_Execute_JSONOutputFormat_TextOnly(t *testing.T
 
 		// The mock server returns plain text "This is a mock response..."
 		// When output_format is "json", parseJSONResponse must fail
-		result, err := provider.Execute(context.Background(), "What is 2+2?", options)
+		result, err := provider.Execute(context.Background(), "What is 2+2?", options, nil, nil)
 
 		// parseJSONResponse should fail on non-json text
 		require.Error(t, err, "should error when response is not json")
@@ -1044,7 +1044,7 @@ func TestOpenAICompatibleProvider_ExecuteConversation_MessageArrayStructure(t *t
 		t.Run(tt.name, func(t *testing.T) {
 			provider := NewOpenAICompatibleProvider()
 			state := tt.setup()
-			result, err := provider.ExecuteConversation(context.Background(), state, tt.prompt, tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), state, tt.prompt, tt.options, nil, nil)
 			tt.validate(t, result, err)
 		})
 	}
@@ -1108,7 +1108,7 @@ func TestOpenAICompatibleProvider_ExecuteConversation_TokenFieldsPopulated(t *te
 		t.Run(tt.name, func(t *testing.T) {
 			provider := NewOpenAICompatibleProvider()
 			state := tt.setup()
-			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", tt.options, nil, nil)
 
 			require.NoError(t, err, "should execute without error")
 			tt.validate(t, result)
@@ -1131,7 +1131,7 @@ func TestOpenAICompatibleProvider_ExecuteConversation_StateUpdateValidation(t *t
 	result, err := provider.ExecuteConversation(context.Background(), state, "How are you?", map[string]any{
 		"base_url": "http://localhost:11434/v1",
 		"model":    "llama",
-	})
+	}, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -1161,7 +1161,7 @@ func TestOpenAICompatibleProvider_ExecuteConversation_ResponseOutput(t *testing.
 	result, err := provider.ExecuteConversation(context.Background(), state, "What is 2+2?", map[string]any{
 		"base_url": "http://localhost:11434/v1",
 		"model":    "llama",
-	})
+	}, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -1212,7 +1212,7 @@ func TestOpenAICompatibleProvider_ExecuteConversation_SystemPromptHandling(t *te
 			provider := NewOpenAICompatibleProvider()
 			state := workflow.NewConversationState("system")
 
-			result, err := provider.ExecuteConversation(context.Background(), state, "test", tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test", tt.options, nil, nil)
 
 			require.NoError(t, err, "should execute regardless of system_prompt presence")
 			require.NotNil(t, result)
@@ -1270,7 +1270,7 @@ func TestOpenAICompatibleProvider_ExecuteConversation_ErrorPropagation(t *testin
 		t.Run(tt.name, func(t *testing.T) {
 			provider := NewOpenAICompatibleProvider()
 
-			result, err := provider.ExecuteConversation(context.Background(), tt.state, tt.prompt, tt.options)
+			result, err := provider.ExecuteConversation(context.Background(), tt.state, tt.prompt, tt.options, nil, nil)
 
 			require.Error(t, err, "should return error for invalid options")
 			assert.Nil(t, result, "should not return result on error")
@@ -1288,7 +1288,7 @@ func TestOpenAICompatibleProvider_ExecuteConversation_TimestampTracking(t *testi
 	result, err := provider.ExecuteConversation(context.Background(), state, "test", map[string]any{
 		"base_url": "http://localhost:11434/v1",
 		"model":    "llama",
-	})
+	}, nil, nil)
 	endAfter := time.Now()
 
 	require.NoError(t, err)
@@ -1362,7 +1362,7 @@ func TestOpenAICompatibleProvider_HTTPErrorMapping_401Unauthorized_Execute(t *te
 			result, err := provider.Execute(context.Background(), "test prompt", map[string]any{
 				"base_url": "http://localhost:11434/v1",
 				"model":    "test-model",
-			})
+			}, nil, nil)
 
 			require.Error(t, err, "should return error for 401 status")
 			assert.Nil(t, result, "should not return result on error")
@@ -1401,7 +1401,7 @@ func TestOpenAICompatibleProvider_HTTPErrorMapping_429RateLimited_Execute(t *tes
 			result, err := provider.Execute(context.Background(), "test prompt", map[string]any{
 				"base_url": "http://localhost:11434/v1",
 				"model":    "test-model",
-			})
+			}, nil, nil)
 
 			require.Error(t, err, "should return error for 429 status")
 			assert.Nil(t, result, "should not return result on error")
@@ -1446,7 +1446,7 @@ func TestOpenAICompatibleProvider_HTTPErrorMapping_5xxServerError_Execute(t *tes
 			result, err := provider.Execute(context.Background(), "test prompt", map[string]any{
 				"base_url": "http://localhost:11434/v1",
 				"model":    "test-model",
-			})
+			}, nil, nil)
 
 			require.Error(t, err, "should return error for 5xx status")
 			assert.Nil(t, result, "should not return result on error")
@@ -1487,7 +1487,7 @@ func TestOpenAICompatibleProvider_HTTPErrorMapping_400BadRequest_Execute(t *test
 			result, err := provider.Execute(context.Background(), "test prompt", map[string]any{
 				"base_url": "http://localhost:11434/v1",
 				"model":    "test-model",
-			})
+			}, nil, nil)
 
 			require.Error(t, err, "should return error for 4xx status")
 			assert.Nil(t, result, "should not return result on error")
@@ -1505,7 +1505,7 @@ func TestOpenAICompatibleProvider_HTTPErrorMapping_401Unauthorized_ExecuteConver
 	result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", map[string]any{
 		"base_url": "http://localhost:11434/v1",
 		"model":    "test-model",
-	})
+	}, nil, nil)
 
 	require.Error(t, err, "should return error for 401 status")
 	assert.Nil(t, result, "should not return result on error")
@@ -1521,7 +1521,7 @@ func TestOpenAICompatibleProvider_HTTPErrorMapping_429RateLimited_ExecuteConvers
 	result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", map[string]any{
 		"base_url": "http://localhost:11434/v1",
 		"model":    "test-model",
-	})
+	}, nil, nil)
 
 	require.Error(t, err, "should return error for 429 status")
 	assert.Nil(t, result, "should not return result on error")
@@ -1537,7 +1537,7 @@ func TestOpenAICompatibleProvider_HTTPErrorMapping_5xxServerError_ExecuteConvers
 	result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", map[string]any{
 		"base_url": "http://localhost:11434/v1",
 		"model":    "test-model",
-	})
+	}, nil, nil)
 
 	require.Error(t, err, "should return error for 5xx status")
 	assert.Nil(t, result, "should not return result on error")
@@ -1577,7 +1577,7 @@ func TestOpenAICompatibleProvider_HTTPErrorMapping_APIKeyNeverInError(t *testing
 				"base_url": "http://localhost:11434/v1",
 				"model":    "test-model",
 				"api_key":  tt.apiKey,
-			})
+			}, nil, nil)
 
 			require.Error(t, err, "should return error for error status")
 			assert.Nil(t, result, "should not return result on error")
@@ -1599,7 +1599,7 @@ func TestOpenAICompatibleProvider_ContextDeadlineExceeded_Execute(t *testing.T) 
 	result, err := provider.Execute(ctx, "test prompt", map[string]any{
 		"base_url": "http://localhost:11434/v1",
 		"model":    "test-model",
-	})
+	}, nil, nil)
 
 	require.Error(t, err, "should return error for canceled context")
 	assert.Nil(t, result, "should not return result on error")
@@ -1617,7 +1617,7 @@ func TestOpenAICompatibleProvider_ContextDeadlineExceeded_ExecuteConversation(t 
 	result, err := provider.ExecuteConversation(ctx, state, "test prompt", map[string]any{
 		"base_url": "http://localhost:11434/v1",
 		"model":    "test-model",
-	})
+	}, nil, nil)
 
 	require.Error(t, err, "should return error for canceled context")
 	assert.Nil(t, result, "should not return result on error")
@@ -1632,7 +1632,7 @@ func TestOpenAICompatibleProvider_HTTPErrorMapping_UnexpectedStatus_Execute(t *t
 	result, err := provider.Execute(context.Background(), "test prompt", map[string]any{
 		"base_url": "http://localhost:11434/v1",
 		"model":    "test-model",
-	})
+	}, nil, nil)
 
 	require.Error(t, err, "should return error for unexpected status")
 	assert.Nil(t, result, "should not return result on error")

--- a/internal/infrastructure/agents/opencode_provider.go
+++ b/internal/infrastructure/agents/opencode_provider.go
@@ -5,17 +5,20 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/awf-project/cli/internal/domain/ports"
 	"github.com/awf-project/cli/internal/domain/workflow"
+	"github.com/awf-project/cli/internal/infrastructure/logger"
 )
 
 // OpenCodeProvider implements AgentProvider for OpenCode CLI.
 // Invokes: opencode run "prompt"
 type OpenCodeProvider struct {
+	logger   ports.Logger
 	executor ports.CLIExecutor
 }
 
@@ -23,6 +26,7 @@ type OpenCodeProvider struct {
 // If no executor is provided, ExecCLIExecutor is used by default.
 func NewOpenCodeProvider() *OpenCodeProvider {
 	return &OpenCodeProvider{
+		logger:   logger.NopLogger{},
 		executor: NewExecCLIExecutor(),
 	}
 }
@@ -30,6 +34,7 @@ func NewOpenCodeProvider() *OpenCodeProvider {
 // NewOpenCodeProviderWithOptions creates a new OpenCodeProvider with functional options.
 func NewOpenCodeProviderWithOptions(opts ...OpenCodeProviderOption) *OpenCodeProvider {
 	p := &OpenCodeProvider{
+		logger:   logger.NopLogger{},
 		executor: NewExecCLIExecutor(),
 	}
 	for _, opt := range opts {
@@ -39,7 +44,7 @@ func NewOpenCodeProviderWithOptions(opts ...OpenCodeProviderOption) *OpenCodePro
 }
 
 // Execute invokes the OpenCode CLI with the given prompt and options.
-func (p *OpenCodeProvider) Execute(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+func (p *OpenCodeProvider) Execute(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 	startedAt := time.Now()
 
 	if strings.TrimSpace(prompt) == "" {
@@ -56,6 +61,18 @@ func (p *OpenCodeProvider) Execute(ctx context.Context, prompt string, options m
 
 	args := []string{"run", prompt}
 
+	// Always pass --format json for structured output
+	args = append(args, "--format", "json")
+
+	if model, ok := getStringOption(options, "model"); ok {
+		args = append(args, "--model", model)
+	}
+
+	if skipPerms, ok := getBoolOption(options, "dangerously_skip_permissions"); ok && skipPerms {
+		// OpenCode has no equivalent flag; log at debug level so operators are aware the option was present but ignored.
+		p.logger.Debug("dangerously_skip_permissions is not supported by OpenCode and will be ignored")
+	}
+
 	if options != nil {
 		if framework, ok := options["framework"].(string); ok {
 			args = append(args, "--framework", framework)
@@ -68,7 +85,7 @@ func (p *OpenCodeProvider) Execute(ctx context.Context, prompt string, options m
 		}
 	}
 
-	stdout, stderr, err := p.executor.Run(ctx, "opencode", args...)
+	stdoutBytes, stderrBytes, err := p.executor.Run(ctx, "opencode", stdout, stderr, args...)
 	completedAt := time.Now()
 
 	if err != nil {
@@ -76,9 +93,9 @@ func (p *OpenCodeProvider) Execute(ctx context.Context, prompt string, options m
 	}
 
 	// Combine stdout and stderr like CombinedOutput()
-	output := make([]byte, 0, len(stdout)+len(stderr))
-	output = append(output, stdout...)
-	output = append(output, stderr...)
+	output := make([]byte, 0, len(stdoutBytes)+len(stderrBytes))
+	output = append(output, stdoutBytes...)
+	output = append(output, stderrBytes...)
 	outputStr := string(output)
 	result := &workflow.AgentResult{
 		Provider:    "opencode",
@@ -101,7 +118,7 @@ func (p *OpenCodeProvider) Execute(ctx context.Context, prompt string, options m
 }
 
 // ExecuteConversation invokes the OpenCode CLI with conversation history for multi-turn interactions.
-func (p *OpenCodeProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+func (p *OpenCodeProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 	startedAt := time.Now()
 
 	if state == nil {
@@ -129,6 +146,18 @@ func (p *OpenCodeProvider) ExecuteConversation(ctx context.Context, state *workf
 
 	args := []string{"run", prompt}
 
+	// Always pass --format json for structured output
+	args = append(args, "--format", "json")
+
+	if model, ok := getStringOption(options, "model"); ok {
+		args = append(args, "--model", model)
+	}
+
+	if skipPerms, ok := getBoolOption(options, "dangerously_skip_permissions"); ok && skipPerms {
+		// OpenCode has no equivalent flag; log at debug level so operators are aware the option was present but ignored.
+		p.logger.Debug("dangerously_skip_permissions is not supported by OpenCode and will be ignored")
+	}
+
 	// Resume from previous session if available
 	if workingState.SessionID != "" {
 		args = append(args, "-s", workingState.SessionID)
@@ -151,16 +180,16 @@ func (p *OpenCodeProvider) ExecuteConversation(ctx context.Context, state *workf
 		}
 	}
 
-	stdout, stderr, err := p.executor.Run(ctx, "opencode", args...)
+	stdoutBytes, stderrBytes, err := p.executor.Run(ctx, "opencode", stdout, stderr, args...)
 	completedAt := time.Now()
 
 	if err != nil {
 		return nil, fmt.Errorf("opencode execution failed: %w", err)
 	}
 
-	output := make([]byte, 0, len(stdout)+len(stderr))
-	output = append(output, stdout...)
-	output = append(output, stderr...)
+	output := make([]byte, 0, len(stdoutBytes)+len(stderrBytes))
+	output = append(output, stdoutBytes...)
+	output = append(output, stderrBytes...)
 	outputStr := strings.TrimSpace(string(output))
 	if outputStr == "" {
 		outputStr = " "

--- a/internal/infrastructure/agents/opencode_provider_session_test.go
+++ b/internal/infrastructure/agents/opencode_provider_session_test.go
@@ -93,7 +93,7 @@ func TestOpenCodeProvider_ExecuteConversation_FirstTurn(t *testing.T) {
 	provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
 	state := workflow.NewConversationState("You are a code generator")
 
-	result, err := provider.ExecuteConversation(context.Background(), state, "Create a Hello World program", nil)
+	result, err := provider.ExecuteConversation(context.Background(), state, "Create a Hello World program", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -124,7 +124,7 @@ func TestOpenCodeProvider_ExecuteConversation_Resume(t *testing.T) {
 	}
 	state.TotalTurns = 3
 
-	result, err := provider.ExecuteConversation(context.Background(), state, "Add more features", nil)
+	result, err := provider.ExecuteConversation(context.Background(), state, "Add more features", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -148,7 +148,7 @@ func TestOpenCodeProvider_ExecuteConversation_SystemPrompt(t *testing.T) {
 		"system_prompt": "You are a specialized code generator",
 	}
 
-	result, err := provider.ExecuteConversation(context.Background(), state, "Generate test code", options)
+	result, err := provider.ExecuteConversation(context.Background(), state, "Generate test code", options, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -188,7 +188,7 @@ func TestOpenCodeProvider_ExecuteConversation_GracefulFallback(t *testing.T) {
 			state := workflow.NewConversationState("System prompt")
 			state.SessionID = "previous-session-id"
 
-			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", nil)
+			result, err := provider.ExecuteConversation(context.Background(), state, "test prompt", nil, nil, nil)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -225,7 +225,7 @@ func TestOpenCodeProvider_ExecuteConversation_ValidationErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := provider.ExecuteConversation(context.Background(), tt.state, tt.prompt, nil)
+			result, err := provider.ExecuteConversation(context.Background(), tt.state, tt.prompt, nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Nil(t, result)
@@ -243,7 +243,7 @@ func TestOpenCodeProvider_ExecuteConversation_ContextErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	result, err := provider.ExecuteConversation(ctx, state, "test", nil)
+	result, err := provider.ExecuteConversation(ctx, state, "test", nil, nil, nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -257,7 +257,7 @@ func TestOpenCodeProvider_ExecuteConversation_CLIErrors(t *testing.T) {
 	provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
 	state := workflow.NewConversationState("")
 
-	result, err := provider.ExecuteConversation(context.Background(), state, "test", nil)
+	result, err := provider.ExecuteConversation(context.Background(), state, "test", nil, nil, nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, result)

--- a/internal/infrastructure/agents/opencode_provider_unit_test.go
+++ b/internal/infrastructure/agents/opencode_provider_unit_test.go
@@ -3,9 +3,11 @@ package agents
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/awf-project/cli/internal/domain/workflow"
 	"github.com/awf-project/cli/internal/testutil/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -69,7 +71,7 @@ func TestOpenCodeProvider_Execute_Success(t *testing.T) {
 			mockExec.SetOutput(tt.mockStdout, nil)
 			provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), tt.prompt, tt.options)
+			result, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -130,7 +132,7 @@ func TestOpenCodeProvider_Execute_WithOptions(t *testing.T) {
 			mockExec.SetOutput(tt.mockStdout, nil)
 			provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), tt.prompt, tt.options)
+			result, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -169,7 +171,7 @@ func TestOpenCodeProvider_Execute_EmptyPrompt(t *testing.T) {
 			mockExec := mocks.NewMockCLIExecutor()
 			provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), tt.prompt, nil)
+			result, err := provider.Execute(context.Background(), tt.prompt, nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Nil(t, result)
@@ -204,7 +206,7 @@ func TestOpenCodeProvider_Execute_ValidationErrors(t *testing.T) {
 			mockExec := mocks.NewMockCLIExecutor()
 			provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), tt.prompt, tt.options)
+			result, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
 
 			assert.Error(t, err)
 			assert.Nil(t, result)
@@ -244,7 +246,7 @@ func TestOpenCodeProvider_Execute_ContextErrors(t *testing.T) {
 			mockExec := mocks.NewMockCLIExecutor()
 			provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
 
-			result, err := provider.Execute(tt.ctxFunc(), "test prompt", nil)
+			result, err := provider.Execute(tt.ctxFunc(), "test prompt", nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Nil(t, result)
@@ -282,7 +284,7 @@ func TestOpenCodeProvider_Execute_CLIErrors(t *testing.T) {
 			mockExec.SetError(tt.mockErr)
 			provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "test prompt", nil)
+			result, err := provider.Execute(context.Background(), "test prompt", nil, nil, nil)
 
 			assert.Error(t, err)
 			assert.Nil(t, result)
@@ -324,7 +326,7 @@ func TestOpenCodeProvider_Execute_StdoutStderr(t *testing.T) {
 			mockExec.SetOutput(tt.mockStdout, tt.mockStderr)
 			provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "test prompt", nil)
+			result, err := provider.Execute(context.Background(), "test prompt", nil, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -367,7 +369,7 @@ func TestOpenCodeProvider_Execute_TokenEstimation(t *testing.T) {
 			mockExec.SetOutput([]byte(tt.output), nil)
 			provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "test prompt", nil)
+			result, err := provider.Execute(context.Background(), "test prompt", nil, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -382,7 +384,7 @@ func TestOpenCodeProvider_Execute_Timestamps(t *testing.T) {
 	provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
 
 	before := time.Now()
-	result, err := provider.Execute(context.Background(), "test prompt", nil)
+	result, err := provider.Execute(context.Background(), "test prompt", nil, nil, nil)
 	after := time.Now()
 
 	require.NoError(t, err)
@@ -400,7 +402,7 @@ func TestOpenCodeProvider_Execute_ProviderName(t *testing.T) {
 	mockExec.SetOutput([]byte("test output"), nil)
 	provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
 
-	result, err := provider.Execute(context.Background(), "test prompt", nil)
+	result, err := provider.Execute(context.Background(), "test prompt", nil, nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -451,7 +453,7 @@ func TestOpenCodeProvider_Execute_JSONDetection(t *testing.T) {
 			mockExec.SetOutput(tt.mockOutput, nil)
 			provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
 
-			result, err := provider.Execute(context.Background(), "test prompt", nil)
+			result, err := provider.Execute(context.Background(), "test prompt", nil, nil, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -504,39 +506,39 @@ func TestOpenCodeProvider_Execute_CLIArguments(t *testing.T) {
 		wantCmdArgs []string
 	}{
 		{
-			name:        "basic prompt with run subcommand",
+			name:        "basic prompt with run subcommand and format flag",
 			prompt:      "test prompt",
 			options:     nil,
 			wantCmdName: "opencode",
-			wantCmdArgs: []string{"run", "test prompt"},
+			wantCmdArgs: []string{"run", "test prompt", "--format", "json"},
 		},
 		{
-			name:        "with framework option",
+			name:        "with framework option and format flag",
 			prompt:      "test",
 			options:     map[string]any{"framework": "react"},
 			wantCmdName: "opencode",
-			wantCmdArgs: []string{"run", "test", "--framework", "react"},
+			wantCmdArgs: []string{"run", "test", "--format", "json", "--framework", "react"},
 		},
 		{
-			name:        "with verbose option",
+			name:        "with verbose option and format flag",
 			prompt:      "test",
 			options:     map[string]any{"verbose": true},
 			wantCmdName: "opencode",
-			wantCmdArgs: []string{"run", "test", "--verbose"},
+			wantCmdArgs: []string{"run", "test", "--format", "json", "--verbose"},
 		},
 		{
-			name:        "with output_dir option",
+			name:        "with output_dir option and format flag",
 			prompt:      "test",
 			options:     map[string]any{"output_dir": "/tmp/out"},
 			wantCmdName: "opencode",
-			wantCmdArgs: []string{"run", "test", "--output", "/tmp/out"},
+			wantCmdArgs: []string{"run", "test", "--format", "json", "--output", "/tmp/out"},
 		},
 		{
-			name:        "with all options",
+			name:        "with all options and format flag",
 			prompt:      "test",
 			options:     map[string]any{"framework": "vue", "verbose": true, "output_dir": "/tmp"},
 			wantCmdName: "opencode",
-			wantCmdArgs: []string{"run", "test", "--framework", "vue", "--verbose", "--output", "/tmp"},
+			wantCmdArgs: []string{"run", "test", "--format", "json", "--framework", "vue", "--verbose", "--output", "/tmp"},
 		},
 	}
 
@@ -546,7 +548,7 @@ func TestOpenCodeProvider_Execute_CLIArguments(t *testing.T) {
 			mockExec.SetOutput([]byte("ok"), nil)
 			provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
 
-			_, err := provider.Execute(context.Background(), tt.prompt, tt.options)
+			_, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
 			require.NoError(t, err)
 
 			// Verify the CLI arguments
@@ -556,4 +558,444 @@ func TestOpenCodeProvider_Execute_CLIArguments(t *testing.T) {
 			assert.Equal(t, tt.wantCmdArgs, calls[0].Args)
 		})
 	}
+}
+
+// T006: Verify --format json flag is always passed to OpenCode Execute (FR-005)
+func TestOpenCodeProvider_Execute_FormatJSONFlag(t *testing.T) {
+	tests := []struct {
+		name    string
+		prompt  string
+		options map[string]any
+	}{
+		{
+			name:    "no options",
+			prompt:  "test",
+			options: nil,
+		},
+		{
+			name:    "with model option",
+			prompt:  "test",
+			options: map[string]any{"model": "gpt-4o"},
+		},
+		{
+			name:    "with framework option",
+			prompt:  "test",
+			options: map[string]any{"framework": "react"},
+		},
+		{
+			name:    "with verbose option",
+			prompt:  "test",
+			options: map[string]any{"verbose": true},
+		},
+		{
+			name:    "with multiple options",
+			prompt:  "test",
+			options: map[string]any{"model": "gpt-4", "framework": "vue", "verbose": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			mockExec.SetOutput([]byte(`{"status":"ok"}`), nil)
+			provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
+
+			_, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
+			require.NoError(t, err)
+
+			calls := mockExec.GetCalls()
+			require.Len(t, calls, 1)
+
+			assert.Contains(t, calls[0].Args, "--format")
+			formatIdx := -1
+			for i, arg := range calls[0].Args {
+				if arg == "--format" {
+					formatIdx = i
+					break
+				}
+			}
+			require.NotEqual(t, -1, formatIdx, "expected --format flag to be present")
+			require.Less(t, formatIdx+1, len(calls[0].Args), "expected --format to have a value")
+			assert.Equal(t, "json", calls[0].Args[formatIdx+1])
+		})
+	}
+}
+
+// T006: Verify --model flag is passed when model option is provided (FR-006)
+func TestOpenCodeProvider_Execute_ModelFlag(t *testing.T) {
+	tests := []struct {
+		name         string
+		prompt       string
+		options      map[string]any
+		wantHasModel bool
+		wantModel    string
+	}{
+		{
+			name:         "model provided",
+			prompt:       "test",
+			options:      map[string]any{"model": "gpt-4o"},
+			wantHasModel: true,
+			wantModel:    "gpt-4o",
+		},
+		{
+			name:         "model provided as latest",
+			prompt:       "test",
+			options:      map[string]any{"model": "gpt-4o-latest"},
+			wantHasModel: true,
+			wantModel:    "gpt-4o-latest",
+		},
+		{
+			name:         "no model option",
+			prompt:       "test",
+			options:      nil,
+			wantHasModel: false,
+		},
+		{
+			name:         "empty options",
+			prompt:       "test",
+			options:      map[string]any{},
+			wantHasModel: false,
+		},
+		{
+			name:         "model with other options",
+			prompt:       "test",
+			options:      map[string]any{"model": "gpt-3.5-turbo", "framework": "react"},
+			wantHasModel: true,
+			wantModel:    "gpt-3.5-turbo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			mockExec.SetOutput([]byte("ok"), nil)
+			provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
+
+			_, err := provider.Execute(context.Background(), tt.prompt, tt.options, nil, nil)
+			require.NoError(t, err)
+
+			calls := mockExec.GetCalls()
+			require.Len(t, calls, 1)
+
+			if tt.wantHasModel {
+				require.Contains(t, calls[0].Args, "--model", "expected --model flag")
+				modelIdx := -1
+				for i, arg := range calls[0].Args {
+					if arg == "--model" {
+						modelIdx = i
+						break
+					}
+				}
+				require.NotEqual(t, -1, modelIdx)
+				require.Less(t, modelIdx+1, len(calls[0].Args))
+				assert.Equal(t, tt.wantModel, calls[0].Args[modelIdx+1])
+			} else {
+				assert.NotContains(t, calls[0].Args, "--model", "expected no --model flag")
+			}
+		})
+	}
+}
+
+// T006: Verify --format json and --model work correctly in ExecuteConversation (FR-006)
+func TestOpenCodeProvider_ExecuteConversation_FormatAndModelFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		prompt        string
+		options       map[string]any
+		wantHasFormat bool
+		wantHasModel  bool
+		wantModel     string
+		sessionID     string
+	}{
+		{
+			name:          "first turn with model",
+			prompt:        "test",
+			options:       map[string]any{"model": "gpt-4o"},
+			wantHasFormat: true,
+			wantHasModel:  true,
+			wantModel:     "gpt-4o",
+			sessionID:     "",
+		},
+		{
+			name:          "first turn without model",
+			prompt:        "test",
+			options:       nil,
+			wantHasFormat: true,
+			wantHasModel:  false,
+			sessionID:     "",
+		},
+		{
+			name:          "resume with model",
+			prompt:        "test",
+			options:       map[string]any{"model": "gpt-3.5-turbo"},
+			wantHasFormat: true,
+			wantHasModel:  true,
+			wantModel:     "gpt-3.5-turbo",
+			sessionID:     "opencode-12345",
+		},
+		{
+			name:          "resume without model",
+			prompt:        "test",
+			options:       map[string]any{},
+			wantHasFormat: true,
+			wantHasModel:  false,
+			sessionID:     "opencode-67890",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			mockExec.SetOutput([]byte(`Session: opencode-12345\n{"status":"ok"}`), nil)
+			provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
+
+			state := &workflow.ConversationState{
+				Turns:     []workflow.Turn{},
+				SessionID: tt.sessionID,
+			}
+
+			_, err := provider.ExecuteConversation(context.Background(), state, tt.prompt, tt.options, nil, nil)
+			require.NoError(t, err)
+
+			calls := mockExec.GetCalls()
+			require.Len(t, calls, 1)
+
+			if tt.wantHasFormat {
+				assert.Contains(t, calls[0].Args, "--format")
+				formatIdx := -1
+				for i, arg := range calls[0].Args {
+					if arg == "--format" {
+						formatIdx = i
+						break
+					}
+				}
+				require.NotEqual(t, -1, formatIdx)
+				require.Less(t, formatIdx+1, len(calls[0].Args))
+				assert.Equal(t, "json", calls[0].Args[formatIdx+1])
+			}
+
+			if tt.wantHasModel {
+				require.Contains(t, calls[0].Args, "--model")
+				modelIdx := -1
+				for i, arg := range calls[0].Args {
+					if arg == "--model" {
+						modelIdx = i
+						break
+					}
+				}
+				require.NotEqual(t, -1, modelIdx)
+				require.Less(t, modelIdx+1, len(calls[0].Args))
+				assert.Equal(t, tt.wantModel, calls[0].Args[modelIdx+1])
+			} else {
+				assert.NotContains(t, calls[0].Args, "--model")
+			}
+		})
+	}
+}
+
+// T013: Verify debug log is emitted when dangerously_skip_permissions is present (FR-009)
+func TestOpenCodeProvider_Execute_DangerouslySkipPermissions_DebugLog(t *testing.T) {
+	tests := []struct {
+		name    string
+		options map[string]any
+		hasFlag bool
+	}{
+		{
+			name:    "dangerously_skip_permissions true",
+			options: map[string]any{"dangerously_skip_permissions": true},
+			hasFlag: true,
+		},
+		{
+			name:    "dangerously_skip_permissions false",
+			options: map[string]any{"dangerously_skip_permissions": false},
+			hasFlag: false,
+		},
+		{
+			name:    "no dangerously_skip_permissions",
+			options: nil,
+			hasFlag: false,
+		},
+		{
+			name:    "with other options but no dangerously_skip_permissions",
+			options: map[string]any{"model": "gpt-4o", "framework": "react"},
+			hasFlag: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := mocks.NewMockCLIExecutor()
+			mockExec.SetOutput([]byte(`{"status":"ok"}`), nil)
+			mockLogger := mocks.NewMockLogger()
+
+			provider := NewOpenCodeProviderWithOptions(
+				WithOpenCodeExecutor(mockExec),
+				WithOpenCodeLogger(mockLogger),
+			)
+
+			_, err := provider.Execute(context.Background(), "test prompt", tt.options, nil, nil)
+			require.NoError(t, err)
+
+			debugMessages := mockLogger.GetMessagesByLevel("DEBUG")
+
+			if tt.hasFlag {
+				require.Greater(t, len(debugMessages), 0, "expected at least one debug message when dangerously_skip_permissions is present")
+				foundMsg := false
+				for _, msg := range debugMessages {
+					if strings.Contains(msg.Msg, "dangerously_skip_permissions") && strings.Contains(msg.Msg, "OpenCode") {
+						foundMsg = true
+						break
+					}
+				}
+				assert.True(t, foundMsg, "expected debug message mentioning dangerously_skip_permissions and OpenCode")
+			} else {
+				// When flag is not present, should not have any dangerously_skip_permissions debug messages
+				for _, msg := range debugMessages {
+					assert.NotContains(t, msg.Msg, "dangerously_skip_permissions", "should not log dangerously_skip_permissions when not provided")
+				}
+			}
+		})
+	}
+}
+
+// T013: Verify debug log content when dangerously_skip_permissions is present (FR-009)
+func TestOpenCodeProvider_Execute_DangerouslySkipPermissions_LogContent(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	mockExec.SetOutput([]byte(`{"result":"code"}`), nil)
+	mockLogger := mocks.NewMockLogger()
+
+	provider := NewOpenCodeProviderWithOptions(
+		WithOpenCodeExecutor(mockExec),
+		WithOpenCodeLogger(mockLogger),
+	)
+
+	options := map[string]any{
+		"dangerously_skip_permissions": true,
+	}
+
+	_, err := provider.Execute(context.Background(), "Generate code", options, nil, nil)
+	require.NoError(t, err)
+
+	messages := mockLogger.GetMessages()
+	require.Greater(t, len(messages), 0, "expected at least one log message")
+
+	// Find the debug message about dangerously_skip_permissions
+	var debugMsg *mocks.LogMessage
+	for i := range messages {
+		if messages[i].Level == "DEBUG" && strings.Contains(messages[i].Msg, "dangerously_skip_permissions") {
+			debugMsg = &messages[i]
+			break
+		}
+	}
+
+	require.NotNil(t, debugMsg, "expected a DEBUG level message about dangerously_skip_permissions")
+	assert.Contains(t, debugMsg.Msg, "not supported", "message should indicate the option is not supported")
+	assert.Contains(t, debugMsg.Msg, "ignored", "message should indicate the option will be ignored")
+	assert.Contains(t, debugMsg.Msg, "OpenCode", "message should mention OpenCode")
+}
+
+// T013: Verify ExecuteConversation also emits debug log for dangerously_skip_permissions (FR-009)
+func TestOpenCodeProvider_ExecuteConversation_DangerouslySkipPermissions_DebugLog(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	mockExec.SetOutput([]byte(`{"status":"ok","session_id":"opencode-123"}`), nil)
+	mockLogger := mocks.NewMockLogger()
+
+	provider := NewOpenCodeProviderWithOptions(
+		WithOpenCodeExecutor(mockExec),
+		WithOpenCodeLogger(mockLogger),
+	)
+
+	state := &workflow.ConversationState{
+		Turns:     []workflow.Turn{},
+		SessionID: "",
+	}
+
+	options := map[string]any{
+		"dangerously_skip_permissions": true,
+	}
+
+	_, err := provider.ExecuteConversation(context.Background(), state, "Generate code", options, nil, nil)
+	require.NoError(t, err)
+
+	debugMessages := mockLogger.GetMessagesByLevel("DEBUG")
+	require.Greater(t, len(debugMessages), 0, "expected at least one debug message in ExecuteConversation")
+
+	foundMsg := false
+	for _, msg := range debugMessages {
+		if strings.Contains(msg.Msg, "dangerously_skip_permissions") && strings.Contains(msg.Msg, "OpenCode") {
+			foundMsg = true
+			break
+		}
+	}
+	assert.True(t, foundMsg, "expected debug message about dangerously_skip_permissions in ExecuteConversation")
+}
+
+// T013: Verify no dangerously_skip_permissions flag is passed to OpenCode CLI (FR-009)
+func TestOpenCodeProvider_Execute_DangerouslySkipPermissions_NoFlag(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	mockExec.SetOutput([]byte(`{"status":"ok"}`), nil)
+
+	provider := NewOpenCodeProviderWithOptions(
+		WithOpenCodeExecutor(mockExec),
+	)
+
+	options := map[string]any{
+		"dangerously_skip_permissions": true,
+	}
+
+	_, err := provider.Execute(context.Background(), "test", options, nil, nil)
+	require.NoError(t, err)
+
+	calls := mockExec.GetCalls()
+	require.Len(t, calls, 1)
+
+	for _, arg := range calls[0].Args {
+		assert.NotEqual(t, "--dangerously-skip-permissions", arg, "should not pass dangerously_skip_permissions flag to CLI")
+		assert.NotEqual(t, "--dangerously_skip_permissions", arg, "should not pass dangerously_skip_permissions flag to CLI")
+		assert.NotEqual(t, "--yolo", arg, "should not pass --yolo flag (Codex specific)")
+		assert.NotEqual(t, "--approval-mode", arg, "should not pass --approval-mode flag (Gemini specific)")
+	}
+}
+
+// T013: Verify dangerously_skip_permissions with other options still logs debug (FR-009)
+func TestOpenCodeProvider_Execute_DangerouslySkipPermissions_WithOtherOptions(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	mockExec.SetOutput([]byte(`{"status":"ok"}`), nil)
+	mockLogger := mocks.NewMockLogger()
+
+	provider := NewOpenCodeProviderWithOptions(
+		WithOpenCodeExecutor(mockExec),
+		WithOpenCodeLogger(mockLogger),
+	)
+
+	options := map[string]any{
+		"dangerously_skip_permissions": true,
+		"model":                        "gpt-4o",
+		"framework":                    "react",
+		"verbose":                      true,
+	}
+
+	_, err := provider.Execute(context.Background(), "test", options, nil, nil)
+	require.NoError(t, err)
+
+	debugMessages := mockLogger.GetMessagesByLevel("DEBUG")
+	require.Greater(t, len(debugMessages), 0, "expected debug message even with other options present")
+
+	var found bool
+	for _, msg := range debugMessages {
+		if strings.Contains(msg.Msg, "dangerously_skip_permissions") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected debug message about dangerously_skip_permissions")
+
+	// Verify other options are still passed to CLI
+	calls := mockExec.GetCalls()
+	require.Len(t, calls, 1)
+	assert.Contains(t, calls[0].Args, "--model")
+	assert.Contains(t, calls[0].Args, "gpt-4o")
+	assert.Contains(t, calls[0].Args, "--framework")
+	assert.Contains(t, calls[0].Args, "react")
+	assert.Contains(t, calls[0].Args, "--verbose")
 }

--- a/internal/infrastructure/agents/options.go
+++ b/internal/infrastructure/agents/options.go
@@ -43,6 +43,12 @@ func WithOpenCodeExecutor(executor ports.CLIExecutor) OpenCodeProviderOption {
 	}
 }
 
+func WithOpenCodeLogger(l ports.Logger) OpenCodeProviderOption {
+	return func(p *OpenCodeProvider) {
+		p.logger = l
+	}
+}
+
 type OpenAICompatibleProviderOption func(*OpenAICompatibleProvider)
 
 func WithHTTPClient(client *httpx.Client) OpenAICompatibleProviderOption {

--- a/internal/infrastructure/agents/provider_options_test.go
+++ b/internal/infrastructure/agents/provider_options_test.go
@@ -73,7 +73,7 @@ func TestClaudeProvider_NewWithOptions_HappyPath(t *testing.T) {
 			// Verify executor is functional by executing
 			if mockExec != nil {
 				ctx := context.Background()
-				result, err := provider.Execute(ctx, "test prompt", nil)
+				result, err := provider.Execute(ctx, "test prompt", nil, nil, nil)
 
 				if tt.expectError {
 					assert.Error(t, err)
@@ -131,7 +131,7 @@ func TestGeminiProvider_NewWithOptions_HappyPath(t *testing.T) {
 			// Verify executor is functional
 			if mockExec != nil {
 				ctx := context.Background()
-				result, err := provider.Execute(ctx, "test prompt", nil)
+				result, err := provider.Execute(ctx, "test prompt", nil, nil, nil)
 				assert.NoError(t, err)
 				assert.NotNil(t, result)
 			}
@@ -184,7 +184,7 @@ func TestCodexProvider_NewWithOptions_HappyPath(t *testing.T) {
 			// Verify executor is functional
 			if mockExec != nil {
 				ctx := context.Background()
-				result, err := provider.Execute(ctx, "test prompt", nil)
+				result, err := provider.Execute(ctx, "test prompt", nil, nil, nil)
 				assert.NoError(t, err)
 				assert.NotNil(t, result)
 			}
@@ -237,7 +237,7 @@ func TestOpenCodeProvider_NewWithOptions_HappyPath(t *testing.T) {
 			// Verify executor is functional
 			if mockExec != nil {
 				ctx := context.Background()
-				result, err := provider.Execute(ctx, "test prompt", nil)
+				result, err := provider.Execute(ctx, "test prompt", nil, nil, nil)
 				assert.NoError(t, err)
 				assert.NotNil(t, result)
 			}
@@ -294,7 +294,7 @@ func TestProviderOptions_EdgeCases(t *testing.T) {
 
 		// Verify the last executor was used
 		ctx := context.Background()
-		result, err := provider.Execute(ctx, "test", nil)
+		result, err := provider.Execute(ctx, "test", nil, nil, nil)
 		require.NoError(t, err)
 		assert.Contains(t, result.Output, "mock2")
 	})
@@ -327,7 +327,7 @@ func TestProviderOptions_ErrorHandling(t *testing.T) {
 		provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 		ctx := context.Background()
 
-		result, err := provider.Execute(ctx, "test prompt", nil)
+		result, err := provider.Execute(ctx, "test prompt", nil, nil, nil)
 
 		assert.Error(t, err)
 		assert.Nil(t, result)
@@ -341,7 +341,7 @@ func TestProviderOptions_ErrorHandling(t *testing.T) {
 		provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 		ctx := context.Background()
 
-		result, err := provider.Execute(ctx, "test prompt", nil)
+		result, err := provider.Execute(ctx, "test prompt", nil, nil, nil)
 
 		assert.Error(t, err)
 		assert.Nil(t, result)
@@ -355,7 +355,7 @@ func TestProviderOptions_ErrorHandling(t *testing.T) {
 		provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 		ctx := context.Background()
 
-		result, err := provider.Execute(ctx, "test prompt", nil)
+		result, err := provider.Execute(ctx, "test prompt", nil, nil, nil)
 
 		assert.Error(t, err)
 		assert.Nil(t, result)
@@ -369,7 +369,7 @@ func TestProviderOptions_ErrorHandling(t *testing.T) {
 		provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
 		ctx := context.Background()
 
-		result, err := provider.Execute(ctx, "test prompt", nil)
+		result, err := provider.Execute(ctx, "test prompt", nil, nil, nil)
 
 		assert.Error(t, err)
 		assert.Nil(t, result)
@@ -385,7 +385,7 @@ func TestProviderOptions_Integration(t *testing.T) {
 		provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 		ctx := context.Background()
 
-		result, err := provider.Execute(ctx, "What is 2+2?", nil)
+		result, err := provider.Execute(ctx, "What is 2+2?", nil, nil, nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -410,7 +410,7 @@ func TestProviderOptions_Integration(t *testing.T) {
 		provider := NewGeminiProviderWithOptions(WithGeminiExecutor(mockExec))
 		ctx := context.Background()
 
-		result, err := provider.Execute(ctx, "Explain Go interfaces", nil)
+		result, err := provider.Execute(ctx, "Explain Go interfaces", nil, nil, nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -431,7 +431,7 @@ func TestProviderOptions_Integration(t *testing.T) {
 		provider := NewCodexProviderWithOptions(WithCodexExecutor(mockExec))
 		ctx := context.Background()
 
-		result, err := provider.Execute(ctx, "Write a function", nil)
+		result, err := provider.Execute(ctx, "Write a function", nil, nil, nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -451,7 +451,7 @@ func TestProviderOptions_Integration(t *testing.T) {
 		provider := NewOpenCodeProviderWithOptions(WithOpenCodeExecutor(mockExec))
 		ctx := context.Background()
 
-		result, err := provider.Execute(ctx, "Generate code", nil)
+		result, err := provider.Execute(ctx, "Generate code", nil, nil, nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -479,11 +479,11 @@ func TestProviderOptions_Integration(t *testing.T) {
 		ctx := context.Background()
 
 		// Execute both
-		claudeResult, err := claudeProvider.Execute(ctx, "prompt1", nil)
+		claudeResult, err := claudeProvider.Execute(ctx, "prompt1", nil, nil, nil)
 		require.NoError(t, err)
 		assert.Contains(t, claudeResult.Output, "Claude specific")
 
-		geminiResult, err := geminiProvider.Execute(ctx, "prompt2", nil)
+		geminiResult, err := geminiProvider.Execute(ctx, "prompt2", nil, nil, nil)
 		require.NoError(t, err)
 		assert.Contains(t, geminiResult.Output, "Gemini specific")
 

--- a/internal/infrastructure/agents/registry_test.go
+++ b/internal/infrastructure/agents/registry_test.go
@@ -3,6 +3,7 @@ package agents
 import (
 	"context"
 	"fmt"
+	"io"
 	"sync"
 	"testing"
 
@@ -28,14 +29,14 @@ func TestAgentRegistry_InterfaceCompliance(t *testing.T) {
 	var _ ports.AgentRegistry = (*AgentRegistry)(nil)
 }
 
-func (m *mockProvider) Execute(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+func (m *mockProvider) Execute(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 	return &workflow.AgentResult{
 		Provider: m.name,
 		Output:   "mock output",
 	}, nil
 }
 
-func (m *mockProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+func (m *mockProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 	return nil, nil
 }
 

--- a/internal/testutil/mocks/mocks.go
+++ b/internal/testutil/mocks/mocks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"sync"
 	"time"
 
@@ -1176,7 +1177,7 @@ func (m *MockAgentRegistry) Clear() {
 // Usage:
 //
 //	provider := testutil.NewMockAgentProvider("test-agent")
-//	provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+//	provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 //		return &workflow.AgentResult{
 //			Provider: "test-agent",
 //			Output:   "mock response",
@@ -1187,8 +1188,8 @@ func (m *MockAgentRegistry) Clear() {
 type MockAgentProvider struct {
 	mu               sync.RWMutex
 	name             string
-	executeFunc      func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error)
-	conversationFunc func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error)
+	executeFunc      func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error)
+	conversationFunc func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error)
 	validateFunc     func() error
 }
 
@@ -1202,12 +1203,12 @@ func NewMockAgentProvider(name string) *MockAgentProvider {
 // Execute invokes the agent with the given prompt and options.
 // Thread-safe for concurrent access.
 // Returns a stub result if no executeFunc is configured.
-func (m *MockAgentProvider) Execute(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+func (m *MockAgentProvider) Execute(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	if m.executeFunc != nil {
-		return m.executeFunc(ctx, prompt, options)
+		return m.executeFunc(ctx, prompt, options, stdout, stderr)
 	}
 
 	// Default stub behavior
@@ -1221,12 +1222,12 @@ func (m *MockAgentProvider) Execute(ctx context.Context, prompt string, options 
 // ExecuteConversation invokes the agent with conversation history for multi-turn interactions.
 // Thread-safe for concurrent access.
 // Returns a stub result if no conversationFunc is configured.
-func (m *MockAgentProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+func (m *MockAgentProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	if m.conversationFunc != nil {
-		return m.conversationFunc(ctx, state, prompt, options)
+		return m.conversationFunc(ctx, state, prompt, options, stdout, stderr)
 	}
 
 	// Default stub behavior
@@ -1262,7 +1263,7 @@ func (m *MockAgentProvider) Validate() error {
 
 // SetExecuteFunc sets the callback function for Execute method (test helper).
 // Thread-safe for concurrent access.
-func (m *MockAgentProvider) SetExecuteFunc(f func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error)) {
+func (m *MockAgentProvider) SetExecuteFunc(f func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error)) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1271,7 +1272,7 @@ func (m *MockAgentProvider) SetExecuteFunc(f func(ctx context.Context, prompt st
 
 // SetConversationFunc sets the callback function for ExecuteConversation method (test helper).
 // Thread-safe for concurrent access.
-func (m *MockAgentProvider) SetConversationFunc(f func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error)) {
+func (m *MockAgentProvider) SetConversationFunc(f func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error)) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1305,7 +1306,7 @@ func (m *MockAgentProvider) Clear() {
 //
 //	executor := testutil.NewMockCLIExecutor()
 //	executor.SetOutput([]byte("output"), []byte(""))
-//	stdout, stderr, err := executor.Run(ctx, "claude", "--version")
+//	stdout, stderr, err := executor.Run(ctx, "claude", nil, nil, "--version")
 type MockCLIExecutor struct {
 	mu      sync.Mutex
 	stdout  []byte
@@ -1328,7 +1329,7 @@ func NewMockCLIExecutor() *MockCLIExecutor {
 }
 
 // Run executes a binary and returns the configured output.
-func (m *MockCLIExecutor) Run(ctx context.Context, name string, args ...string) (stdout, stderr []byte, err error) {
+func (m *MockCLIExecutor) Run(ctx context.Context, name string, stdoutW, stderrW io.Writer, args ...string) (stdout, stderr []byte, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/internal/testutil/mocks/mocks_agent_test.go
+++ b/internal/testutil/mocks/mocks_agent_test.go
@@ -3,6 +3,7 @@ package mocks_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -426,8 +427,8 @@ func TestMockAgentRegistry_ThreadSafety_ConcurrentClear(t *testing.T) {
 // mockAgentProvider is a minimal test implementation of ports.AgentProvider
 type mockAgentProvider struct {
 	name             string
-	executeFunc      func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error)
-	conversationFunc func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error)
+	executeFunc      func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error)
+	conversationFunc func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error)
 	validateFunc     func() error
 }
 
@@ -435,9 +436,9 @@ func (m *mockAgentProvider) Name() string {
 	return m.name
 }
 
-func (m *mockAgentProvider) Execute(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+func (m *mockAgentProvider) Execute(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 	if m.executeFunc != nil {
-		return m.executeFunc(ctx, prompt, options)
+		return m.executeFunc(ctx, prompt, options, stdout, stderr)
 	}
 	return &workflow.AgentResult{
 		Provider:    m.name,
@@ -447,9 +448,9 @@ func (m *mockAgentProvider) Execute(ctx context.Context, prompt string, options 
 	}, nil
 }
 
-func (m *mockAgentProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+func (m *mockAgentProvider) ExecuteConversation(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 	if m.conversationFunc != nil {
-		return m.conversationFunc(ctx, state, prompt, options)
+		return m.conversationFunc(ctx, state, prompt, options, stdout, stderr)
 	}
 	return &workflow.ConversationResult{
 		Provider:    m.name,
@@ -483,7 +484,7 @@ func TestMockAgentProvider_NewMockAgentProvider(t *testing.T) {
 
 	// Verify it's usable immediately with default stub behavior
 	ctx := context.Background()
-	result, err := provider.Execute(ctx, "test prompt", nil)
+	result, err := provider.Execute(ctx, "test prompt", nil, nil, nil)
 	require.NoError(t, err, "Execute should not error with default stub behavior")
 	assert.NotNil(t, result, "Execute should return non-nil result")
 	assert.Equal(t, "test-agent", result.Provider, "Result provider should match mock name")
@@ -520,7 +521,7 @@ func TestMockAgentProvider_Execute_HappyPath(t *testing.T) {
 			name:         "execute with custom function - simple response",
 			providerName: "gemini",
 			setupFunc: func(p *mocks.MockAgentProvider) {
-				p.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+				p.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 					return &workflow.AgentResult{
 						Provider: "gemini",
 						Output:   "Custom response",
@@ -538,7 +539,7 @@ func TestMockAgentProvider_Execute_HappyPath(t *testing.T) {
 			name:         "execute with custom function - echo prompt",
 			providerName: "test-agent",
 			setupFunc: func(p *mocks.MockAgentProvider) {
-				p.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+				p.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 					return &workflow.AgentResult{
 						Provider: "test-agent",
 						Output:   fmt.Sprintf("You asked: %s", prompt),
@@ -556,7 +557,7 @@ func TestMockAgentProvider_Execute_HappyPath(t *testing.T) {
 			name:         "execute with custom function - reads options",
 			providerName: "codex",
 			setupFunc: func(p *mocks.MockAgentProvider) {
-				p.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+				p.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 					temp := options["temperature"].(float64)
 					return &workflow.AgentResult{
 						Provider: "codex",
@@ -579,7 +580,7 @@ func TestMockAgentProvider_Execute_HappyPath(t *testing.T) {
 			tt.setupFunc(provider)
 			ctx := context.Background()
 
-			result, err := provider.Execute(ctx, tt.prompt, tt.options)
+			result, err := provider.Execute(ctx, tt.prompt, tt.options, nil, nil)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -624,7 +625,7 @@ func TestMockAgentProvider_ExecuteConversation_HappyPath(t *testing.T) {
 			name:         "execute conversation with custom function - simple response",
 			providerName: "gemini",
 			setupFunc: func(p *mocks.MockAgentProvider) {
-				p.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+				p.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 					return &workflow.ConversationResult{
 						Provider: "gemini",
 						State:    state,
@@ -648,7 +649,7 @@ func TestMockAgentProvider_ExecuteConversation_HappyPath(t *testing.T) {
 			name:         "execute conversation with stateful response",
 			providerName: "test-agent",
 			setupFunc: func(p *mocks.MockAgentProvider) {
-				p.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+				p.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 					turnCount := len(state.Turns)
 					return &workflow.ConversationResult{
 						Provider: "test-agent",
@@ -678,7 +679,7 @@ func TestMockAgentProvider_ExecuteConversation_HappyPath(t *testing.T) {
 			tt.setupFunc(provider)
 			ctx := context.Background()
 
-			result, err := provider.ExecuteConversation(ctx, tt.initialState, tt.prompt, tt.options)
+			result, err := provider.ExecuteConversation(ctx, tt.initialState, tt.prompt, tt.options, nil, nil)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -800,7 +801,7 @@ func TestMockAgentProvider_SetExecuteFunc_OverwritesPrevious(t *testing.T) {
 	ctx := context.Background()
 
 	// Set first function
-	provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider: "test-agent",
 			Output:   "First response",
@@ -808,7 +809,7 @@ func TestMockAgentProvider_SetExecuteFunc_OverwritesPrevious(t *testing.T) {
 		}, nil
 	})
 
-	provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider: "test-agent",
 			Output:   "Second response",
@@ -816,7 +817,7 @@ func TestMockAgentProvider_SetExecuteFunc_OverwritesPrevious(t *testing.T) {
 		}, nil
 	})
 
-	result, err := provider.Execute(ctx, "test", nil)
+	result, err := provider.Execute(ctx, "test", nil, nil, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, "Second response", result.Output, "Should use the second function")
@@ -833,7 +834,7 @@ func TestMockAgentProvider_SetConversationFunc_OverwritesPrevious(t *testing.T) 
 	}
 
 	// Set first function
-	provider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		return &workflow.ConversationResult{
 			Provider: "test-agent",
 			State:    state,
@@ -841,7 +842,7 @@ func TestMockAgentProvider_SetConversationFunc_OverwritesPrevious(t *testing.T) 
 		}, nil
 	})
 
-	provider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		return &workflow.ConversationResult{
 			Provider: "test-agent",
 			State:    state,
@@ -849,7 +850,7 @@ func TestMockAgentProvider_SetConversationFunc_OverwritesPrevious(t *testing.T) 
 		}, nil
 	})
 
-	result, err := provider.ExecuteConversation(ctx, state, "test", nil)
+	result, err := provider.ExecuteConversation(ctx, state, "test", nil, nil, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, "Second conversation", result.Output, "Should use the second function")
@@ -875,7 +876,7 @@ func TestMockAgentProvider_SetValidateFunc_OverwritesPrevious(t *testing.T) {
 
 func TestMockAgentProvider_Execute_EmptyPrompt(t *testing.T) {
 	provider := mocks.NewMockAgentProvider("test-agent")
-	provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider: "test-agent",
 			Output:   fmt.Sprintf("Prompt length: %d", len(prompt)),
@@ -884,7 +885,7 @@ func TestMockAgentProvider_Execute_EmptyPrompt(t *testing.T) {
 	})
 	ctx := context.Background()
 
-	result, err := provider.Execute(ctx, "", nil)
+	result, err := provider.Execute(ctx, "", nil, nil, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, "Prompt length: 0", result.Output, "Should handle empty prompt")
@@ -892,7 +893,7 @@ func TestMockAgentProvider_Execute_EmptyPrompt(t *testing.T) {
 
 func TestMockAgentProvider_Execute_NilOptions(t *testing.T) {
 	provider := mocks.NewMockAgentProvider("test-agent")
-	provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		optionsNil := options == nil
 		return &workflow.AgentResult{
 			Provider: "test-agent",
@@ -902,7 +903,7 @@ func TestMockAgentProvider_Execute_NilOptions(t *testing.T) {
 	})
 	ctx := context.Background()
 
-	result, err := provider.Execute(ctx, "test", nil)
+	result, err := provider.Execute(ctx, "test", nil, nil, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, "Options nil: true", result.Output, "Should handle nil options")
@@ -910,7 +911,7 @@ func TestMockAgentProvider_Execute_NilOptions(t *testing.T) {
 
 func TestMockAgentProvider_Execute_EmptyOptions(t *testing.T) {
 	provider := mocks.NewMockAgentProvider("test-agent")
-	provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider: "test-agent",
 			Output:   fmt.Sprintf("Options count: %d", len(options)),
@@ -919,7 +920,7 @@ func TestMockAgentProvider_Execute_EmptyOptions(t *testing.T) {
 	})
 	ctx := context.Background()
 
-	result, err := provider.Execute(ctx, "test", map[string]any{})
+	result, err := provider.Execute(ctx, "test", map[string]any{}, nil, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, "Options count: 0", result.Output, "Should handle empty options map")
@@ -927,7 +928,7 @@ func TestMockAgentProvider_Execute_EmptyOptions(t *testing.T) {
 
 func TestMockAgentProvider_ExecuteConversation_NilState(t *testing.T) {
 	provider := mocks.NewMockAgentProvider("test-agent")
-	provider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		stateNil := state == nil
 		return &workflow.ConversationResult{
 			Provider: "test-agent",
@@ -937,7 +938,7 @@ func TestMockAgentProvider_ExecuteConversation_NilState(t *testing.T) {
 	})
 	ctx := context.Background()
 
-	result, err := provider.ExecuteConversation(ctx, nil, "test", nil)
+	result, err := provider.ExecuteConversation(ctx, nil, "test", nil, nil, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, "State nil: true", result.Output, "Should handle nil state")
@@ -946,7 +947,7 @@ func TestMockAgentProvider_ExecuteConversation_NilState(t *testing.T) {
 
 func TestMockAgentProvider_ExecuteConversation_EmptyTurns(t *testing.T) {
 	provider := mocks.NewMockAgentProvider("test-agent")
-	provider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		return &workflow.ConversationResult{
 			Provider: "test-agent",
 			State:    state,
@@ -960,7 +961,7 @@ func TestMockAgentProvider_ExecuteConversation_EmptyTurns(t *testing.T) {
 		TotalTokens: 0,
 	}
 
-	result, err := provider.ExecuteConversation(ctx, state, "test", nil)
+	result, err := provider.ExecuteConversation(ctx, state, "test", nil, nil, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, "Turn count: 0", result.Output, "Should handle empty turns")
@@ -978,7 +979,7 @@ func TestMockAgentProvider_Execute_CustomError(t *testing.T) {
 		{
 			name: "execute returns custom error",
 			setupFunc: func(p *mocks.MockAgentProvider) {
-				p.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+				p.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 					return nil, fmt.Errorf("agent execution failed: API timeout")
 				})
 			},
@@ -987,7 +988,7 @@ func TestMockAgentProvider_Execute_CustomError(t *testing.T) {
 		{
 			name: "execute returns error with nil result",
 			setupFunc: func(p *mocks.MockAgentProvider) {
-				p.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+				p.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 					return nil, fmt.Errorf("authentication failed")
 				})
 			},
@@ -996,7 +997,7 @@ func TestMockAgentProvider_Execute_CustomError(t *testing.T) {
 		{
 			name: "execute returns error based on prompt",
 			setupFunc: func(p *mocks.MockAgentProvider) {
-				p.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+				p.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 					if prompt == "" {
 						return nil, fmt.Errorf("prompt cannot be empty")
 					}
@@ -1013,7 +1014,7 @@ func TestMockAgentProvider_Execute_CustomError(t *testing.T) {
 			tt.setupFunc(provider)
 			ctx := context.Background()
 
-			result, err := provider.Execute(ctx, "", nil)
+			result, err := provider.Execute(ctx, "", nil, nil, nil)
 
 			require.Error(t, err)
 			assert.Nil(t, result, "Result should be nil when error occurs")
@@ -1031,7 +1032,7 @@ func TestMockAgentProvider_ExecuteConversation_CustomError(t *testing.T) {
 		{
 			name: "conversation returns custom error",
 			setupFunc: func(p *mocks.MockAgentProvider) {
-				p.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+				p.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 					return nil, fmt.Errorf("conversation failed: rate limit exceeded")
 				})
 			},
@@ -1040,7 +1041,7 @@ func TestMockAgentProvider_ExecuteConversation_CustomError(t *testing.T) {
 		{
 			name: "conversation returns error with nil result",
 			setupFunc: func(p *mocks.MockAgentProvider) {
-				p.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+				p.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 					return nil, fmt.Errorf("invalid conversation state")
 				})
 			},
@@ -1059,7 +1060,7 @@ func TestMockAgentProvider_ExecuteConversation_CustomError(t *testing.T) {
 				TotalTokens: 0,
 			}
 
-			result, err := provider.ExecuteConversation(ctx, state, "test", nil)
+			result, err := provider.ExecuteConversation(ctx, state, "test", nil, nil, nil)
 
 			require.Error(t, err)
 			assert.Nil(t, result, "Result should be nil when error occurs")
@@ -1088,7 +1089,7 @@ func TestMockAgentProvider_ThreadSafety_ConcurrentExecute(t *testing.T) {
 	var callCount int
 	var mu sync.Mutex
 
-	provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		mu.Lock()
 		callCount++
 		mu.Unlock()
@@ -1109,7 +1110,7 @@ func TestMockAgentProvider_ThreadSafety_ConcurrentExecute(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			prompt := fmt.Sprintf("prompt-%d", id)
-			result, err := provider.Execute(ctx, prompt, nil)
+			result, err := provider.Execute(ctx, prompt, nil, nil, nil)
 			assert.NoError(t, err, "Concurrent Execute should not error")
 			assert.NotNil(t, result, "Concurrent Execute should return result")
 		}(i)
@@ -1127,7 +1128,7 @@ func TestMockAgentProvider_ThreadSafety_ConcurrentExecuteConversation(t *testing
 	var callCount int
 	var mu sync.Mutex
 
-	provider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any) (*workflow.ConversationResult, error) {
+	provider.SetConversationFunc(func(ctx context.Context, state *workflow.ConversationState, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.ConversationResult, error) {
 		mu.Lock()
 		callCount++
 		mu.Unlock()
@@ -1152,7 +1153,7 @@ func TestMockAgentProvider_ThreadSafety_ConcurrentExecuteConversation(t *testing
 				TotalTurns:  0,
 				TotalTokens: 0,
 			}
-			result, err := provider.ExecuteConversation(ctx, state, fmt.Sprintf("prompt-%d", id), nil)
+			result, err := provider.ExecuteConversation(ctx, state, fmt.Sprintf("prompt-%d", id), nil, nil, nil)
 			assert.NoError(t, err, "Concurrent ExecuteConversation should not error")
 			assert.NotNil(t, result, "Concurrent ExecuteConversation should return result")
 		}(i)
@@ -1179,7 +1180,7 @@ func TestMockAgentProvider_ThreadSafety_ConcurrentSetAndExecute(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			for j := 0; j < 5; j++ {
-				_, _ = provider.Execute(ctx, fmt.Sprintf("prompt-%d-%d", id, j), nil)
+				_, _ = provider.Execute(ctx, fmt.Sprintf("prompt-%d-%d", id, j), nil, nil, nil)
 				_ = provider.Name()
 				_ = provider.Validate()
 			}
@@ -1190,7 +1191,7 @@ func TestMockAgentProvider_ThreadSafety_ConcurrentSetAndExecute(t *testing.T) {
 	for i := 0; i < numWriters; i++ {
 		go func(id int) {
 			defer wg.Done()
-			provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+			provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 				return &workflow.AgentResult{
 					Provider: "test-agent",
 					Output:   fmt.Sprintf("Writer-%d: %s", id, prompt),
@@ -1202,7 +1203,7 @@ func TestMockAgentProvider_ThreadSafety_ConcurrentSetAndExecute(t *testing.T) {
 
 	wg.Wait()
 
-	result, err := provider.Execute(ctx, "final-test", nil)
+	result, err := provider.Execute(ctx, "final-test", nil, nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -1240,20 +1241,20 @@ func TestMockAgentProvider_ThreadSafety_MixedOperations(t *testing.T) {
 			defer wg.Done()
 			switch id % 5 {
 			case 0:
-				_, _ = provider.Execute(ctx, fmt.Sprintf("prompt-%d", id), nil)
+				_, _ = provider.Execute(ctx, fmt.Sprintf("prompt-%d", id), nil, nil, nil)
 			case 1:
 				state := &workflow.ConversationState{
 					Turns:       []workflow.Turn{},
 					TotalTurns:  0,
 					TotalTokens: 0,
 				}
-				_, _ = provider.ExecuteConversation(ctx, state, fmt.Sprintf("prompt-%d", id), nil)
+				_, _ = provider.ExecuteConversation(ctx, state, fmt.Sprintf("prompt-%d", id), nil, nil, nil)
 			case 2:
 				_ = provider.Name()
 			case 3:
 				_ = provider.Validate()
 			case 4:
-				provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+				provider.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 					return &workflow.AgentResult{Provider: "test-agent", Output: "ok"}, nil
 				})
 			}

--- a/internal/testutil/mocks/mocks_cli_executor_test.go
+++ b/internal/testutil/mocks/mocks_cli_executor_test.go
@@ -101,7 +101,7 @@ func TestMockCLIExecutor_Run_HappyPath(t *testing.T) {
 			tt.setupFunc(executor)
 			ctx := context.Background()
 
-			stdout, stderr, err := executor.Run(ctx, tt.binary, tt.args...)
+			stdout, stderr, err := executor.Run(ctx, tt.binary, nil, nil, tt.args...)
 
 			assert.NoError(t, err, "Run should not error for configured output")
 			assert.Equal(t, tt.wantStdout, string(stdout), "Stdout should match configured value")
@@ -168,7 +168,7 @@ func TestMockCLIExecutor_Run_ErrorInjection(t *testing.T) {
 			tt.setupFunc(executor)
 			ctx := context.Background()
 
-			stdout, stderr, err := executor.Run(ctx, tt.binary, tt.args...)
+			stdout, stderr, err := executor.Run(ctx, tt.binary, nil, nil, tt.args...)
 
 			assert.Error(t, err, "Run should return error when error is configured")
 			assert.EqualError(t, err, tt.wantErr.Error(), "Run should return the configured error")
@@ -217,7 +217,7 @@ func TestMockCLIExecutor_Run_ContextCancellation(t *testing.T) {
 			tt.setupFunc(executor)
 			ctx := tt.ctxFunc()
 
-			stdout, stderr, err := executor.Run(ctx, "claude", "--version")
+			stdout, stderr, err := executor.Run(ctx, "claude", nil, nil, "--version")
 
 			assert.Error(t, err, "Run should return error for context issues")
 			assert.ErrorIs(t, err, tt.wantErr, "Error should match expected context error")
@@ -238,7 +238,7 @@ func TestMockCLIExecutor_Run_EdgeCases(t *testing.T) {
 				executor := mocks.NewMockCLIExecutor()
 				ctx := context.Background()
 
-				stdout, stderr, err := executor.Run(ctx, "tool", "arg")
+				stdout, stderr, err := executor.Run(ctx, "tool", nil, nil, "arg")
 
 				assert.NoError(t, err, "Run without output config should not error")
 				assert.Nil(t, stdout, "Stdout should be nil without config")
@@ -253,7 +253,7 @@ func TestMockCLIExecutor_Run_EdgeCases(t *testing.T) {
 				executor.SetOutput([]byte("ok"), []byte(""))
 				ctx := context.Background()
 
-				stdout, stderr, err := executor.Run(ctx, "", "arg")
+				stdout, stderr, err := executor.Run(ctx, "", nil, nil, "arg")
 
 				assert.NoError(t, err, "Run should handle empty binary name")
 				assert.Equal(t, "ok", string(stdout))
@@ -272,7 +272,7 @@ func TestMockCLIExecutor_Run_EdgeCases(t *testing.T) {
 
 				// Note: passing nil context is undefined behavior in production
 				// but mock should handle it gracefully
-				stdout, stderr, err := executor.Run(context.Background(), "tool", "arg")
+				stdout, stderr, err := executor.Run(context.Background(), "tool", nil, nil, "arg")
 
 				assert.NoError(t, err, "Mock should handle nil context")
 				assert.Equal(t, "output", string(stdout))
@@ -290,7 +290,7 @@ func TestMockCLIExecutor_Run_EdgeCases(t *testing.T) {
 				executor.SetOutput(largeOutput, []byte(""))
 				ctx := context.Background()
 
-				stdout, stderr, err := executor.Run(ctx, "generator", "data")
+				stdout, stderr, err := executor.Run(ctx, "generator", nil, nil, "data")
 
 				assert.NoError(t, err, "Run should handle large output")
 				assert.Len(t, stdout, 1024*1024, "Large output should be preserved")
@@ -305,7 +305,7 @@ func TestMockCLIExecutor_Run_EdgeCases(t *testing.T) {
 				ctx := context.Background()
 
 				unicodeArgs := []string{"--prompt", "你好世界", "--emoji", "😀🎉"}
-				stdout, stderr, err := executor.Run(ctx, "tool", unicodeArgs...)
+				stdout, stderr, err := executor.Run(ctx, "tool", nil, nil, unicodeArgs...)
 
 				assert.NoError(t, err)
 				assert.Equal(t, "success", string(stdout))
@@ -323,7 +323,7 @@ func TestMockCLIExecutor_Run_EdgeCases(t *testing.T) {
 				ctx := context.Background()
 
 				specialBinary := "tool-v2.0_beta"
-				stdout, stderr, err := executor.Run(ctx, specialBinary, "--test")
+				stdout, stderr, err := executor.Run(ctx, specialBinary, nil, nil, "--test")
 
 				assert.NoError(t, err)
 				assert.Equal(t, "ok", string(stdout))
@@ -345,7 +345,7 @@ func TestMockCLIExecutor_Run_EdgeCases(t *testing.T) {
 					args[i] = fmt.Sprintf("arg%d", i)
 				}
 
-				stdout, stderr, err := executor.Run(ctx, "tool", args...)
+				stdout, stderr, err := executor.Run(ctx, "tool", nil, nil, args...)
 
 				assert.NoError(t, err)
 				assert.Equal(t, "done", string(stdout))
@@ -363,7 +363,7 @@ func TestMockCLIExecutor_Run_EdgeCases(t *testing.T) {
 				executor.SetOutput(binaryData, []byte(""))
 				ctx := context.Background()
 
-				stdout, stderr, err := executor.Run(ctx, "binary-tool")
+				stdout, stderr, err := executor.Run(ctx, "binary-tool", nil, nil)
 
 				assert.NoError(t, err)
 				assert.Equal(t, binaryData, stdout, "Binary data with null bytes should be preserved")
@@ -392,7 +392,7 @@ func TestMockCLIExecutor_CallRecording(t *testing.T) {
 	}
 
 	for _, cmd := range commands {
-		_, _, _ = executor.Run(ctx, cmd.binary, cmd.args...)
+		_, _, _ = executor.Run(ctx, cmd.binary, nil, nil, cmd.args...)
 	}
 
 	calls := executor.GetCalls()
@@ -410,7 +410,7 @@ func TestMockCLIExecutor_CallRecording_MultipleExecutionsOfSameCommand(t *testin
 	ctx := context.Background()
 
 	for i := 0; i < 5; i++ {
-		_, _, err := executor.Run(ctx, "claude", "--version")
+		_, _, err := executor.Run(ctx, "claude", nil, nil, "--version")
 		assert.NoError(t, err, "Execution %d should succeed", i)
 	}
 
@@ -427,7 +427,7 @@ func TestMockCLIExecutor_GetCalls_IsolatedCopy(t *testing.T) {
 	executor.SetOutput([]byte("ok"), []byte(""))
 	ctx := context.Background()
 
-	_, _, _ = executor.Run(ctx, "tool", "arg1", "arg2")
+	_, _, _ = executor.Run(ctx, "tool", nil, nil, "arg1", "arg2")
 
 	calls1 := executor.GetCalls()
 	calls2 := executor.GetCalls()
@@ -445,7 +445,7 @@ func TestMockCLIExecutor_SetOutput(t *testing.T) {
 	ctx := context.Background()
 
 	executor.SetOutput([]byte("stdout content"), []byte("stderr content"))
-	stdout, stderr, err := executor.Run(ctx, "tool")
+	stdout, stderr, err := executor.Run(ctx, "tool", nil, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "stdout content", string(stdout))
@@ -458,7 +458,7 @@ func TestMockCLIExecutor_SetOutput_Overwrites(t *testing.T) {
 
 	executor.SetOutput([]byte("first"), []byte(""))
 	executor.SetOutput([]byte("second"), []byte(""))
-	stdout, stderr, err := executor.Run(ctx, "tool")
+	stdout, stderr, err := executor.Run(ctx, "tool", nil, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "second", string(stdout), "Second SetOutput should overwrite first")
@@ -471,7 +471,7 @@ func TestMockCLIExecutor_SetError(t *testing.T) {
 	expectedErr := errors.New("test error")
 
 	executor.SetError(expectedErr)
-	stdout, stderr, err := executor.Run(ctx, "tool")
+	stdout, stderr, err := executor.Run(ctx, "tool", nil, nil)
 
 	assert.Error(t, err)
 	assert.Equal(t, expectedErr, err)
@@ -485,7 +485,7 @@ func TestMockCLIExecutor_SetError_Overwrites(t *testing.T) {
 
 	executor.SetError(errors.New("first error"))
 	executor.SetError(errors.New("second error"))
-	_, _, err := executor.Run(ctx, "tool")
+	_, _, err := executor.Run(ctx, "tool", nil, nil)
 
 	assert.Error(t, err)
 	assert.EqualError(t, err, "second error", "Second SetError should overwrite first")
@@ -497,7 +497,7 @@ func TestMockCLIExecutor_SetError_TakesPrecedenceOverOutput(t *testing.T) {
 
 	executor.SetOutput([]byte("stdout"), []byte("stderr"))
 	executor.SetError(errors.New("execution failed"))
-	stdout, stderr, err := executor.Run(ctx, "tool")
+	stdout, stderr, err := executor.Run(ctx, "tool", nil, nil)
 
 	assert.Error(t, err, "Error should take precedence over output")
 	assert.EqualError(t, err, "execution failed")
@@ -513,7 +513,7 @@ func TestMockCLIExecutor_Clear(t *testing.T) {
 
 	// Execute some commands
 	for i := 0; i < 3; i++ {
-		_, _, _ = executor.Run(ctx, fmt.Sprintf("cmd-%d", i))
+		_, _, _ = executor.Run(ctx, fmt.Sprintf("cmd-%d", i), nil, nil)
 	}
 
 	// Verify state before clear
@@ -525,7 +525,7 @@ func TestMockCLIExecutor_Clear(t *testing.T) {
 	calls = executor.GetCalls()
 	assert.Empty(t, calls, "Clear should remove all recorded calls")
 
-	stdout, stderr, err := executor.Run(ctx, "new-cmd")
+	stdout, stderr, err := executor.Run(ctx, "new-cmd", nil, nil)
 	assert.NoError(t, err, "Clear should reset error configuration")
 	assert.Nil(t, stdout, "Clear should reset output configuration")
 	assert.Nil(t, stderr, "Clear should reset stderr configuration")
@@ -545,7 +545,7 @@ func TestMockCLIExecutor_ConcurrentRun(t *testing.T) {
 			defer wg.Done()
 			binary := fmt.Sprintf("tool-%d", id)
 			args := []string{fmt.Sprintf("arg-%d", id)}
-			stdout, stderr, err := executor.Run(ctx, binary, args...)
+			stdout, stderr, err := executor.Run(ctx, binary, nil, nil, args...)
 			assert.NoError(t, err)
 			assert.Equal(t, "output", string(stdout))
 			assert.Empty(t, stderr)
@@ -572,7 +572,7 @@ func TestMockCLIExecutor_ConcurrentReadWrite(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			for j := 0; j < iterations; j++ {
-				_, _, _ = executor.Run(ctx, fmt.Sprintf("reader-%d", id), fmt.Sprintf("iter-%d", j))
+				_, _, _ = executor.Run(ctx, fmt.Sprintf("reader-%d", id), nil, nil, fmt.Sprintf("iter-%d", j))
 			}
 		}(i)
 	}
@@ -626,7 +626,7 @@ func TestMockCLIExecutor_ConcurrentClear(t *testing.T) {
 	for i := 0; i < goroutines; i++ {
 		go func(id int) {
 			defer wg.Done()
-			_, _, _ = executor.Run(ctx, fmt.Sprintf("tool-%d", id))
+			_, _, _ = executor.Run(ctx, fmt.Sprintf("tool-%d", id), nil, nil)
 		}(i)
 	}
 
@@ -641,7 +641,7 @@ func TestMockCLIExecutor_ClaudeProviderScenario(t *testing.T) {
 	jsonResponse := `{"output": "Hello, world!", "tokens": 100}`
 	executor.SetOutput([]byte(jsonResponse), []byte(""))
 
-	stdout, stderr, err := executor.Run(ctx, "claude", "--model", "opus", "--prompt", "Say hello")
+	stdout, stderr, err := executor.Run(ctx, "claude", nil, nil, "--model", "opus", "--prompt", "Say hello")
 
 	assert.NoError(t, err)
 	assert.Equal(t, jsonResponse, string(stdout))
@@ -659,7 +659,7 @@ func TestMockCLIExecutor_GeminiProviderScenario(t *testing.T) {
 
 	executor.SetOutput([]byte(`{"result": "Analysis complete"}`), []byte(""))
 
-	stdout, stderr, err := executor.Run(ctx, "gemini",
+	stdout, stderr, err := executor.Run(ctx, "gemini", nil, nil,
 		"--temperature", "0.5",
 		"--max-tokens", "2000",
 		"--format", "json",
@@ -682,7 +682,7 @@ func TestMockCLIExecutor_ProviderErrorScenario(t *testing.T) {
 	// Simulate CLI error (e.g., API key invalid)
 	executor.SetError(errors.New("exit status 1: API key invalid"))
 
-	stdout, stderr, err := executor.Run(ctx, "claude", "--prompt", "test")
+	stdout, stderr, err := executor.Run(ctx, "claude", nil, nil, "--prompt", "test")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "API key invalid")
@@ -701,7 +701,7 @@ func TestMockCLIExecutor_ProviderTimeoutScenario(t *testing.T) {
 	// Simulate timeout
 	executor.SetError(context.DeadlineExceeded)
 
-	stdout, stderr, err := executor.Run(ctx, "codex", "--prompt", "long running task")
+	stdout, stderr, err := executor.Run(ctx, "codex", nil, nil, "--prompt", "long running task")
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)

--- a/tests/integration/execution/provider_interpolation_test.go
+++ b/tests/integration/execution/provider_interpolation_test.go
@@ -6,6 +6,7 @@ package execution_test
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -73,7 +74,7 @@ states:
 
 	registry := mocks.NewMockAgentRegistry()
 	claude := mocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider:    "claude",
 			Output:      "Resolved provider executed",
@@ -177,7 +178,7 @@ states:
 
 	registry := mocks.NewMockAgentRegistry()
 	claude := mocks.NewMockAgentProvider("claude")
-	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any) (*workflow.AgentResult, error) {
+	claude.SetExecuteFunc(func(ctx context.Context, prompt string, options map[string]any, stdout, stderr io.Writer) (*workflow.AgentResult, error) {
 		return &workflow.AgentResult{
 			Provider:    "claude",
 			Output:      "OK",


### PR DESCRIPTION
## Summary

- Fix CLI invocation flags for all 4 providers to match current binary APIs: Claude/Gemini `--output-format json` → `stream-json`, Codex `--prompt`/`--quiet` → `exec --json <prompt>`, OpenCode gains `--format json` and `--model` support
- Add `stdout, stderr io.Writer` parameters to `Execute` and `ExecuteConversation` in the ports interface and all provider implementations, enabling streaming output propagation
- Remove dead validation helpers (`validatePrompt`, `validateContext`, `validateState`, `validateCodexOptions`) that became no-ops after previous provider refactoring

## Changes

### Ports / Interface
- `internal/domain/ports/agent_provider.go`: Add `stdout, stderr io.Writer` params to `Execute` and `ExecuteConversation` signatures
- `internal/domain/ports/agent_provider_test.go`: Update interface tests for new signature
- `internal/domain/ports/cli_executor.go`: Propagate writer params through CLI executor abstraction
- `internal/domain/ports/cli_executor_test.go`: Update tests

### Provider Implementations
- `internal/infrastructure/agents/claude_provider.go`: Map `output_format: json` → `--output-format stream-json`; accept `stream-json` pass-through; wire `stdout`/`stderr` writers
- `internal/infrastructure/agents/codex_provider.go`: Migrate from `--prompt`/`--quiet` to `exec --json <prompt>`; resume from `codex resume <id> --prompt` to `codex resume <id> --json`; remove `quiet` option
- `internal/infrastructure/agents/gemini_provider.go`: Map `output_format: json` → `--output-format stream-json`; wire writers
- `internal/infrastructure/agents/opencode_provider.go`: Add `--format json` always-on flag and `--model` option support; wire writers
- `internal/infrastructure/agents/openai_compatible_provider.go`: Update signature to accept `stdout`/`stderr` writers
- `internal/infrastructure/agents/cli_executor.go`: Wire writer params through CLI execution
- `internal/infrastructure/agents/helpers.go`: Remove dead validation helpers (`validatePrompt`, `validateContext`, `validateState`)
- `internal/infrastructure/agents/options.go`: Add `output_format` / `quiet` option declarations

### Application Layer
- `internal/application/conversation_manager.go`: Thread `stdoutW, stderrW io.Writer` through `executeTurn` and `ExecuteConversation`
- `internal/application/execution_service.go`: Pass writers through agent step and conversation execution

### Mocks & Test Infrastructure
- `internal/testutil/mocks/mocks.go`: Update `MockAgentProvider` to match new `Execute`/`ExecuteConversation` signatures
- `internal/testutil/mocks/mocks_agent_test.go`: Update mock tests
- `internal/testutil/mocks/mocks_cli_executor_test.go`: Update CLI executor mock tests

### Tests
- `internal/infrastructure/agents/claude_provider_stream_json_test.go` *(new)*: Tests for `stream-json` output format flag mapping
- `internal/infrastructure/agents/codex_provider_exec_test.go` *(new)*: Tests for `codex exec --json` invocation
- `internal/infrastructure/agents/codex_provider_resume_test.go` *(new)*: Tests for `codex resume --json` conversation resume
- `internal/infrastructure/agents/claude_provider_unit_test.go`: Extend unit tests for new flag behavior
- `internal/infrastructure/agents/codex_provider_unit_test.go`: Extend unit tests; remove `quiet` option tests
- `internal/infrastructure/agents/codex_provider_model_unit_test.go`: Trim tests no longer applicable after exec migration
- `internal/infrastructure/agents/codex_provider_session_test.go`: Update session tests for resume flag change
- `internal/infrastructure/agents/gemini_provider_unit_test.go`: Extend tests for `stream-json` mapping
- `internal/infrastructure/agents/gemini_provider_session_test.go`: Update session tests
- `internal/infrastructure/agents/opencode_provider_unit_test.go`: Extend tests for `--format json` and `--model`
- `internal/infrastructure/agents/opencode_provider_session_test.go`: Update session tests
- `internal/infrastructure/agents/openai_compatible_provider_test.go`: Update for new signature
- `internal/infrastructure/agents/openai_compatible_provider_unit_test.go`: Update unit tests
- `internal/infrastructure/agents/helpers_test.go`: Remove tests for deleted helpers
- `internal/infrastructure/agents/cli_executor_test.go`: Update for writer params
- `internal/infrastructure/agents/mock_provider.go`: Update mock to new interface
- `internal/infrastructure/agents/mock_provider_test.go`: Update mock tests
- `internal/infrastructure/agents/provider_options_test.go`: Update option validation tests
- `internal/infrastructure/agents/registry_test.go`: Minor updates
- `internal/application/agent_step_test.go`: Update all `SetExecuteFunc` callbacks to new signature
- `internal/application/conversation_manager.go`: Already covered above
- `internal/application/conversation_manager_helpers_test.go`: Update internal mock to new interface
- `internal/application/conversation_manager_test.go`: Pass `nil, nil` writers in all `ExecuteConversation` calls
- `internal/application/execution_service_conversation_step_test.go` *(renamed from t009)*: Rename for clarity
- `internal/application/execution_service_conversation_test.go`: Minor updates
- `internal/application/execution_service_dangerous_skip_audit_test.go`: Minor updates
- `internal/application/execution_service_hooks_test.go`: Minor updates
- `internal/application/execution_service_json_field_mapping_test.go`: Minor updates
- `internal/application/execution_service_output_format_test.go`: Update for new `stream-json` mapping
- `tests/integration/execution/provider_interpolation_test.go`: Minor updates

### Documentation
- `CHANGELOG.md`: Document F078 breaking changes (flag migrations, removed `quiet` option) and additions (OpenCode `--model`, `--format json`)
- `CLAUDE.md`: Add architecture rule to synchronize provider CLI flag changes with `options.go`; remove stale review section

## Test plan

- [x] Run unit tests: `make test-unit` — all provider flag-construction tests pass
- [x] Verify Codex invocation builds `exec --json <prompt>` and resume builds `codex resume <id> --json <prompt>`: check `codex_provider_exec_test.go` and `codex_provider_resume_test.go`
- [x] Verify Claude/Gemini `output_format: json` in a workflow YAML produces `--output-format stream-json` in the CLI command: check `claude_provider_stream_json_test.go`
- [x] Run full test suite with race detector: `make test-race`

Closes #301

---
Generated with [awf](https://github.com/awf-project/cli) commit workflow

