### PR TITLE
feat(history): display full IDs and workflow names without truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **F087**: `awf history` now displays full workflow execution IDs without truncation — UUIDs are shown in their complete 36-character form so they can be copied directly into downstream commands (`awf status <id>`, `awf logs <id>`); workflow names are also displayed in full; table rendering migrated from fixed-width `fmt.Fprintf` to `text/tabwriter` for auto-sizing columns, matching the pattern used by other table outputs
+
 ## [0.7.1] - 2026-04-27
 
 ### Fixed

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -742,7 +742,7 @@ awf error EXECUTION.COMMAND.FAILED -f json
 
 ## awf history
 
-Show workflow execution history.
+Show workflow execution history. IDs and workflow names are displayed in full (no truncation), so IDs can be copied directly into commands like `awf status <id>`.
 
 ```bash
 awf history [flags]

--- a/internal/interfaces/cli/history.go
+++ b/internal/interfaces/cli/history.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"text/tabwriter"
 	"time"
 
 	"github.com/awf-project/cli/internal/application"
@@ -15,7 +16,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// HistoryInfo is the JSON/output structure for history command.
 type HistoryInfo struct {
 	ID           string `json:"id"`
 	WorkflowID   string `json:"workflow_id"`
@@ -28,7 +28,6 @@ type HistoryInfo struct {
 	ErrorMessage string `json:"error_message,omitempty"`
 }
 
-// HistoryStatsInfo is the JSON/output structure for history stats.
 type HistoryStatsInfo struct {
 	TotalExecutions int   `json:"total_executions"`
 	SuccessCount    int   `json:"success_count"`
@@ -74,7 +73,6 @@ func runHistory(cmd *cobra.Command, cfg *Config, workflowName, status, since str
 	ctx := context.Background()
 	writer := ui.NewOutputWriter(cmd.OutOrStdout(), cmd.ErrOrStderr(), cfg.OutputFormat, cfg.NoColor, cfg.NoHints)
 
-	// Open history store
 	historyPath := filepath.Join(cfg.StoragePath, "history.db")
 	historyStore, err := store.NewSQLiteHistoryStore(historyPath)
 	if err != nil {
@@ -82,13 +80,9 @@ func runHistory(cmd *cobra.Command, cfg *Config, workflowName, status, since str
 	}
 	defer func() { _ = historyStore.Close() }()
 
-	// Create logger (silent for CLI commands)
 	log := logger.NewConsoleLogger(io.Discard, logger.LevelWarn, cfg.NoColor)
-
-	// Create history service
 	historySvc := application.NewHistoryService(historyStore, log)
 
-	// Build filter
 	filter := &workflow.HistoryFilter{
 		WorkflowName: workflowName,
 		Status:       status,
@@ -128,10 +122,9 @@ func writeHistoryStats(writer *ui.OutputWriter, stats *workflow.HistoryStats) er
 	}
 
 	if writer.IsJSONFormat() {
-		return writeJSON(writer, info)
+		return writer.WriteJSON(info)
 	}
 
-	// Text/table output
 	_, _ = fmt.Fprintf(writer.Out(), "Execution Statistics\n")
 	_, _ = fmt.Fprintf(writer.Out(), "====================\n")
 	_, _ = fmt.Fprintf(writer.Out(), "Total Executions: %d\n", stats.TotalExecutions)
@@ -162,7 +155,7 @@ func writeHistoryRecords(writer *ui.OutputWriter, records []*workflow.ExecutionR
 	}
 
 	if writer.IsJSONFormat() {
-		return writeJSON(writer, infos)
+		return writer.WriteJSON(infos)
 	}
 
 	if len(infos) == 0 {
@@ -170,30 +163,23 @@ func writeHistoryRecords(writer *ui.OutputWriter, records []*workflow.ExecutionR
 		return nil
 	}
 
-	// Text/table output
-	_, _ = fmt.Fprintf(writer.Out(), "%-20s %-15s %-10s %-12s %s\n", "ID", "WORKFLOW", "STATUS", "DURATION", "COMPLETED")
-	_, _ = fmt.Fprintf(writer.Out(), "%-20s %-15s %-10s %-12s %s\n", "--------------------", "---------------", "----------", "------------", "---------")
+	w := tabwriter.NewWriter(writer.Out(), 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tWORKFLOW\tSTATUS\tDURATION\tCOMPLETED")
+	_, _ = fmt.Fprintln(w, "----\t--------\t------\t--------\t---------")
 	for i := range infos {
 		info := &infos[i]
-		completedAt, _ := time.Parse(time.RFC3339, info.CompletedAt)
 		duration := formatDuration(info.DurationMs)
-		_, _ = fmt.Fprintf(writer.Out(), "%-20s %-15s %-10s %-12s %s\n",
-			truncate(info.ID, 20),
-			truncate(info.WorkflowName, 15),
+		completedAt, _ := time.Parse(time.RFC3339, info.CompletedAt)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			info.ID,
+			info.WorkflowName,
 			info.Status,
 			duration,
 			completedAt.Format("2006-01-02 15:04"),
 		)
 	}
 
-	return nil
-}
-
-func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen-3] + "..."
+	return w.Flush()
 }
 
 func formatDuration(ms int64) string {
@@ -204,10 +190,4 @@ func formatDuration(ms int64) string {
 		return fmt.Sprintf("%.1fs", float64(ms)/1000)
 	}
 	return fmt.Sprintf("%.1fm", float64(ms)/60000)
-}
-
-func writeJSON(writer *ui.OutputWriter, v any) error {
-	// OutputWriter handles JSON internally through other methods,
-	// but we need direct JSON output here
-	return writer.WriteJSON(v)
 }

--- a/internal/interfaces/cli/history_internal_test.go
+++ b/internal/interfaces/cli/history_internal_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,28 +12,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTruncate(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		maxLen int
-		want   string
-	}{
-		{"empty string", "", 10, ""},
-		{"short string", "hello", 10, "hello"},
-		{"exact length", "exactly10!", 10, "exactly10!"},
-		{"too long", "this is too long", 10, "this is..."},
-		{"unicode", "hello world!", 8, "hello..."},
-		{"maxLen 3", "abc", 3, "abc"},
-		{"maxLen 4 with truncation", "abcde", 4, "a..."},
+func TestWriteHistoryRecords_DisplaysFullValues(t *testing.T) {
+	var out bytes.Buffer
+	writer := ui.NewOutputWriter(&out, &out, ui.FormatText, true, false)
+
+	now := time.Now()
+	records := []*workflow.ExecutionRecord{
+		{
+			ID:           "550e8400-e29b-41d4-a716-446655440000",
+			WorkflowID:   "wf-001",
+			WorkflowName: "deploy-staging-eu-west-1",
+			Status:       "success",
+			ExitCode:     0,
+			StartedAt:    now.Add(-5 * time.Minute),
+			CompletedAt:  now,
+			DurationMs:   300000,
+		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := truncate(tt.input, tt.maxLen)
-			assert.Equal(t, tt.want, got)
-		})
-	}
+	err := writeHistoryRecords(writer, records)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "550e8400-e29b-41d4-a716-446655440000")
+	assert.Contains(t, output, "deploy-staging-eu-west-1")
+	assert.NotContains(t, output, "...")
 }
 
 func TestFormatDuration(t *testing.T) {
@@ -210,16 +214,18 @@ func TestWriteHistoryRecords_JSON(t *testing.T) {
 	assert.Contains(t, output, `"duration_ms": 300000`)
 }
 
-func TestWriteHistoryRecords_TruncatesLongValues(t *testing.T) {
+func TestWriteHistoryRecords_DisplaysFullID(t *testing.T) {
 	var out bytes.Buffer
 	writer := ui.NewOutputWriter(&out, &out, ui.FormatText, true, false)
 
 	now := time.Now()
+	longID := "this-is-a-very-long-execution-id-that-exceeds-20-chars"
+	longWorkflowName := "very-long-workflow-name-that-exceeds-limit"
 	records := []*workflow.ExecutionRecord{
 		{
-			ID:           "this-is-a-very-long-execution-id-that-exceeds-20-chars",
+			ID:           longID,
 			WorkflowID:   "wf-001",
-			WorkflowName: "very-long-workflow-name-that-exceeds-limit",
+			WorkflowName: longWorkflowName,
 			Status:       "success",
 			ExitCode:     0,
 			StartedAt:    now.Add(-5 * time.Minute),
@@ -232,10 +238,8 @@ func TestWriteHistoryRecords_TruncatesLongValues(t *testing.T) {
 	require.NoError(t, err)
 
 	output := out.String()
-	// IDs are truncated to 20 chars (17 + "...")
-	assert.Contains(t, output, "this-is-a-very-lo...")
-	// Workflow names are truncated to 15 chars (12 + "...")
-	assert.Contains(t, output, "very-long-wo...")
+	assert.Contains(t, output, longID)
+	assert.Contains(t, output, longWorkflowName)
 }
 
 func TestHistoryInfo_Struct(t *testing.T) {
@@ -257,6 +261,70 @@ func TestHistoryInfo_Struct(t *testing.T) {
 	assert.Equal(t, "success", info.Status)
 	assert.Equal(t, 0, info.ExitCode)
 	assert.Equal(t, int64(300000), info.DurationMs)
+}
+
+func TestWriteHistoryRecords_TabwriterFormattedTable(t *testing.T) {
+	var out bytes.Buffer
+	writer := ui.NewOutputWriter(&out, &out, ui.FormatText, true, false)
+
+	now := time.Now()
+	records := []*workflow.ExecutionRecord{
+		{
+			ID:           "exec-tabwriter-001",
+			WorkflowID:   "wf-001",
+			WorkflowName: "deploy",
+			Status:       "success",
+			StartedAt:    now.Add(-2 * time.Minute),
+			CompletedAt:  now,
+			DurationMs:   120000,
+		},
+	}
+
+	err := writeHistoryRecords(writer, records)
+	require.NoError(t, err)
+
+	output := out.String()
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	require.GreaterOrEqual(t, len(lines), 3, "tabwriter output must have header, separator, and data rows")
+
+	headerLine := lines[0]
+	for _, col := range []string{"ID", "WORKFLOW", "STATUS", "DURATION", "COMPLETED"} {
+		assert.Contains(t, headerLine, col, "header must contain column %q", col)
+	}
+
+	assert.Contains(t, lines[1], "----")
+
+	dataLine := lines[2]
+	assert.Contains(t, dataLine, "exec-tabwriter-001")
+	assert.Contains(t, dataLine, "deploy")
+	assert.Contains(t, dataLine, "success")
+}
+
+func TestWriteHistoryRecords_NoTruncation(t *testing.T) {
+	var out bytes.Buffer
+	writer := ui.NewOutputWriter(&out, &out, ui.FormatText, true, false)
+
+	now := time.Now()
+	longExecID := "exec-" + strings.Repeat("abcdef01234567890", 4)
+	longWorkflowName := "deploy-" + strings.Repeat("region-failover-", 3)
+	records := []*workflow.ExecutionRecord{
+		{
+			ID:           longExecID,
+			WorkflowID:   "wf-001",
+			WorkflowName: longWorkflowName,
+			Status:       "success",
+			StartedAt:    now.Add(-time.Minute),
+			CompletedAt:  now,
+			DurationMs:   60000,
+		},
+	}
+
+	err := writeHistoryRecords(writer, records)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, longExecID, "execution ID must not be truncated")
+	assert.Contains(t, output, longWorkflowName, "workflow name must not be truncated")
 }
 
 func TestHistoryStatsInfo_Struct(t *testing.T) {

--- a/tests/integration/cli/history_full_display_test.go
+++ b/tests/integration/cli/history_full_display_test.go
@@ -1,0 +1,190 @@
+// Feature: F087
+//go:build integration
+
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/awf-project/cli/internal/domain/workflow"
+	"github.com/awf-project/cli/internal/infrastructure/store"
+	"github.com/awf-project/cli/internal/interfaces/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFullIDDisplay_MultipleRecords(t *testing.T) {
+	tmpDir := t.TempDir()
+	historyPath := filepath.Join(tmpDir, "history.db")
+
+	historyStore, err := store.NewSQLiteHistoryStore(historyPath)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	now := time.Now()
+
+	records := []struct {
+		id           string
+		workflowID   string
+		workflowName string
+		status       string
+	}{
+		{
+			id:           "550e8400-e29b-41d4-a716-446655440000",
+			workflowID:   "wf-staging-deploy-eu-west-1-primary",
+			workflowName: "deploy-staging-eu-west-1",
+			status:       "success",
+		},
+		{
+			id:           "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+			workflowID:   "wf-prod-rollback-us-east-2-canary-v2",
+			workflowName: "production-rollback-us-east-2-canary",
+			status:       "failed",
+		},
+		{
+			id:           "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+			workflowID:   "wf-ci",
+			workflowName: "ci",
+			status:       "success",
+		},
+	}
+
+	for i, r := range records {
+		err = historyStore.Record(ctx, &workflow.ExecutionRecord{
+			ID:           r.id,
+			WorkflowID:   r.workflowID,
+			WorkflowName: r.workflowName,
+			Status:       r.status,
+			StartedAt:    now.Add(-time.Duration(len(records)-i) * 10 * time.Minute),
+			CompletedAt:  now.Add(-time.Duration(len(records)-i-1) * 10 * time.Minute),
+			DurationMs:   600000,
+		})
+		require.NoError(t, err)
+	}
+	require.NoError(t, historyStore.Close())
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--storage=" + tmpDir, "history"})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	output := out.String()
+
+	for _, r := range records {
+		assert.Contains(t, output, r.id, "execution ID must appear in full")
+		assert.Contains(t, output, r.workflowName, "workflow name must appear in full")
+	}
+	assert.NotContains(t, output, "...", "no values should be truncated")
+}
+
+func TestFullIDDisplay_TabwriterAlignment(t *testing.T) {
+	tmpDir := t.TempDir()
+	historyPath := filepath.Join(tmpDir, "history.db")
+
+	historyStore, err := store.NewSQLiteHistoryStore(historyPath)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	now := time.Now()
+
+	// Short and long IDs to verify tabwriter aligns columns
+	err = historyStore.Record(ctx, &workflow.ExecutionRecord{
+		ID:           "short-id",
+		WorkflowID:   "wf-1",
+		WorkflowName: "ci",
+		Status:       "success",
+		StartedAt:    now.Add(-2 * time.Minute),
+		CompletedAt:  now.Add(-time.Minute),
+		DurationMs:   60000,
+	})
+	require.NoError(t, err)
+
+	err = historyStore.Record(ctx, &workflow.ExecutionRecord{
+		ID:           "550e8400-e29b-41d4-a716-446655440000",
+		WorkflowID:   "wf-prod-deploy-multi-region-failover-v3",
+		WorkflowName: "deploy-production-multi-region-failover",
+		Status:       "failed",
+		StartedAt:    now.Add(-time.Minute),
+		CompletedAt:  now,
+		DurationMs:   60000,
+		ErrorMessage: "timeout",
+	})
+	require.NoError(t, err)
+	require.NoError(t, historyStore.Close())
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--storage=" + tmpDir, "history"})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	output := out.String()
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	require.GreaterOrEqual(t, len(lines), 4, "header + separator + 2 data rows")
+
+	assert.Contains(t, lines[0], "ID")
+	assert.Contains(t, lines[0], "WORKFLOW")
+	assert.Contains(t, lines[0], "STATUS")
+
+	assert.Contains(t, output, "short-id")
+	assert.Contains(t, output, "550e8400-e29b-41d4-a716-446655440000")
+	assert.Contains(t, output, "deploy-production-multi-region-failover")
+}
+
+func TestFullIDDisplay_JSONPreservesFullValues(t *testing.T) {
+	tmpDir := t.TempDir()
+	historyPath := filepath.Join(tmpDir, "history.db")
+
+	historyStore, err := store.NewSQLiteHistoryStore(historyPath)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	now := time.Now()
+
+	fullUUID := "550e8400-e29b-41d4-a716-446655440000"
+	fullWorkflowID := "wf-staging-deploy-eu-west-1-primary-v2"
+	fullWorkflowName := "deploy-staging-eu-west-1-primary"
+
+	err = historyStore.Record(ctx, &workflow.ExecutionRecord{
+		ID:           fullUUID,
+		WorkflowID:   fullWorkflowID,
+		WorkflowName: fullWorkflowName,
+		Status:       "success",
+		StartedAt:    now.Add(-5 * time.Minute),
+		CompletedAt:  now,
+		DurationMs:   300000,
+	})
+	require.NoError(t, err)
+	require.NoError(t, historyStore.Close())
+
+	cmd := cli.NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--storage=" + tmpDir, "--format=json", "history"})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	var records []map[string]interface{}
+	err = json.Unmarshal(out.Bytes(), &records)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+
+	assert.Equal(t, fullUUID, records[0]["id"])
+	assert.Equal(t, fullWorkflowID, records[0]["workflow_id"])
+	assert.Equal(t, fullWorkflowName, records[0]["workflow_name"])
+}

--- a/tests/integration/cli/history_test.go
+++ b/tests/integration/cli/history_test.go
@@ -4,12 +4,16 @@ package cli_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/awf-project/cli/internal/domain/workflow"
+	"github.com/awf-project/cli/internal/infrastructure/store"
 	"github.com/awf-project/cli/internal/interfaces/cli"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -337,7 +341,6 @@ func TestHistoryCommand_AcceptsNoArguments(t *testing.T) {
 func TestRunHistory_NoHistory(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create empty history directory
 	historyDir := filepath.Join(tmpDir, "history")
 	require.NoError(t, os.MkdirAll(historyDir, 0o755))
 
@@ -381,7 +384,6 @@ func TestRunHistory_InvalidSinceFormat(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 
-			// Create history directory
 			historyDir := filepath.Join(tmpDir, "history")
 			require.NoError(t, os.MkdirAll(historyDir, 0o755))
 
@@ -408,7 +410,6 @@ func TestRunHistory_InvalidSinceFormat(t *testing.T) {
 func TestRunHistory_ValidSinceFormat(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create history directory
 	historyDir := filepath.Join(tmpDir, "history")
 	require.NoError(t, os.MkdirAll(historyDir, 0o755))
 
@@ -419,14 +420,12 @@ func TestRunHistory_ValidSinceFormat(t *testing.T) {
 	cmd.SetArgs([]string{"--storage=" + tmpDir, "history", "--since=2025-12-01"})
 
 	err := cmd.Execute()
-	// Should not error on date parsing
 	require.NoError(t, err)
 }
 
 func TestRunHistory_Stats(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create history directory
 	historyDir := filepath.Join(tmpDir, "history")
 	require.NoError(t, os.MkdirAll(historyDir, 0o755))
 
@@ -474,7 +473,6 @@ func TestRunHistory_Stats(t *testing.T) {
 func TestRunHistory_JSONFormat(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create history directory
 	historyDir := filepath.Join(tmpDir, "history")
 	require.NoError(t, os.MkdirAll(historyDir, 0o755))
 
@@ -488,7 +486,6 @@ func TestRunHistory_JSONFormat(t *testing.T) {
 	require.NoError(t, err)
 
 	output := out.String()
-	// Empty history should return valid JSON array
 	var records []interface{}
 	err = json.Unmarshal([]byte(output), &records)
 	require.NoError(t, err, "output should be valid JSON array")
@@ -497,7 +494,6 @@ func TestRunHistory_JSONFormat(t *testing.T) {
 func TestRunHistory_Filters(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create history directory
 	historyDir := filepath.Join(tmpDir, "history")
 	require.NoError(t, os.MkdirAll(historyDir, 0o755))
 
@@ -540,7 +536,6 @@ func TestRunHistory_Filters(t *testing.T) {
 			cmd.SetArgs(tt.args)
 
 			err := cmd.Execute()
-			// Should not error (even if no results found)
 			require.NoError(t, err)
 		})
 	}
@@ -549,7 +544,6 @@ func TestRunHistory_Filters(t *testing.T) {
 func TestRunHistory_TextOutput(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create history directory
 	historyDir := filepath.Join(tmpDir, "history")
 	require.NoError(t, os.MkdirAll(historyDir, 0o755))
 
@@ -563,9 +557,7 @@ func TestRunHistory_TextOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	output := out.String()
-	// For empty history, should show "No execution history found"
 	if !strings.Contains(output, "No execution history found") {
-		// If there are records, should have table headers
 		assert.Contains(t, output, "ID")
 		assert.Contains(t, output, "WORKFLOW")
 		assert.Contains(t, output, "STATUS")
@@ -574,8 +566,6 @@ func TestRunHistory_TextOutput(t *testing.T) {
 	}
 }
 
-// TestHistoryCommand_SQLiteHistoryStore_Wiring validates that the history command
-// uses SQLiteHistoryStore (T005 component validation for bug-48 fix)
 func TestHistoryCommand_SQLiteHistoryStore_Wiring(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -603,8 +593,6 @@ func TestHistoryCommand_SQLiteHistoryStore_Wiring(t *testing.T) {
 	}
 }
 
-// TestHistoryCommand_ConcurrentAccess validates that multiple history commands
-// can run concurrently without lock errors (bug-48 fix validation)
 func TestHistoryCommand_ConcurrentAccess(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -628,34 +616,27 @@ func TestHistoryCommand_ConcurrentAccess(t *testing.T) {
 		}(i)
 	}
 
-	// Wait for all workers to complete
 	for i := 0; i < numConcurrent; i++ {
 		<-doneChan
 	}
 	close(errChan)
 
-	// Check if any worker failed
-	// Preallocate for potential errors
 	errors := make([]error, 0, numConcurrent)
 	for err := range errChan {
 		errors = append(errors, err)
 	}
 
-	// All concurrent executions should succeed (no lock errors)
 	assert.Empty(t, errors, "concurrent history command executions should not fail with lock errors")
 
-	// Verify history.db exists and is a valid SQLite file
 	historyDBPath := filepath.Join(tmpDir, "history.db")
 	info, err := os.Stat(historyDBPath)
 	require.NoError(t, err)
 	assert.True(t, info.Size() > 0, "history.db should have content")
 }
 
-// TestHistoryCommand_Stats_SQLiteIntegration validates stats with SQLite store
 func TestHistoryCommand_Stats_SQLiteIntegration(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Execute history stats command
 	cmd := cli.NewRootCommand()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
@@ -665,7 +646,6 @@ func TestHistoryCommand_Stats_SQLiteIntegration(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 
-	// Verify SQLite database was created
 	historyDBPath := filepath.Join(tmpDir, "history.db")
 	_, statErr := os.Stat(historyDBPath)
 	assert.NoError(t, statErr, "SQLite history.db should exist after stats query")
@@ -675,7 +655,6 @@ func TestHistoryCommand_Stats_SQLiteIntegration(t *testing.T) {
 	assert.Contains(t, output, "Execution Statistics")
 }
 
-// TestHistoryCommand_FilterWithSQLite validates filtering with SQLite store
 func TestHistoryCommand_FilterWithSQLite(t *testing.T) {
 	tests := []struct {
 		name string
@@ -716,7 +695,6 @@ func TestHistoryCommand_FilterWithSQLite(t *testing.T) {
 			err := cmd.Execute()
 			require.NoError(t, err)
 
-			// Verify SQLite database was created
 			historyDBPath := filepath.Join(tmpDir, "history.db")
 			_, statErr := os.Stat(historyDBPath)
 			assert.NoError(t, statErr, "SQLite history.db should exist after filtered query")
@@ -724,7 +702,6 @@ func TestHistoryCommand_FilterWithSQLite(t *testing.T) {
 	}
 }
 
-// TestHistoryCommand_JSONOutput_SQLite validates JSON output with SQLite store
 func TestHistoryCommand_JSONOutput_SQLite(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -737,7 +714,6 @@ func TestHistoryCommand_JSONOutput_SQLite(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 
-	// Verify SQLite database was created
 	historyDBPath := filepath.Join(tmpDir, "history.db")
 	_, statErr := os.Stat(historyDBPath)
 	assert.NoError(t, statErr, "SQLite history.db should exist for JSON output")
@@ -749,7 +725,6 @@ func TestHistoryCommand_JSONOutput_SQLite(t *testing.T) {
 	require.NoError(t, jsonErr, "output should be valid JSON array")
 }
 
-// TestHistoryCommand_StatsJSON_SQLite validates JSON stats output with SQLite
 func TestHistoryCommand_StatsJSON_SQLite(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -762,7 +737,6 @@ func TestHistoryCommand_StatsJSON_SQLite(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 
-	// Verify SQLite database was created
 	historyDBPath := filepath.Join(tmpDir, "history.db")
 	_, statErr := os.Stat(historyDBPath)
 	assert.NoError(t, statErr, "SQLite history.db should exist for JSON stats")
@@ -773,4 +747,84 @@ func TestHistoryCommand_StatsJSON_SQLite(t *testing.T) {
 	jsonErr := json.Unmarshal([]byte(output), &stats)
 	require.NoError(t, jsonErr, "output should be valid JSON object")
 	assert.Contains(t, stats, "total_executions")
+}
+
+func TestRunHistory_FullIDDisplay(t *testing.T) {
+	tmpDir := t.TempDir()
+	historyPath := filepath.Join(tmpDir, "history.db")
+
+	ctx := context.Background()
+
+	historyStore, err := store.NewSQLiteHistoryStore(historyPath)
+	require.NoError(t, err)
+	defer func() { _ = historyStore.Close() }()
+
+	fullUUID := "550e8400-e29b-41d4-a716-446655440000"
+	fullWorkflowName := "deploy-staging-eu-west-1"
+	record := &workflow.ExecutionRecord{
+		ID:           fullUUID,
+		WorkflowID:   "wf-staging-deploy-001",
+		WorkflowName: fullWorkflowName,
+		Status:       "success",
+		ExitCode:     0,
+		StartedAt:    time.Now().Add(-5 * time.Minute),
+		CompletedAt:  time.Now(),
+		DurationMs:   300000,
+	}
+
+	err = historyStore.Record(ctx, record)
+	require.NoError(t, err)
+
+	historyStore.Close()
+
+	t.Run("text output shows full UUID and workflow name without truncation", func(t *testing.T) {
+		cmd := cli.NewRootCommand()
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"--storage=" + tmpDir, "history"})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		output := out.String()
+		assert.Contains(t, output, fullUUID)
+		assert.Contains(t, output, fullWorkflowName)
+		assert.NotContains(t, output, "...")
+	})
+
+	t.Run("json output preserves full IDs", func(t *testing.T) {
+		cmd := cli.NewRootCommand()
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"--storage=" + tmpDir, "--format=json", "history"})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		var records []map[string]interface{}
+		err = json.Unmarshal(out.Bytes(), &records)
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+
+		assert.Equal(t, fullUUID, records[0]["id"])
+		assert.Equal(t, fullWorkflowName, records[0]["workflow_name"])
+	})
+
+	t.Run("filtered output preserves full IDs", func(t *testing.T) {
+		cmd := cli.NewRootCommand()
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"--storage=" + tmpDir, "history", "--workflow=" + fullWorkflowName})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		output := out.String()
+		assert.Contains(t, output, fullUUID)
+		assert.Contains(t, output, fullWorkflowName)
+		assert.NotContains(t, output, "...")
+	})
 }


### PR DESCRIPTION
## Summary

- `awf history` previously truncated execution IDs to 20 characters and workflow names to 15 characters, making the output IDs unusable for downstream commands like `awf status <id>` — this removes all truncation so full values are always displayed
- Table rendering is migrated from fixed-width `fmt.Fprintf` with `%-Ns` format verbs to `text/tabwriter` for auto-sizing columns, consistent with other table outputs in the CLI
- The `truncate()` helper and the `writeJSON()` wrapper are deleted as they are no longer needed

## Changes

### Implementation
- `internal/interfaces/cli/history.go`: Replace fixed-width `fmt.Fprintf` table rendering with `text/tabwriter`; emit full `info.ID` and `info.WorkflowName` without truncation; delete `truncate()` and `writeJSON()` helpers; replace `writeJSON(writer, v)` calls with `writer.WriteJSON(v)` directly

### Tests — Unit
- `internal/interfaces/cli/history_internal_test.go`: Replace `TestTruncate` (now-deleted function) with `TestWriteHistoryRecords_DisplaysFullValues`; flip `TestWriteHistoryRecords_TruncatesLongValues` to `TestWriteHistoryRecords_DisplaysFullID` asserting full values appear; add `TestWriteHistoryRecords_TabwriterFormattedTable` and `TestWriteHistoryRecords_NoTruncation`

### Tests — Integration
- `tests/integration/cli/history_full_display_test.go`: New file with three integration scenarios — multiple-record full display, tabwriter column alignment with mixed-length IDs, and JSON output preserving full field values
- `tests/integration/cli/history_test.go`: Add `TestRunHistory_FullIDDisplay` covering text, JSON, and filtered output paths; remove now-obsolete inline comments

### Documentation
- `CHANGELOG.md`: Document F087 behavior change under `[Unreleased]`
- `docs/user-guide/commands.md`: Update `awf history` description to note IDs are displayed in full and can be copied directly into other commands

## Test plan

- [x] Run `awf history` with a UUID execution ID and verify the full 36-character UUID appears untruncated in text output
- [x] Run `awf history --format=json` and confirm `id` and `workflow_name` fields contain full values with no `...` suffix
- [x] Run unit tests: `make test-unit` — verify `TestWriteHistoryRecords_*` and `TestFormatDuration` pass
- [x] Run integration tests: `make test-integration` — verify `TestFullIDDisplay_*` and `TestRunHistory_FullIDDisplay` pass

Closes #322

---
Generated with [awf](https://github.com/awf-project/cli) commit workflow
