### PR TITLE
fix(agents): parse NDJSON stream-json for Claude CLI

### DIFF
--- a/internal/infrastructure/agents/claude_provider.go
+++ b/internal/infrastructure/agents/claude_provider.go
@@ -67,12 +67,23 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, options map
 	if model, ok := getStringOption(options, "model"); ok {
 		args = append(args, "--model", model)
 	}
-	if outputFormat, ok := getStringOption(options, "output_format"); ok {
-		if outputFormat == "json" {
-			outputFormat = "stream-json"
-		}
-		args = append(args, "--output-format", outputFormat)
+
+	// Claude CLI text mode (default with -p) buffers the full response until
+	// process exit, so streaming output via --output=streaming would show nothing
+	// progressively. Force stream-json (NDJSON events) unless the user explicitly
+	// set output_format: text. stream-json requires --verbose in -p mode.
+	userFormat, userFormatSet := getStringOption(options, "output_format")
+	forcedStreamJSON := false
+	switch {
+	case !userFormatSet:
+		args = append(args, "--output-format", "stream-json", "--verbose")
+		forcedStreamJSON = true
+	case userFormat == "json", userFormat == "stream-json":
+		args = append(args, "--output-format", "stream-json", "--verbose")
+	default:
+		args = append(args, "--output-format", userFormat)
 	}
+
 	if allowedTools, ok := getStringOption(options, "allowed_tools"); ok && allowedTools != "" {
 		args = append(args, "--allowedTools", allowedTools)
 	}
@@ -91,7 +102,18 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, options map
 	output := make([]byte, 0, len(stdoutBytes)+len(stderrBytes))
 	output = append(output, stdoutBytes...)
 	output = append(output, stderrBytes...)
-	outputStr := string(output)
+	rawOutputStr := string(output)
+
+	// When we forced stream-json internally (user did not request it), extract
+	// the clean final text from the NDJSON "result" event so downstream steps
+	// reading states.X.output see text, not raw NDJSON.
+	outputStr := rawOutputStr
+	if forcedStreamJSON {
+		if extracted := p.extractTextFromJSON(rawOutputStr); extracted != "" {
+			outputStr = extracted
+		}
+	}
+
 	result := &workflow.AgentResult{
 		Provider:        "claude",
 		Output:          outputStr,
@@ -101,12 +123,9 @@ func (p *ClaudeProvider) Execute(ctx context.Context, prompt string, options map
 		TokensEstimated: true,
 	}
 
-	if options != nil {
-		if format, ok := options["output_format"].(string); ok && format == "json" {
-			var jsonResp map[string]any
-			if err := json.Unmarshal(output, &jsonResp); err != nil {
-				return nil, fmt.Errorf("failed to parse JSON output: %w", err)
-			}
+	// Populate Response only when user explicitly requested structured output.
+	if userFormatSet && (userFormat == "json" || userFormat == "stream-json") {
+		if jsonResp := p.extractResultEvent(rawOutputStr); jsonResp != nil {
 			result.Response = jsonResp
 		}
 	}
@@ -149,8 +168,9 @@ func (p *ClaudeProvider) ExecuteConversation(ctx context.Context, state *workflo
 		args = append(args, "--model", model)
 	}
 
-	// Force stream-json output for session ID extraction on all conversation turns
-	args = append(args, "--output-format", "stream-json")
+	// Force stream-json output for session ID extraction on all conversation turns.
+	// stream-json requires --verbose when combined with --print (-p).
+	args = append(args, "--output-format", "stream-json", "--verbose")
 
 	// Resume from previous session if available
 	if workingState.SessionID != "" {
@@ -232,11 +252,9 @@ func (p *ClaudeProvider) ExecuteConversation(ctx context.Context, state *workflo
 	}
 
 	if userRequestedJSON {
-		var jsonResp map[string]any
-		if err := json.Unmarshal(output, &jsonResp); err != nil {
-			return nil, fmt.Errorf("failed to parse JSON output: %w", err)
+		if jsonResp := p.extractResultEvent(rawOutputStr); jsonResp != nil {
+			result.Response = jsonResp
 		}
-		result.Response = jsonResp
 	}
 
 	return result, nil
@@ -273,68 +291,66 @@ func isValidClaudeModel(model string) bool {
 	return slices.Contains(aliases, model) || strings.HasPrefix(model, "claude-")
 }
 
+// extractResultEvent scans NDJSON stream-json output and returns the final
+// {"type":"result", ...} event as a parsed map, or nil if absent. Each line of
+// claude's stream-json is a standalone JSON object (system, assistant, result,
+// etc.); the "result" event is the authoritative final summary.
+func (p *ClaudeProvider) extractResultEvent(output string) map[string]any {
+	if output == "" {
+		return nil
+	}
+	var found map[string]any
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var evt map[string]any
+		if err := json.Unmarshal([]byte(line), &evt); err != nil {
+			continue
+		}
+		if t, ok := evt["type"].(string); ok && t == "result" {
+			found = evt
+		}
+	}
+	return found
+}
+
 func (p *ClaudeProvider) extractSessionID(output string) (string, error) {
 	if output == "" {
 		return "", errors.New("empty output")
 	}
-
-	var data map[string]any
-	if err := json.Unmarshal([]byte(output), &data); err != nil {
-		return "", fmt.Errorf("output is not valid JSON: %w", err)
+	evt := p.extractResultEvent(output)
+	if evt == nil {
+		return "", errors.New("result event not found")
 	}
-
-	sessionIDVal, ok := data["session_id"]
-	if !ok {
-		return "", errors.New("session_id field not found")
+	sessionIDVal, ok := evt["session_id"]
+	if !ok || sessionIDVal == nil {
+		return "", errors.New("session_id missing")
 	}
-
-	// Handle null value
-	if sessionIDVal == nil {
-		return "", errors.New("session_id is null")
-	}
-
-	// Extract string value
-	if str, ok := sessionIDVal.(string); ok {
+	if str, ok := sessionIDVal.(string); ok && str != "" {
 		return str, nil
 	}
-
 	return "", errors.New("session_id is not a string")
 }
 
 func (p *ClaudeProvider) extractTextFromJSON(output string) string {
-	if output == "" {
+	evt := p.extractResultEvent(output)
+	if evt == nil {
 		return ""
 	}
-
-	var data map[string]any
-	if err := json.Unmarshal([]byte(output), &data); err != nil {
+	result, ok := evt["result"]
+	if !ok || result == nil {
 		return ""
 	}
-
-	result, ok := data["result"]
-	if !ok {
-		return ""
-	}
-
-	// Handle null value
-	if result == nil {
-		return ""
-	}
-
-	// Handle string values
 	if str, ok := result.(string); ok {
 		return str
 	}
-
-	// Handle numeric values - convert to string
 	if num, ok := result.(float64); ok {
-		// Check if it's an integer
 		if num == float64(int64(num)) {
 			return fmt.Sprintf("%.0f", num)
 		}
 		return fmt.Sprint(num)
 	}
-
-	// Unexpected types (boolean, array, object, etc.) - return empty string
 	return ""
 }

--- a/internal/infrastructure/agents/claude_provider_extract_test.go
+++ b/internal/infrastructure/agents/claude_provider_extract_test.go
@@ -6,8 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// T004: Extract Session ID and Text from JSON
-// Tests for extractSessionID() and extractTextFromJSON() methods
+// Tests for extractSessionID() and extractTextFromJSON() — claude CLI stream-json
+// is NDJSON (one JSON object per line); the "result" event carries the final
+// session_id and text payload.
 
 func TestClaudeProvider_extractSessionID(t *testing.T) {
 	provider := NewClaudeProvider()
@@ -19,32 +20,32 @@ func TestClaudeProvider_extractSessionID(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "valid json with session_id",
-			output:  `{"session_id":"claude-session-12345","result":"ok"}`,
+			name:    "NDJSON result event carries session_id",
+			output:  `{"type":"system","subtype":"init"}` + "\n" + `{"type":"result","subtype":"success","session_id":"claude-session-12345","result":"ok"}`,
 			wantID:  "claude-session-12345",
 			wantErr: false,
 		},
 		{
-			name:    "json with uuid-like session_id",
-			output:  `{"session_id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","result":"response"}`,
+			name:    "NDJSON with uuid-like session_id in result event",
+			output:  `{"type":"result","subtype":"success","session_id":"f47ac10b-58cc-4372-a567-0e02b2c3d479","result":"response"}`,
 			wantID:  "f47ac10b-58cc-4372-a567-0e02b2c3d479",
 			wantErr: false,
 		},
 		{
-			name:    "json with numeric session_id",
-			output:  `{"session_id":"98765","data":"content"}`,
+			name:    "NDJSON with numeric-looking session_id string",
+			output:  `{"type":"result","subtype":"success","session_id":"98765","result":"content"}`,
 			wantID:  "98765",
 			wantErr: false,
 		},
 		{
-			name:    "malformed json returns error",
+			name:    "malformed JSON returns error",
 			output:  `{"session_id":"incomplete`,
 			wantID:  "",
 			wantErr: true,
 		},
 		{
-			name:    "json without session_id field returns error",
-			output:  `{"result":"ok","data":"no session"}`,
+			name:    "result event without session_id returns error",
+			output:  `{"type":"result","subtype":"success","result":"ok"}`,
 			wantID:  "",
 			wantErr: true,
 		},
@@ -55,14 +56,20 @@ func TestClaudeProvider_extractSessionID(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "plain text (not json) returns error",
+			name:    "plain text (no result event) returns error",
 			output:  "this is plain text output",
 			wantID:  "",
 			wantErr: true,
 		},
 		{
-			name:    "null session_id returns error",
-			output:  `{"session_id":null,"result":"ok"}`,
+			name:    "null session_id in result event returns error",
+			output:  `{"type":"result","subtype":"success","session_id":null,"result":"ok"}`,
+			wantID:  "",
+			wantErr: true,
+		},
+		{
+			name:    "session_id only present in non-result event is ignored",
+			output:  `{"type":"system","subtype":"init","session_id":"should-not-match"}`,
 			wantID:  "",
 			wantErr: true,
 		},
@@ -91,32 +98,32 @@ func TestClaudeProvider_extractTextFromJSON(t *testing.T) {
 		wantText string
 	}{
 		{
-			name:     "valid json with result field",
-			output:   `{"result":"Hello, world!","session_id":"abc123"}`,
+			name:     "NDJSON result event with string result",
+			output:   `{"type":"result","subtype":"success","result":"Hello, world!","session_id":"abc123"}`,
 			wantText: "Hello, world!",
 		},
 		{
-			name:     "result field with multiline text",
-			output:   `{"result":"Line 1\nLine 2\nLine 3","metadata":{}}`,
+			name:     "NDJSON with preceding events before result",
+			output:   `{"type":"system","subtype":"init"}` + "\n" + `{"type":"assistant","message":{}}` + "\n" + `{"type":"result","subtype":"success","result":"Line 1\nLine 2\nLine 3"}`,
 			wantText: "Line 1\nLine 2\nLine 3",
 		},
 		{
 			name:     "result field with special characters",
-			output:   `{"result":"Response with {braces} and [brackets] and \"quotes\"","id":"123"}`,
+			output:   `{"type":"result","subtype":"success","result":"Response with {braces} and [brackets] and \"quotes\"","id":"123"}`,
 			wantText: `Response with {braces} and [brackets] and "quotes"`,
 		},
 		{
 			name:     "empty result field returns empty",
-			output:   `{"result":"","session_id":"xyz"}`,
+			output:   `{"type":"result","subtype":"success","result":"","session_id":"xyz"}`,
 			wantText: "",
 		},
 		{
-			name:     "json without result field returns empty",
-			output:   `{"session_id":"abc","output":"not result field"}`,
+			name:     "result event without result field returns empty",
+			output:   `{"type":"result","subtype":"success","session_id":"abc","output":"not result field"}`,
 			wantText: "",
 		},
 		{
-			name:     "malformed json returns empty",
+			name:     "malformed JSON returns empty",
 			output:   `{"result":"incomplete`,
 			wantText: "",
 		},
@@ -126,18 +133,23 @@ func TestClaudeProvider_extractTextFromJSON(t *testing.T) {
 			wantText: "",
 		},
 		{
-			name:     "plain text (not json) returns empty",
+			name:     "plain text returns empty",
 			output:   "plain text response",
 			wantText: "",
 		},
 		{
-			name:     "result field with numeric value returns string representation",
-			output:   `{"result":42,"session_id":"abc"}`,
+			name:     "numeric result value returned as string",
+			output:   `{"type":"result","subtype":"success","result":42,"session_id":"abc"}`,
 			wantText: "42",
 		},
 		{
 			name:     "null result field returns empty",
-			output:   `{"result":null,"session_id":"abc"}`,
+			output:   `{"type":"result","subtype":"success","result":null,"session_id":"abc"}`,
+			wantText: "",
+		},
+		{
+			name:     "no result event in stream returns empty",
+			output:   `{"type":"system","subtype":"init","session_id":"abc"}`,
 			wantText: "",
 		},
 	}

--- a/internal/infrastructure/agents/claude_provider_session_test.go
+++ b/internal/infrastructure/agents/claude_provider_session_test.go
@@ -33,7 +33,7 @@ func TestClaudeProvider_ExecuteConversation_ResumeFlag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockExec := mocks.NewMockCLIExecutor()
-			mockExec.SetOutput([]byte(`{"session_id":"sess_new","result":"response"}`), nil)
+			mockExec.SetOutput([]byte(`{"type":"result","subtype":"success","session_id":"sess_new","result":"response"}`), nil)
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 			state := workflow.NewConversationState("system")
@@ -68,14 +68,14 @@ func TestClaudeProvider_ExecuteConversation_SessionIDExtracted(t *testing.T) {
 		wantOutputText string
 	}{
 		{
-			name:           "session ID extracted from JSON output",
-			mockOutput:     []byte(`{"session_id":"sess_extracted_123","result":"actual response text"}`),
+			name:           "session ID extracted from NDJSON result event",
+			mockOutput:     []byte(`{"type":"system","subtype":"init"}` + "\n" + `{"type":"result","subtype":"success","session_id":"sess_extracted_123","result":"actual response text"}`),
 			wantSessionID:  "sess_extracted_123",
 			wantOutputText: "actual response text",
 		},
 		{
 			name:           "no session_id field yields empty SessionID",
-			mockOutput:     []byte(`{"result":"response without session"}`),
+			mockOutput:     []byte(`{"type":"result","subtype":"success","result":"response without session"}`),
 			wantSessionID:  "",
 			wantOutputText: "response without session",
 		},
@@ -100,7 +100,7 @@ func TestClaudeProvider_ExecuteConversation_SessionIDExtracted(t *testing.T) {
 
 func TestClaudeProvider_ExecuteConversation_SystemPromptOnFirstTurn(t *testing.T) {
 	mockExec := mocks.NewMockCLIExecutor()
-	mockExec.SetOutput([]byte(`{"session_id":"sess_1","result":"ok"}`), nil)
+	mockExec.SetOutput([]byte(`{"type":"result","subtype":"success","session_id":"sess_1","result":"ok"}`), nil)
 	provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 	state := workflow.NewConversationState("")
@@ -117,7 +117,7 @@ func TestClaudeProvider_ExecuteConversation_SystemPromptOnFirstTurn(t *testing.T
 
 func TestClaudeProvider_ExecuteConversation_NoSystemPromptOnResumeTurn(t *testing.T) {
 	mockExec := mocks.NewMockCLIExecutor()
-	mockExec.SetOutput([]byte(`{"session_id":"sess_resume","result":"ok"}`), nil)
+	mockExec.SetOutput([]byte(`{"type":"result","subtype":"success","session_id":"sess_resume","result":"ok"}`), nil)
 	provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 	state := workflow.NewConversationState("")
@@ -147,7 +147,7 @@ func TestClaudeProvider_ExecuteConversation_GracefulFallback_NonJSON(t *testing.
 
 func TestClaudeProvider_ExecuteConversation_ForceJSONOutputFormat(t *testing.T) {
 	mockExec := mocks.NewMockCLIExecutor()
-	mockExec.SetOutput([]byte(`{"session_id":"sess_1","result":"ok"}`), nil)
+	mockExec.SetOutput([]byte(`{"type":"result","subtype":"success","session_id":"sess_1","result":"ok"}`), nil)
 	provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 	state := workflow.NewConversationState("system")

--- a/internal/infrastructure/agents/claude_provider_stream_json_test.go
+++ b/internal/infrastructure/agents/claude_provider_stream_json_test.go
@@ -12,31 +12,46 @@ import (
 
 // F078 Tests: Fix CLI Provider Invocations (output_format mapping and ExecuteConversation session handling)
 
-// T001: Execute maps output_format: json to stream-json
+// T001: Execute maps output_format and forces stream-json by default for live streaming
 func TestClaudeProvider_Execute_OutputFormatMapping(t *testing.T) {
+	// NDJSON result event used so extractTextFromJSON can populate clean output
+	ndjson := []byte(`{"type":"system","subtype":"init"}
+{"type":"result","subtype":"success","result":"test output","session_id":"sess-1"}`)
+
 	tests := []struct {
 		name           string
 		options        map[string]any
 		mockOutput     []byte
 		wantFormatFlag string
+		wantVerbose    bool
 	}{
 		{
-			name:           "json format mapped to stream-json",
+			name:           "json format mapped to stream-json with --verbose",
 			options:        map[string]any{"output_format": "json"},
-			mockOutput:     []byte(`{"result":"test output"}`),
+			mockOutput:     ndjson,
 			wantFormatFlag: "stream-json",
+			wantVerbose:    true,
 		},
 		{
-			name:           "stream-json format passed through",
+			name:           "stream-json format passed through with --verbose",
 			options:        map[string]any{"output_format": "stream-json"},
-			mockOutput:     []byte("test output"),
+			mockOutput:     ndjson,
 			wantFormatFlag: "stream-json",
+			wantVerbose:    true,
 		},
 		{
-			name:           "no output format specified",
+			name:           "no output format specified forces stream-json for live streaming",
 			options:        map[string]any{},
+			mockOutput:     ndjson,
+			wantFormatFlag: "stream-json",
+			wantVerbose:    true,
+		},
+		{
+			name:           "explicit text format is respected (no stream-json override)",
+			options:        map[string]any{"output_format": "text"},
 			mockOutput:     []byte("test output"),
-			wantFormatFlag: "",
+			wantFormatFlag: "text",
+			wantVerbose:    false,
 		},
 	}
 
@@ -54,26 +69,24 @@ func TestClaudeProvider_Execute_OutputFormatMapping(t *testing.T) {
 			require.Len(t, calls, 1)
 			call := calls[0]
 
-			if tt.wantFormatFlag != "" {
-				// Find --output-format flag in args
-				found := false
-				for i, arg := range call.Args {
-					if arg == "--output-format" && i+1 < len(call.Args) {
-						assert.Equal(t, tt.wantFormatFlag, call.Args[i+1])
-						found = true
-						break
-					}
-				}
-				assert.True(t, found, "expected --output-format flag not found in args: %v", call.Args)
-			} else {
-				// Ensure no --output-format flag
-				for i, arg := range call.Args {
-					if arg == "--output-format" {
-						t.Errorf("unexpected --output-format flag in args: %v", call.Args)
-					}
-					_ = i
+			found := false
+			for i, arg := range call.Args {
+				if arg == "--output-format" && i+1 < len(call.Args) {
+					assert.Equal(t, tt.wantFormatFlag, call.Args[i+1])
+					found = true
+					break
 				}
 			}
+			assert.True(t, found, "expected --output-format flag not found in args: %v", call.Args)
+
+			hasVerbose := false
+			for _, arg := range call.Args {
+				if arg == "--verbose" {
+					hasVerbose = true
+					break
+				}
+			}
+			assert.Equal(t, tt.wantVerbose, hasVerbose, "--verbose presence mismatch in args: %v", call.Args)
 		})
 	}
 }
@@ -103,7 +116,8 @@ func TestClaudeProvider_ExecuteConversation_ForcesStreamJSON(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockExec := mocks.NewMockCLIExecutor()
-			mockExec.SetOutput([]byte(`{"session_id":"sess-456","result":"response text"}`), nil)
+			mockExec.SetOutput([]byte(`{"type":"system","subtype":"init","session_id":"sess-456"}
+{"type":"result","subtype":"success","result":"response text","session_id":"sess-456"}`), nil)
 			provider := NewClaudeProviderWithOptions(WithClaudeExecutor(mockExec))
 
 			_, err := provider.ExecuteConversation(context.Background(), tt.state, "user prompt", map[string]any{}, nil, nil)
@@ -141,7 +155,7 @@ func TestClaudeProvider_ExecuteConversation_ForcesStreamJSON(t *testing.T) {
 	}
 }
 
-// extractSessionID works with stream-json output format
+// extractSessionID works with stream-json NDJSON output (one JSON object per line)
 func TestClaudeProvider_ExtractSessionID_StreamJSON(t *testing.T) {
 	provider := NewClaudeProvider()
 
@@ -152,25 +166,35 @@ func TestClaudeProvider_ExtractSessionID_StreamJSON(t *testing.T) {
 		wantError bool
 	}{
 		{
-			name:      "valid stream-json with session_id",
-			output:    `{"session_id":"sess-abc123","result":"text","cost_usd":0.001}`,
+			name: "valid NDJSON with session_id in result event",
+			output: `{"type":"system","subtype":"init","session_id":"sess-abc123"}
+{"type":"result","subtype":"success","result":"text","session_id":"sess-abc123","cost_usd":0.001}`,
 			wantID:    "sess-abc123",
 			wantError: false,
 		},
 		{
-			name:      "valid stream-json with different field order",
-			output:    `{"result":"text","session_id":"sess-xyz789","cost_usd":0.002}`,
+			name: "valid NDJSON with multiple events before result",
+			output: `{"type":"system","subtype":"init"}
+{"type":"assistant","message":{}}
+{"type":"result","subtype":"success","result":"text","session_id":"sess-xyz789"}`,
 			wantID:    "sess-xyz789",
 			wantError: false,
 		},
 		{
-			name:      "missing session_id field",
-			output:    `{"result":"text","cost_usd":0.001}`,
+			name:      "result event missing session_id",
+			output:    `{"type":"result","subtype":"success","result":"text"}`,
 			wantID:    "",
 			wantError: true,
 		},
 		{
-			name:      "invalid JSON",
+			name: "no result event in stream",
+			output: `{"type":"system","subtype":"init"}
+{"type":"assistant","message":{}}`,
+			wantID:    "",
+			wantError: true,
+		},
+		{
+			name:      "all invalid JSON lines",
 			output:    `not valid json`,
 			wantID:    "",
 			wantError: true,
@@ -198,7 +222,7 @@ func TestClaudeProvider_ExtractSessionID_StreamJSON(t *testing.T) {
 	}
 }
 
-// extractTextFromJSON works with stream-json output
+// extractTextFromJSON works with stream-json NDJSON output
 func TestClaudeProvider_ExtractTextFromJSON_StreamJSON(t *testing.T) {
 	provider := NewClaudeProvider()
 
@@ -208,18 +232,19 @@ func TestClaudeProvider_ExtractTextFromJSON_StreamJSON(t *testing.T) {
 		wantText string
 	}{
 		{
-			name:     "valid stream-json with result field",
-			output:   `{"session_id":"sess-123","result":"Hello, this is the response","cost_usd":0.001}`,
+			name: "valid NDJSON with result event",
+			output: `{"type":"system","subtype":"init"}
+{"type":"result","subtype":"success","result":"Hello, this is the response","session_id":"sess-123"}`,
 			wantText: "Hello, this is the response",
 		},
 		{
-			name:     "stream-json with multiline result",
-			output:   `{"session_id":"sess-456","result":"Line 1\nLine 2\nLine 3"}`,
+			name:     "NDJSON with multiline result",
+			output:   `{"type":"result","subtype":"success","result":"Line 1\nLine 2\nLine 3","session_id":"sess-456"}`,
 			wantText: "Line 1\nLine 2\nLine 3",
 		},
 		{
-			name:     "stream-json with empty result",
-			output:   `{"session_id":"sess-789","result":""}`,
+			name:     "NDJSON with empty result",
+			output:   `{"type":"result","subtype":"success","result":"","session_id":"sess-789"}`,
 			wantText: "",
 		},
 		{
@@ -228,13 +253,13 @@ func TestClaudeProvider_ExtractTextFromJSON_StreamJSON(t *testing.T) {
 			wantText: "",
 		},
 		{
-			name:     "invalid JSON (graceful fallback)",
+			name:     "invalid JSON lines (graceful fallback)",
 			output:   `{"result": invalid}`,
 			wantText: "",
 		},
 		{
-			name:     "missing result field (graceful fallback)",
-			output:   `{"session_id":"sess-999","cost_usd":0.001}`,
+			name:     "no result event in stream",
+			output:   `{"type":"system","subtype":"init","session_id":"sess-999"}`,
 			wantText: "",
 		},
 	}

--- a/internal/infrastructure/agents/claude_provider_unit_test.go
+++ b/internal/infrastructure/agents/claude_provider_unit_test.go
@@ -97,31 +97,29 @@ func TestClaudeProvider_Execute_JSONParsing(t *testing.T) {
 		errMsg     string
 	}{
 		{
-			name:       "valid json response",
-			mockStdout: []byte(`{"result":"ok","count":42}`),
+			name:       "valid NDJSON result event",
+			mockStdout: []byte(`{"type":"system","subtype":"init"}` + "\n" + `{"type":"result","subtype":"success","result":"ok","session_id":"s1"}`),
 			options:    map[string]any{"output_format": "json"},
 			wantJSON:   true,
 			wantErr:    false,
 		},
 		{
-			name:       "malformed json response",
+			name:       "malformed NDJSON yields nil Response (graceful)",
 			mockStdout: []byte(`{"result":"incomplete`),
 			options:    map[string]any{"output_format": "json"},
 			wantJSON:   false,
-			wantErr:    true,
-			errMsg:     "failed to parse JSON output",
+			wantErr:    false,
 		},
 		{
-			name:       "non-json response with json format",
+			name:       "non-json response with json format yields nil Response (graceful)",
 			mockStdout: []byte("plain text response"),
 			options:    map[string]any{"output_format": "json"},
 			wantJSON:   false,
-			wantErr:    true,
-			errMsg:     "failed to parse JSON output",
+			wantErr:    false,
 		},
 		{
-			name:       "json response without format option",
-			mockStdout: []byte(`{"result":"ok"}`),
+			name:       "no explicit format option does not populate Response",
+			mockStdout: []byte(`{"type":"result","subtype":"success","result":"ok","session_id":"s2"}`),
 			options:    nil,
 			wantJSON:   false,
 			wantErr:    false,
@@ -677,18 +675,18 @@ func TestClaudeProvider_ExecuteConversation_JSONParsing(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:       "valid json",
-			mockStdout: []byte(`{"result":"ok"}`),
+			name:       "valid NDJSON result event populates Response",
+			mockStdout: []byte(`{"type":"result","subtype":"success","result":"ok","session_id":"s1"}`),
 			options:    map[string]any{"output_format": "json"},
 			wantJSON:   true,
 			wantErr:    false,
 		},
 		{
-			name:       "malformed json",
+			name:       "malformed NDJSON yields nil Response without error (graceful)",
 			mockStdout: []byte(`{"result":"incomplete`),
 			options:    map[string]any{"output_format": "json"},
 			wantJSON:   false,
-			wantErr:    true,
+			wantErr:    false,
 		},
 	}
 

--- a/internal/infrastructure/agents/opencode_provider.go
+++ b/internal/infrastructure/agents/opencode_provider.go
@@ -61,8 +61,10 @@ func (p *OpenCodeProvider) Execute(ctx context.Context, prompt string, options m
 
 	args := []string{"run", prompt}
 
-	// Always pass --format json for structured output
-	args = append(args, "--format", "json")
+	// Map user-provided output_format to opencode --format flag.
+	// opencode supports: default (formatted text) | json (NDJSON events).
+	// Absent → json (structured output, live streaming compatible).
+	args = append(args, "--format", resolveOpenCodeFormat(options))
 
 	if model, ok := getStringOption(options, "model"); ok {
 		args = append(args, "--model", model)
@@ -146,8 +148,8 @@ func (p *OpenCodeProvider) ExecuteConversation(ctx context.Context, state *workf
 
 	args := []string{"run", prompt}
 
-	// Always pass --format json for structured output
-	args = append(args, "--format", "json")
+	// Map user-provided output_format to opencode --format flag (same logic as Execute).
+	args = append(args, "--format", resolveOpenCodeFormat(options))
 
 	if model, ok := getStringOption(options, "model"); ok {
 		args = append(args, "--model", model)
@@ -238,6 +240,29 @@ func (p *OpenCodeProvider) Validate() error {
 		return fmt.Errorf("opencode CLI not found in PATH: %w", err)
 	}
 	return nil
+}
+
+// resolveOpenCodeFormat maps the user-provided output_format option to the
+// matching opencode CLI --format value. opencode supports:
+//   - "default": formatted human-readable output
+//   - "json": NDJSON events (required by session ID extraction and
+//     compatible with --output=streaming for live events)
+//
+// Mapping:
+//   - output_format: "text"|"default" → "default"
+//   - output_format: "json"           → "json"
+//   - absent or any other value       → "json" (default, preserves prior behavior)
+func resolveOpenCodeFormat(options map[string]any) string {
+	format, ok := getStringOption(options, "output_format")
+	if !ok {
+		return "json"
+	}
+	switch format {
+	case "text", "default":
+		return "default"
+	default:
+		return "json"
+	}
 }
 
 // validateOpenCodeOptions validates provider-specific options.


### PR DESCRIPTION
## Summary

- Fix the Claude CLI provider to correctly parse NDJSON (stream-json) output: Claude's `--output-format stream-json` emits one JSON object per line, not a single JSON blob — all extraction methods (`extractSessionID`, `extractTextFromJSON`, `extractResultEvent`) are updated accordingly
- Force `--output-format stream-json --verbose` by default in `ClaudeProvider.Execute()` so responses stream live instead of buffering until process exit; when the user did not request structured output, the extracted text is transparently cleaned up before being stored in `states.X.output`
- Add `resolveOpenCodeFormat()` helper in `OpenCodeProvider` to consistently map `output_format` options to OpenCode's `--format` flag in both `Execute` and `ExecuteConversation`
- Tighten JSON parsing to be graceful: malformed or absent NDJSON no longer returns an error — `result.Response` is simply left nil, matching the documented fallback behaviour

## Changes

### Claude Provider — NDJSON parsing and default stream-json

- `internal/infrastructure/agents/claude_provider.go`: Add `extractResultEvent()` to scan NDJSON lines for the `{"type":"result"}` event; refactor `extractSessionID` and `extractTextFromJSON` to delegate to it; force `--output-format stream-json --verbose` by default in `Execute()`; drop `json.Unmarshal(output)` error paths in favour of graceful nil-Response fallback

### OpenCode Provider — format resolution helper

- `internal/infrastructure/agents/opencode_provider.go`: Extract `resolveOpenCodeFormat()` helper; apply it in both `Execute` and `ExecuteConversation` to map `output_format: text|default → default` and everything else (including absent) to `json`

### Tests

- `internal/infrastructure/agents/claude_provider_extract_test.go`: Update all fixture strings from single-object JSON to multi-line NDJSON; add cases for session_id only in non-result events being ignored
- `internal/infrastructure/agents/claude_provider_session_test.go`: Align mock outputs to NDJSON `{"type":"result",...}` format across all session lifecycle tests
- `internal/infrastructure/agents/claude_provider_stream_json_test.go`: Extend output-format mapping tests to assert `--verbose` presence; update all NDJSON fixtures to multi-line streams; add explicit `text` format case
- `internal/infrastructure/agents/claude_provider_unit_test.go`: Update JSON parsing tests to expect graceful nil-Response on malformed NDJSON (no error returned)

## Test plan

- [x] `go test ./internal/infrastructure/agents/... -run TestClaudeProvider` — all Claude provider tests pass
- [x] `go test ./internal/infrastructure/agents/... -run TestOpenCodeProvider` — all OpenCode provider tests pass
- [x] Run a workflow with a Claude agent step and verify `states.<step>.output` contains clean text (not raw NDJSON)
- [x] Run a multi-turn conversation workflow and confirm session IDs are extracted and resumed correctly

Closes #301

---
Generated with [awf](https://github.com/awf-project/cli) commit workflow
