### PR TITLE
feat(resume): add `--from` flag to resume workflow from a specific step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,3 +310,4 @@ func TestWorkflowValidation(t *testing.T) {
 
 ## Review Standards
 
+- Never mark implementation complete without confirming `make build`, `make lint`, and `make test` pass with zero violations

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ AWF is a powerful orchestration tool that grants AI agents and workflows direct 
 | `awf error [code]` | Lookup error codes with descriptions and resolutions |
 | `awf list` | List available workflows |
 | `awf list prompts` | List available prompt files |
-| `awf resume` | Resume interrupted workflow |
+| `awf resume <id>` | Resume interrupted workflow with `--from` to jump to `previous` step, `current` (default), or specific step name |
 | `awf history` | Show execution history |
 | `awf status <id>` | Check workflow status |
 | `awf config show` | Display project configuration |

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -10,7 +10,7 @@ title: "CLI Commands"
 | `awf init --global` | Initialize global prompts and scripts directories |
 | `awf run <workflow>` | Execute a local workflow |
 | `awf run <pack/workflow>` | Execute a workflow from an installed pack |
-| `awf resume [workflow-id]` | Resume an interrupted workflow |
+| `awf resume [workflow-id]` | Resume an interrupted workflow (`--from` to resume from a specific step) |
 | `awf list` | List available workflows |
 | `awf list prompts` | List available prompt files |
 | `awf status <id>` | Show execution status |
@@ -429,8 +429,24 @@ awf resume [workflow-id] [flags]
 | Flag | Description |
 |------|-------------|
 | `--list, -l` | List resumable workflows |
+| `--from` | Resume from step: `current` (default), `previous` (last completed step), or explicit `<step-name>` |
 | `--input, -i` | Override input parameter on resume (key=value) |
 | `--output, -o` | Output mode: silent (default), streaming, buffered |
+
+### `--from` Flag Values
+
+| Value | Description | Use Case |
+|-------|-------------|----------|
+| `current` | Resume from the current (failed) step | Default behavior; backward compatible with pre-F093 `awf resume` |
+| `previous` | Resume from the last completed step before the failure | Recover from upstream issues without re-running the current step |
+| `<step-name>` | Resume from a specific named step | Jump back multiple steps to the root cause |
+
+### State Cleanup Behavior
+
+When using `--from previous` or `--from <step-name>`:
+- All step states completed after the target step are removed from execution history
+- The workflow re-executes from the target step with the cleaned state
+- Interpolation references to cleaned steps (e.g., `{{states.removed_step.output}}`) will fail with "unknown state"
 
 ### Examples
 
@@ -438,12 +454,25 @@ awf resume [workflow-id] [flags]
 # List all resumable (interrupted) workflows
 awf resume --list
 
-# Resume a specific workflow
+# Resume a specific workflow (default: resume from current step)
 awf resume abc123-def456
 
-# Resume with input override
-awf resume abc123-def456 --input max_tokens=5000
+# Resume from the previous (last completed) step
+awf resume abc123-def456 --from previous
+
+# Resume from a specific step by name
+awf resume abc123-def456 --from build_step
+
+# Resume with input override and from flag
+awf resume abc123-def456 --from previous --input max_tokens=5000
 ```
+
+### Error Handling
+
+| Error | When | Resolution |
+|-------|------|-----------|
+| "no prior completed step" | Using `--from previous` on a workflow that hasn't completed any steps | Use `--from <explicit-step-name>` or re-run with `awf run` |
+| "step not found" | Using `--from <step-name>` where the step never executed | List completed steps with `awf status <id>` to find valid step names |
 
 ---
 

--- a/internal/application/agent_step_test.go
+++ b/internal/application/agent_step_test.go
@@ -1039,7 +1039,7 @@ func TestExecutionService_Resume_WithAgentStep(t *testing.T) {
 	)
 	execSvc.SetAgentRegistry(registry)
 
-	ctx, err := execSvc.Resume(context.Background(), "test-id", nil)
+	ctx, err := execSvc.Resume(context.Background(), "test-id", nil, "current")
 
 	// Should succeed after resuming at the agent step
 	require.NoError(t, err)

--- a/internal/application/execution_service.go
+++ b/internal/application/execution_service.go
@@ -1626,11 +1626,13 @@ func (s *ExecutionService) validateInputs(inputs map[string]any, defs []workflow
 
 // Resume continues an interrupted workflow execution from where it left off.
 // It loads persisted state, validates resumability, merges input overrides,
-// and continues execution from CurrentStep while skipping completed steps.
+// and continues execution from the resolved fromStep while skipping completed steps.
+// fromStep may be "current", "previous", or a literal step name present in States.
 func (s *ExecutionService) Resume(
 	ctx context.Context,
 	workflowID string,
 	inputOverrides map[string]any,
+	fromStep string,
 ) (*workflow.ExecutionContext, error) {
 	// 1. Load state
 	execCtx, err := s.store.Load(ctx, workflowID)
@@ -1657,15 +1659,30 @@ func (s *ExecutionService) Resume(
 		return nil, fmt.Errorf("cannot resume: step '%s' no longer exists in workflow", execCtx.CurrentStep)
 	}
 
-	// 5. Merge input overrides
+	// 5. Resolve the from-step target
+	targetStep, err := s.resolveFromStep(execCtx, wf, fromStep)
+	if err != nil {
+		return nil, err
+	}
+
+	// 6. Cleanup states after target and persist atomically before execution
+	if targetStep != execCtx.CurrentStep {
+		s.cleanupStatesAfter(execCtx, targetStep)
+		s.checkpoint(ctx, execCtx)
+	}
+
+	// 7. Merge input overrides
 	for k, v := range inputOverrides {
 		execCtx.SetInput(k, v)
 	}
 
-	// 6. Reset status to running
+	// 8. Set current step to resolved target
+	execCtx.CurrentStep = targetStep
+
+	// 9. Reset status to running
 	execCtx.Status = workflow.StatusRunning
 
-	// 7. Execute from current step
+	// 10. Execute from resolved step
 	s.logger.Info("resuming workflow", "id", workflowID, "from", execCtx.CurrentStep)
 
 	// emit audit started event before workflow_start hooks (resume path)
@@ -1682,6 +1699,70 @@ func (s *ExecutionService) Resume(
 
 	// Continue execution from current step
 	return s.executeFromStep(ctx, wf, execCtx)
+}
+
+// resolveFromStep resolves the --from flag value to a concrete step name.
+// Accepts "current", "previous", or a literal step name that exists in the workflow.
+func (s *ExecutionService) resolveFromStep(execCtx *workflow.ExecutionContext, wf *workflow.Workflow, fromStep string) (string, error) {
+	switch fromStep {
+	case "current":
+		return execCtx.CurrentStep, nil
+	case "previous":
+		var bestName string
+		var bestTime time.Time
+		allStates := execCtx.GetAllStepStates()
+		for name, state := range allStates { //nolint:gocritic // rangeValCopy: iterating defensive copy from GetAllStepStates, value semantics required for timestamp comparison
+			if name == execCtx.CurrentStep {
+				continue
+			}
+			if state.CompletedAt.IsZero() {
+				continue
+			}
+			if state.CompletedAt.After(bestTime) || (state.CompletedAt.Equal(bestTime) && name > bestName) {
+				bestTime = state.CompletedAt
+				bestName = name
+			}
+		}
+		if bestName == "" {
+			return "", domainerrors.NewUserError(
+				domainerrors.ErrorCodeUserInputValidationFailed,
+				"no prior step: no completed step found to resume from",
+				nil,
+				nil,
+			)
+		}
+		return bestName, nil
+	default:
+		allStates := execCtx.GetAllStepStates()
+		if _, exists := allStates[fromStep]; !exists {
+			return "", domainerrors.NewUserError(
+				domainerrors.ErrorCodeUserInputValidationFailed,
+				fmt.Sprintf("step not found in execution history: %s", fromStep),
+				map[string]any{"step": fromStep},
+				nil,
+			)
+		}
+		return fromStep, nil
+	}
+}
+
+// cleanupStatesAfter deletes all States entries whose CompletedAt is strictly after the target step's CompletedAt.
+// The target step itself is preserved.
+func (s *ExecutionService) cleanupStatesAfter(execCtx *workflow.ExecutionContext, targetStepName string) {
+	targetState, ok := execCtx.GetStepState(targetStepName)
+	if !ok {
+		return
+	}
+	cutoff := targetState.CompletedAt
+	allStates := execCtx.GetAllStepStates()
+	for name, state := range allStates { //nolint:gocritic // rangeValCopy: iterating defensive copy from GetAllStepStates, value semantics required for timestamp comparison
+		if name == targetStepName {
+			continue
+		}
+		if state.CompletedAt.After(cutoff) {
+			execCtx.DeleteStepState(name)
+		}
+	}
 }
 
 // ListResumable returns all workflow executions that can be resumed.
@@ -1729,7 +1810,6 @@ func (s *ExecutionService) executeFromStep(
 
 		execCtx.CurrentStep = currentStep
 
-		// terminal state - done
 		if step.Type == workflow.StepTypeTerminal {
 			// Check terminal status: failure or success (default)
 			if step.Status == workflow.TerminalFailure {
@@ -1755,7 +1835,6 @@ func (s *ExecutionService) executeFromStep(
 			break
 		}
 
-		// execute step based on type
 		var nextStep string
 		var err error
 
@@ -1810,7 +1889,6 @@ func (s *ExecutionService) executeFromStep(
 			})
 		}
 
-		// checkpoint after each step
 		s.checkpoint(ctx, execCtx)
 
 		currentStep = nextStep

--- a/internal/application/execution_service_core_test.go
+++ b/internal/application/execution_service_core_test.go
@@ -1112,7 +1112,7 @@ func TestExecutionService_Resume_Success(t *testing.T) {
 	mocks.StateStore.Save(context.Background(), interruptedState)
 
 	// Execute resume
-	ctx, err := execSvc.Resume(context.Background(), "test-id-123", nil)
+	ctx, err := execSvc.Resume(context.Background(), "test-id-123", nil, "current")
 
 	require.NoError(t, err, "resume should succeed")
 	assert.Equal(t, workflow.StatusCompleted, ctx.Status, "workflow should be completed")
@@ -1137,7 +1137,7 @@ func TestExecutionService_Resume_NotFound(t *testing.T) {
 	// Resume non-existent workflow should fail
 	execSvc, _ := NewTestHarness(t).Build()
 
-	_, err := execSvc.Resume(context.Background(), "non-existent-id", nil)
+	_, err := execSvc.Resume(context.Background(), "non-existent-id", nil, "current")
 
 	require.Error(t, err, "resume should fail for non-existent workflow")
 	assert.Contains(t, err.Error(), "not found", "error should indicate workflow not found")
@@ -1169,7 +1169,7 @@ func TestExecutionService_Resume_AlreadyCompleted(t *testing.T) {
 		Build()
 	mocks.StateStore.Save(context.Background(), completedState)
 
-	_, err := execSvc.Resume(context.Background(), "completed-id", nil)
+	_, err := execSvc.Resume(context.Background(), "completed-id", nil, "current")
 
 	require.Error(t, err, "resume should fail for completed workflow")
 	assert.Contains(t, err.Error(), "completed", "error should mention workflow is completed")
@@ -1191,7 +1191,7 @@ func TestExecutionService_Resume_WorkflowDefinitionNotFound(t *testing.T) {
 	execSvc, mocks := NewTestHarness(t).Build()
 	mocks.StateStore.Save(context.Background(), orphanState)
 
-	_, err := execSvc.Resume(context.Background(), "orphan-id", nil)
+	_, err := execSvc.Resume(context.Background(), "orphan-id", nil, "current")
 
 	require.Error(t, err, "resume should fail when workflow definition not found")
 	assert.Contains(t, err.Error(), "not found", "error should indicate workflow definition not found")
@@ -1224,7 +1224,7 @@ func TestExecutionService_Resume_StepNotFound(t *testing.T) {
 		Build()
 	mocks.StateStore.Save(context.Background(), staleState)
 
-	_, err := execSvc.Resume(context.Background(), "stale-id", nil)
+	_, err := execSvc.Resume(context.Background(), "stale-id", nil, "current")
 
 	require.Error(t, err, "resume should fail when current step no longer exists")
 	assert.Contains(t, err.Error(), "old_step", "error should mention the missing step name")
@@ -1258,7 +1258,7 @@ func TestExecutionService_Resume_InputOverrides(t *testing.T) {
 
 	// Resume with overrides
 	overrides := map[string]any{"key": "overridden"}
-	ctx, err := execSvc.Resume(context.Background(), "override-id", overrides)
+	ctx, err := execSvc.Resume(context.Background(), "override-id", overrides, "current")
 
 	require.NoError(t, err, "resume with overrides should succeed")
 
@@ -1309,7 +1309,7 @@ func TestExecutionService_Resume_SkipsCompletedSteps(t *testing.T) {
 		Build()
 	mocks.StateStore.Save(context.Background(), skipState)
 
-	ctx, err := execSvc.Resume(context.Background(), "skip-id", nil)
+	ctx, err := execSvc.Resume(context.Background(), "skip-id", nil, "current")
 
 	require.NoError(t, err, "resume should succeed")
 	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
@@ -1348,7 +1348,7 @@ func TestExecutionService_Resume_FailedStatus(t *testing.T) {
 		Build()
 	mocks.StateStore.Save(context.Background(), failedState)
 
-	ctx, err := execSvc.Resume(context.Background(), "failed-id", nil)
+	ctx, err := execSvc.Resume(context.Background(), "failed-id", nil, "current")
 
 	require.NoError(t, err, "resume of failed workflow should succeed")
 	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
@@ -1380,7 +1380,7 @@ func TestExecutionService_Resume_CancelledStatus(t *testing.T) {
 		Build()
 	mocks.StateStore.Save(context.Background(), cancelledState)
 
-	ctx, err := execSvc.Resume(context.Background(), "cancelled-id", nil)
+	ctx, err := execSvc.Resume(context.Background(), "cancelled-id", nil, "current")
 
 	require.NoError(t, err, "resume of cancelled workflow should succeed")
 	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
@@ -1737,7 +1737,7 @@ func TestExecutionService_Resume_CallWorkflow_DispatcherRouting(t *testing.T) {
 		Build()
 	mocks.StateStore.Save(context.Background(), resumeState)
 
-	ctx, err := execSvc.Resume(context.Background(), "resume-test-id", nil)
+	ctx, err := execSvc.Resume(context.Background(), "resume-test-id", nil, "current")
 
 	require.NoError(t, err)
 	assert.Equal(t, workflow.StatusCompleted, ctx.Status)

--- a/internal/application/execution_service_from_step_test.go
+++ b/internal/application/execution_service_from_step_test.go
@@ -1,0 +1,959 @@
+package application_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/awf-project/cli/internal/domain/ports"
+	"github.com/awf-project/cli/internal/domain/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecutionService_Resume_From_Integration_PreviousReExecutesStep verifies the full resume-from-step
+// end-to-end flow: 4-step workflow (init → validate → build → test → done), fails at test,
+// resume with "previous" re-executes build, then test, and the workflow completes successfully.
+func TestExecutionService_Resume_From_Integration_PreviousReExecutesStep(t *testing.T) {
+	now := time.Now()
+
+	wf := &workflow.Workflow{
+		Name:    "four-step",
+		Initial: "init",
+		Steps: map[string]*workflow.Step{
+			"init": {
+				Name:      "init",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo init",
+				OnSuccess: "validate",
+			},
+			"validate": {
+				Name:      "validate",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo validate",
+				OnSuccess: "build",
+			},
+			"build": {
+				Name:      "build",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo build",
+				OnSuccess: "test",
+			},
+			"test": {
+				Name:      "test",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo test",
+				OnSuccess: "done",
+			},
+			"done": {
+				Name:   "done",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "integ-prev-001",
+		WorkflowName: "four-step",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "test",
+		States: map[string]workflow.StepState{
+			"init":     {Name: "init", CompletedAt: now.Add(-3 * time.Second)},
+			"validate": {Name: "validate", CompletedAt: now.Add(-2 * time.Second)},
+			"build":    {Name: "build", CompletedAt: now.Add(-1 * time.Second)},
+		},
+		Inputs:    make(map[string]any),
+		Env:       make(map[string]string),
+		StartedAt: now.Add(-4 * time.Second),
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("four-step", wf).
+		WithCommandResult("echo build", &ports.CommandResult{Stdout: "build\n", ExitCode: 0}).
+		WithCommandResult("echo test", &ports.CommandResult{Stdout: "test\n", ExitCode: 0}).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	ctx, err := execSvc.Resume(context.Background(), "integ-prev-001", nil, "previous")
+
+	require.NoError(t, err)
+	require.NotNil(t, ctx)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	// "previous" resolves to build (most recently completed before test);
+	// build must appear in executor calls, proving re-execution started from build.
+	executedCmds := commandsExecuted(mocks)
+	assert.Contains(t, executedCmds, "echo build", "build must be re-executed when resuming from previous")
+	assert.Contains(t, executedCmds, "echo test", "test must execute after build")
+}
+
+// TestExecutionService_Resume_From_Integration_NamedStepCleanup verifies cleanup when resuming
+// from a named step earlier in the chain: 5-step workflow (init → validate → build → test → deploy → done),
+// states for build, test, deploy cleared on resume from "validate", then full chain re-executes.
+func TestExecutionService_Resume_From_Integration_NamedStepCleanup(t *testing.T) {
+	now := time.Now()
+
+	wf := &workflow.Workflow{
+		Name:    "five-step",
+		Initial: "init",
+		Steps: map[string]*workflow.Step{
+			"init": {
+				Name:      "init",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo init",
+				OnSuccess: "validate",
+			},
+			"validate": {
+				Name:      "validate",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo validate",
+				OnSuccess: "build",
+			},
+			"build": {
+				Name:      "build",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo build",
+				OnSuccess: "test",
+			},
+			"test": {
+				Name:      "test",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo test",
+				OnSuccess: "deploy",
+			},
+			"deploy": {
+				Name:      "deploy",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo deploy",
+				OnSuccess: "done",
+			},
+			"done": {
+				Name:   "done",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	// Simulate failure at deploy: init, validate, build, test completed; deploy failed (no state).
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "integ-named-001",
+		WorkflowName: "five-step",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "deploy",
+		States: map[string]workflow.StepState{
+			"init":     {Name: "init", CompletedAt: now.Add(-4 * time.Second)},
+			"validate": {Name: "validate", CompletedAt: now.Add(-3 * time.Second)},
+			"build":    {Name: "build", CompletedAt: now.Add(-2 * time.Second)},
+			"test":     {Name: "test", CompletedAt: now.Add(-1 * time.Second)},
+		},
+		Inputs:    make(map[string]any),
+		Env:       make(map[string]string),
+		StartedAt: now.Add(-5 * time.Second),
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("five-step", wf).
+		WithCommandResult("echo validate", &ports.CommandResult{Stdout: "validate\n", ExitCode: 0}).
+		WithCommandResult("echo build", &ports.CommandResult{Stdout: "build\n", ExitCode: 0}).
+		WithCommandResult("echo test", &ports.CommandResult{Stdout: "test\n", ExitCode: 0}).
+		WithCommandResult("echo deploy", &ports.CommandResult{Stdout: "deploy\n", ExitCode: 0}).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	ctx, err := execSvc.Resume(context.Background(), "integ-named-001", nil, "validate")
+
+	require.NoError(t, err)
+	require.NotNil(t, ctx)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	// Resuming from the named step "validate" must re-execute validate and all subsequent steps.
+	// "echo validate" appearing in calls proves execution started from validate, not deploy (current).
+	executedCmds := commandsExecuted(mocks)
+	assert.Contains(t, executedCmds, "echo validate", "validate must be re-executed when resuming from validate")
+	assert.Contains(t, executedCmds, "echo build", "build must re-execute after validate")
+	assert.Contains(t, executedCmds, "echo test", "test must re-execute after build")
+	assert.Contains(t, executedCmds, "echo deploy", "deploy must re-execute after test")
+}
+
+// TestExecutionService_Resume_From_Integration_ParallelPrevious verifies US4: when "previous"
+// resolves to a parallel step, all parallel branches and subsequent steps re-execute.
+// Workflow: init → parallel_build (branches: build_a, build_b) → test → done.
+// Fails at test; resume with "previous" re-executes the parallel block and test.
+func TestExecutionService_Resume_From_Integration_ParallelPrevious(t *testing.T) {
+	now := time.Now()
+
+	wf := &workflow.Workflow{
+		Name:    "parallel-resume",
+		Initial: "init",
+		Steps: map[string]*workflow.Step{
+			"init": {
+				Name:      "init",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo init",
+				OnSuccess: "parallel_build",
+			},
+			"parallel_build": {
+				Name:      "parallel_build",
+				Type:      workflow.StepTypeParallel,
+				Branches:  []string{"build_a", "build_b"},
+				Strategy:  "all_succeed",
+				OnSuccess: "test",
+			},
+			"build_a": {
+				Name:    "build_a",
+				Type:    workflow.StepTypeCommand,
+				Command: "echo build_a",
+			},
+			"build_b": {
+				Name:    "build_b",
+				Type:    workflow.StepTypeCommand,
+				Command: "echo build_b",
+			},
+			"test": {
+				Name:      "test",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo test",
+				OnSuccess: "done",
+			},
+			"done": {
+				Name:   "done",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	// Simulate: init, build_a, build_b, parallel_build completed; test failed (no state).
+	// parallel_build has the latest CompletedAt before test → "previous" resolves to it.
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "integ-parallel-001",
+		WorkflowName: "parallel-resume",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "test",
+		States: map[string]workflow.StepState{
+			"init":           {Name: "init", CompletedAt: now.Add(-3 * time.Second)},
+			"build_a":        {Name: "build_a", CompletedAt: now.Add(-2 * time.Second)},
+			"build_b":        {Name: "build_b", CompletedAt: now.Add(-2 * time.Second)},
+			"parallel_build": {Name: "parallel_build", CompletedAt: now.Add(-1 * time.Second)},
+		},
+		Inputs:    make(map[string]any),
+		Env:       make(map[string]string),
+		StartedAt: now.Add(-4 * time.Second),
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("parallel-resume", wf).
+		WithCommandResult("echo build_a", &ports.CommandResult{Stdout: "build_a\n", ExitCode: 0}).
+		WithCommandResult("echo build_b", &ports.CommandResult{Stdout: "build_b\n", ExitCode: 0}).
+		WithCommandResult("echo test", &ports.CommandResult{Stdout: "test\n", ExitCode: 0}).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	ctx, err := execSvc.Resume(context.Background(), "integ-parallel-001", nil, "previous")
+
+	require.NoError(t, err)
+	require.NotNil(t, ctx)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+
+	// "previous" resolves to parallel_build; both branches must re-execute.
+	// Branch commands appearing in calls proves the parallel block was re-run from scratch.
+	executedCmds := commandsExecuted(mocks)
+	assert.Contains(t, executedCmds, "echo build_a", "build_a branch must re-execute when parallel parent is resumed")
+	assert.Contains(t, executedCmds, "echo build_b", "build_b branch must re-execute when parallel parent is resumed")
+	assert.Contains(t, executedCmds, "echo test", "test must execute after parallel block completes")
+}
+
+// commandsExecuted returns the Program strings of all commands executed by the mock executor.
+func commandsExecuted(mocks *TestMocks) []string {
+	calls := mocks.Executor.GetCalls()
+	cmds := make([]string, 0, len(calls))
+	for _, c := range calls {
+		cmds = append(cmds, c.Program)
+	}
+	return cmds
+}
+
+// TestResume_FromCurrentStep tests that Resume with "current" resumes from the current step
+func TestResume_FromCurrentStep(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": {
+				Name:      "step1",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo step1",
+				OnSuccess: "step2",
+			},
+			"step2": {
+				Name:   "step2",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	now := time.Now()
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "wf-001",
+		WorkflowName: "test",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "step1",
+		States: map[string]workflow.StepState{
+			"step1": {Name: "step1", CompletedAt: now},
+		},
+		Inputs:    make(map[string]any),
+		Env:       make(map[string]string),
+		StartedAt: now,
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		WithCommandResult("echo step1", &ports.CommandResult{Stdout: "step1\n", ExitCode: 0}).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	ctx, err := execSvc.Resume(context.Background(), "wf-001", nil, "current")
+
+	require.NoError(t, err)
+	assert.NotNil(t, ctx)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+	assert.Equal(t, "step2", ctx.CurrentStep)
+}
+
+// TestResume_FromPreviousStep tests that "previous" resumes from step with latest CompletedAt before CurrentStep
+func TestResume_FromPreviousStep(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": {
+				Name:      "step1",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo 1",
+				OnSuccess: "step2",
+			},
+			"step2": {
+				Name:      "step2",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo 2",
+				OnSuccess: "step3",
+			},
+			"step3": {
+				Name:   "step3",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	now := time.Now()
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "wf-001",
+		WorkflowName: "test",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "step3", // Failed before step3 started
+		States: map[string]workflow.StepState{
+			"step1": {Name: "step1", CompletedAt: now.Add(-2 * time.Second)},
+			"step2": {Name: "step2", CompletedAt: now.Add(-1 * time.Second)},
+		},
+		Inputs:    make(map[string]any),
+		Env:       make(map[string]string),
+		StartedAt: now,
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		WithCommandResult("echo 2", &ports.CommandResult{Stdout: "2\n", ExitCode: 0}).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	// Resume from "previous" should resume from step2 (latest completed before step3)
+	ctx, err := execSvc.Resume(context.Background(), "wf-001", nil, "previous")
+
+	require.NoError(t, err)
+	assert.NotNil(t, ctx)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+}
+
+// TestResume_FromPreviousNoStateForCurrentStep tests that when CurrentStep has no StepState, "previous" uses latest CompletedAt across all states
+func TestResume_FromPreviousNoStateForCurrentStep(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": {
+				Name:      "step1",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo 1",
+				OnSuccess: "step2",
+			},
+			"step2": {
+				Name:      "step2",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo 2",
+				OnSuccess: "step3",
+			},
+			"step3": {
+				Name:   "step3",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	now := time.Now()
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "wf-001",
+		WorkflowName: "test",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "step3", // step3 has no StepState entry (failed before it started)
+		States: map[string]workflow.StepState{
+			"step1": {Name: "step1", CompletedAt: now.Add(-2 * time.Second)},
+			"step2": {Name: "step2", CompletedAt: now.Add(-1 * time.Second)},
+		},
+		Inputs:    make(map[string]any),
+		Env:       make(map[string]string),
+		StartedAt: now,
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	// Resume from "previous" should resolve to step2 despite step3 having no state
+	ctx, err := execSvc.Resume(context.Background(), "wf-001", nil, "previous")
+
+	require.NoError(t, err)
+	assert.NotNil(t, ctx)
+	// step3 is a terminal success, so workflow completes
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+}
+
+// TestResume_FromPreviousNoPriorStep tests that "previous" returns error when no completed step exists before CurrentStep
+func TestResume_FromPreviousNoPriorStep(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": {Name: "step1", Type: workflow.StepTypeCommand, Command: "echo 1"},
+		},
+	}
+
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "wf-001",
+		WorkflowName: "test",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "step1",
+		States:       make(map[string]workflow.StepState), // No completed steps
+		Inputs:       make(map[string]any),
+		Env:          make(map[string]string),
+		StartedAt:    time.Now(),
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	// Resume from "previous" should fail - no prior steps exist
+	_, err = execSvc.Resume(context.Background(), "wf-001", nil, "previous")
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no prior step")
+}
+
+// TestResume_FromLiteralStepName tests that a literal step name resumes from that step when it exists in States
+func TestResume_FromLiteralStepName(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "validate",
+		Steps: map[string]*workflow.Step{
+			"validate": {
+				Name:      "validate",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo validate",
+				OnSuccess: "end",
+			},
+			"end": {
+				Name:   "end",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	now := time.Now()
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "wf-001",
+		WorkflowName: "test",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "end",
+		States: map[string]workflow.StepState{
+			"validate": {Name: "validate", CompletedAt: now},
+		},
+		Inputs:    make(map[string]any),
+		Env:       make(map[string]string),
+		StartedAt: now,
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		WithCommandResult("echo validate", &ports.CommandResult{Stdout: "validate\n", ExitCode: 0}).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	// Resume from literal step name "validate"
+	ctx, err := execSvc.Resume(context.Background(), "wf-001", nil, "validate")
+
+	require.NoError(t, err)
+	assert.NotNil(t, ctx)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+}
+
+// TestResume_FromNonexistentStep tests that a non-existent step name returns an error
+func TestResume_FromNonexistentStep(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "start",
+		Steps: map[string]*workflow.Step{
+			"start": {Name: "start", Type: workflow.StepTypeCommand, Command: "echo start"},
+		},
+	}
+
+	now := time.Now()
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "wf-001",
+		WorkflowName: "test",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "start",
+		States: map[string]workflow.StepState{
+			"start": {Name: "start", CompletedAt: now},
+		},
+		Inputs:    make(map[string]any),
+		Env:       make(map[string]string),
+		StartedAt: now,
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	// Resume from non-existent step should fail
+	_, err = execSvc.Resume(context.Background(), "wf-001", nil, "nonexistent")
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "not found")
+}
+
+// TestResume_FromStepEqualsCurrentStep tests that resuming from a step equal to CurrentStep is equivalent to "current"
+func TestResume_FromStepEqualsCurrentStep(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "start",
+		Steps: map[string]*workflow.Step{
+			"start": {
+				Name:      "start",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo start",
+				OnSuccess: "end",
+			},
+			"end": {
+				Name:   "end",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	now := time.Now()
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "wf-001",
+		WorkflowName: "test",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "start",
+		States: map[string]workflow.StepState{
+			"start": {Name: "start", CompletedAt: now},
+		},
+		Inputs:    make(map[string]any),
+		Env:       make(map[string]string),
+		StartedAt: now,
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		WithCommandResult("echo start", &ports.CommandResult{Stdout: "start\n", ExitCode: 0}).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	// Resume from "start" (equals CurrentStep) should work like "current"
+	ctx, err := execSvc.Resume(context.Background(), "wf-001", nil, "start")
+
+	require.NoError(t, err)
+	assert.NotNil(t, ctx)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+}
+
+// TestResume_FromPreviousIdenticalCompletedAtUsesAlphabetical tests that identical CompletedAt uses alphabetical order as tiebreaker
+func TestResume_FromPreviousIdenticalCompletedAtUsesAlphabetical(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "stepA",
+		Steps: map[string]*workflow.Step{
+			"stepA": {
+				Name:      "stepA",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo A",
+				OnSuccess: "stepB",
+			},
+			"stepB": {
+				Name:      "stepB",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo B",
+				OnSuccess: "stepC",
+			},
+			"stepC": {
+				Name:   "stepC",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	now := time.Now()
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "wf-001",
+		WorkflowName: "test",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "stepC",
+		States: map[string]workflow.StepState{
+			// Both have identical CompletedAt - should use alphabetical order to select stepB
+			"stepA": {Name: "stepA", CompletedAt: now},
+			"stepB": {Name: "stepB", CompletedAt: now},
+		},
+		Inputs:    make(map[string]any),
+		Env:       make(map[string]string),
+		StartedAt: now,
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	// Resume from "previous" should select stepB (alphabetically last when times equal)
+	ctx, err := execSvc.Resume(context.Background(), "wf-001", nil, "previous")
+
+	require.NoError(t, err)
+	assert.NotNil(t, ctx)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+}
+
+// TestResume_CleanupStatesAfterTarget tests that cleanup deletes states after the target step when resuming from an earlier step
+func TestResume_CleanupStatesAfterTarget(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": {
+				Name:      "step1",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo 1",
+				OnSuccess: "step2",
+			},
+			"step2": {
+				Name:      "step2",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo 2",
+				OnSuccess: "step3",
+			},
+			"step3": {
+				Name:   "step3",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	now := time.Now()
+	// State with all 3 steps completed, but we'll resume from step1
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "wf-001",
+		WorkflowName: "test",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "step3",
+		States: map[string]workflow.StepState{
+			"step1": {Name: "step1", CompletedAt: now.Add(-2 * time.Second)},
+			"step2": {Name: "step2", CompletedAt: now.Add(-1 * time.Second)},
+			"step3": {Name: "step3", CompletedAt: now},
+		},
+		Inputs:    make(map[string]any),
+		Env:       make(map[string]string),
+		StartedAt: now,
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		WithCommandResult("echo 2", &ports.CommandResult{Stdout: "2\n", ExitCode: 0}).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	// Resume from step1 - should cleanup step3 (after step1's CompletedAt)
+	ctx, err := execSvc.Resume(context.Background(), "wf-001", nil, "step1")
+
+	require.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	// Check that step3 was cleaned up
+	finalStates := ctx.GetAllStepStates()
+	assert.NotContains(t, finalStates, "step3")
+}
+
+// TestResume_CleanupPreservesTargetStep tests that cleanup preserves the target step itself
+func TestResume_CleanupPreservesTargetStep(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": {
+				Name:      "step1",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo 1",
+				OnSuccess: "step2",
+			},
+			"step2": {
+				Name:   "step2",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	now := time.Now()
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "wf-001",
+		WorkflowName: "test",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "step2",
+		States: map[string]workflow.StepState{
+			"step1": {Name: "step1", CompletedAt: now},
+			"step2": {Name: "step2", CompletedAt: now.Add(1 * time.Second)},
+		},
+		Inputs:    make(map[string]any),
+		Env:       make(map[string]string),
+		StartedAt: now,
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	// Resume from step1 - should preserve step1 and delete step2
+	ctx, err := execSvc.Resume(context.Background(), "wf-001", nil, "step1")
+
+	require.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	// Check that step1 was preserved
+	finalStates := ctx.GetAllStepStates()
+	assert.Contains(t, finalStates, "step1")
+}
+
+// TestResume_CleanupMultipleSteps tests that cleanup removes multiple steps after target
+func TestResume_CleanupMultipleSteps(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": {
+				Name:      "step1",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo 1",
+				OnSuccess: "step2",
+			},
+			"step2": {
+				Name:      "step2",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo 2",
+				OnSuccess: "step3",
+			},
+			"step3": {
+				Name:   "step3",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	now := time.Now()
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "wf-001",
+		WorkflowName: "test",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "step3",
+		States: map[string]workflow.StepState{
+			"step1": {Name: "step1", CompletedAt: now},
+			"step2": {Name: "step2", CompletedAt: now.Add(1 * time.Second)},
+			"step3": {Name: "step3", CompletedAt: now.Add(2 * time.Second)},
+		},
+		Inputs:    make(map[string]any),
+		Env:       make(map[string]string),
+		StartedAt: now,
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	// Resume from step1 - should delete step2 and step3
+	ctx, err := execSvc.Resume(context.Background(), "wf-001", nil, "step1")
+
+	require.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	// Verify cleanup removed step2 and step3, then re-execution repopulated step1 and step2.
+	// After resume from step1: cleanup deletes step2+step3, then execution runs step1→step2→step3.
+	// Terminal steps (step3) do not produce state entries, so final states contain step1 and step2.
+	finalStates := ctx.GetAllStepStates()
+	assert.Len(t, finalStates, 2)
+	assert.Contains(t, finalStates, "step1")
+	assert.Contains(t, finalStates, "step2")
+}
+
+// TestResume_CleanupIsNoOpWhenNothingAfter tests that cleanup is a no-op when nothing is after target
+func TestResume_CleanupIsNoOpWhenNothingAfter(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "step1",
+		Steps: map[string]*workflow.Step{
+			"step1": {
+				Name:      "step1",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo 1",
+				OnSuccess: "step2",
+			},
+			"step2": {
+				Name:   "step2",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	now := time.Now()
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "wf-001",
+		WorkflowName: "test",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "step2", // No StepState for step2
+		States: map[string]workflow.StepState{
+			"step1": {Name: "step1", CompletedAt: now},
+		},
+		Inputs:    make(map[string]any),
+		Env:       make(map[string]string),
+		StartedAt: now,
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	// Resume from step1 - cleanup is no-op since nothing is after step1
+	ctx, err := execSvc.Resume(context.Background(), "wf-001", nil, "step1")
+
+	require.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	// State should remain unchanged
+	finalStates := ctx.GetAllStepStates()
+	assert.Len(t, finalStates, 1)
+	assert.Contains(t, finalStates, "step1")
+}
+
+// TestResume_BackwardsCompatibilityWithPreviousAPI tests that Resume("current") maintains backwards compatibility
+func TestResume_BackwardsCompatibilityWithPreviousAPI(t *testing.T) {
+	wf := &workflow.Workflow{
+		Name:    "test",
+		Initial: "start",
+		Steps: map[string]*workflow.Step{
+			"start": {
+				Name:      "start",
+				Type:      workflow.StepTypeCommand,
+				Command:   "echo hello",
+				OnSuccess: "end",
+			},
+			"end": {
+				Name:   "end",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	now := time.Now()
+	savedState := &workflow.ExecutionContext{
+		WorkflowID:   "wf-001",
+		WorkflowName: "test",
+		Status:       workflow.StatusRunning,
+		CurrentStep:  "start",
+		States: map[string]workflow.StepState{
+			"start": {Name: "start", CompletedAt: now},
+		},
+		Inputs:    make(map[string]any),
+		Env:       make(map[string]string),
+		StartedAt: now,
+	}
+
+	execSvc, mocks := NewTestHarness(t).
+		WithWorkflow("test", wf).
+		WithCommandResult("echo hello", &ports.CommandResult{Stdout: "hello\n", ExitCode: 0}).
+		Build()
+
+	err := mocks.StateStore.Save(context.Background(), savedState)
+	require.NoError(t, err)
+
+	// Resume with "current" should behave like old Resume without fromStep
+	ctx, err := execSvc.Resume(context.Background(), "wf-001", nil, "current")
+
+	require.NoError(t, err)
+	assert.NotNil(t, ctx)
+	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
+	assert.Equal(t, "end", ctx.CurrentStep)
+}

--- a/internal/application/execution_service_on_failure_inline_test.go
+++ b/internal/application/execution_service_on_failure_inline_test.go
@@ -325,7 +325,7 @@ func TestExecutionService_InlineOnFailure_ResumePathMessageIncluded(t *testing.T
 	err := mocks.StateStore.Save(context.Background(), savedState)
 	require.NoError(t, err)
 
-	_, resumeErr := execSvc.Resume(context.Background(), "wf-resume-001", nil)
+	_, resumeErr := execSvc.Resume(context.Background(), "wf-resume-001", nil, "current")
 
 	require.Error(t, resumeErr)
 	assert.True(t, strings.Contains(resumeErr.Error(), "Deployment failed on retry"),

--- a/internal/application/execution_service_parallel_test.go
+++ b/internal/application/execution_service_parallel_test.go
@@ -57,7 +57,7 @@ func TestExecutionService_Resume_ParallelStep(t *testing.T) {
 	})
 	require.NoError(t, err, "setup should succeed")
 
-	ctx, err := execSvc.Resume(context.Background(), "parallel-id", nil)
+	ctx, err := execSvc.Resume(context.Background(), "parallel-id", nil, "current")
 
 	require.NoError(t, err, "resume with parallel step should succeed")
 	assert.Equal(t, workflow.StatusCompleted, ctx.Status)

--- a/internal/application/execution_service_resume_test.go
+++ b/internal/application/execution_service_resume_test.go
@@ -60,7 +60,7 @@ func TestExecuteFromStep_StepNotFound(t *testing.T) {
 	err := mocks.StateStore.Save(context.Background(), savedState)
 	require.NoError(t, err)
 
-	ctx, err := execSvc.Resume(context.Background(), "wf-001", nil)
+	ctx, err := execSvc.Resume(context.Background(), "wf-001", nil, "current")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "step not found")
@@ -106,7 +106,7 @@ func TestExecuteFromStep_TerminalStepSuccess(t *testing.T) {
 	err := mocks.StateStore.Save(context.Background(), savedState)
 	require.NoError(t, err)
 
-	ctx, err := execSvc.Resume(context.Background(), "wf-002", nil)
+	ctx, err := execSvc.Resume(context.Background(), "wf-002", nil, "current")
 
 	require.NoError(t, err)
 	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
@@ -151,7 +151,7 @@ func TestExecuteFromStep_TerminalStepFailure(t *testing.T) {
 	err := mocks.StateStore.Save(context.Background(), savedState)
 	require.NoError(t, err)
 
-	ctx, err := execSvc.Resume(context.Background(), "wf-003", nil)
+	ctx, err := execSvc.Resume(context.Background(), "wf-003", nil, "current")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "terminal failure state")
@@ -204,7 +204,7 @@ func TestExecuteFromStep_ContextCancelled(t *testing.T) {
 	err := mocks.StateStore.Save(context.Background(), savedState)
 	require.NoError(t, err)
 
-	execCtx, err := execSvc.Resume(context.Background(), "wf-004", nil)
+	execCtx, err := execSvc.Resume(context.Background(), "wf-004", nil, "current")
 
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, context.Canceled))
@@ -254,7 +254,7 @@ func TestExecuteFromStep_RegularError_ClassifiesAndExecutesHook(t *testing.T) {
 	err := mocks.StateStore.Save(context.Background(), savedState)
 	require.NoError(t, err)
 
-	ctx, err := execSvc.Resume(context.Background(), "wf-005", nil)
+	ctx, err := execSvc.Resume(context.Background(), "wf-005", nil, "current")
 
 	require.Error(t, err)
 	assert.Equal(t, workflow.StatusFailed, ctx.Status)
@@ -313,7 +313,7 @@ func TestExecuteFromStep_SuccessfulCompletion_ExecutesEndHook(t *testing.T) {
 	err := mocks.StateStore.Save(context.Background(), savedState)
 	require.NoError(t, err)
 
-	ctx, err := execSvc.Resume(context.Background(), "wf-006", nil)
+	ctx, err := execSvc.Resume(context.Background(), "wf-006", nil, "current")
 
 	require.NoError(t, err)
 	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
@@ -356,7 +356,7 @@ func TestExecuteFromStep_DispatchesOperationStep(t *testing.T) {
 	err := mocks.StateStore.Save(context.Background(), savedState)
 	require.NoError(t, err)
 
-	ctx, err := execSvc.Resume(context.Background(), "wf-007", nil)
+	ctx, err := execSvc.Resume(context.Background(), "wf-007", nil, "current")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "operation provider not configured")
@@ -412,7 +412,7 @@ func TestExecuteFromStep_DispatchesParallelStep(t *testing.T) {
 	err := mocks.StateStore.Save(context.Background(), savedState)
 	require.NoError(t, err)
 
-	ctx, err := execSvc.Resume(context.Background(), "wf-008", nil)
+	ctx, err := execSvc.Resume(context.Background(), "wf-008", nil, "current")
 
 	require.NoError(t, err)
 	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
@@ -464,7 +464,7 @@ func TestExecuteFromStep_DispatchesLoopStep(t *testing.T) {
 	err := mocks.StateStore.Save(context.Background(), savedState)
 	require.NoError(t, err)
 
-	ctx, err := execSvc.Resume(context.Background(), "wf-009", nil)
+	ctx, err := execSvc.Resume(context.Background(), "wf-009", nil, "current")
 
 	require.NoError(t, err)
 	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
@@ -527,7 +527,7 @@ func TestExecuteFromStep_DispatchesCallWorkflowStep(t *testing.T) {
 	err := mocks.StateStore.Save(context.Background(), savedState)
 	require.NoError(t, err)
 
-	ctx, err := execSvc.Resume(context.Background(), "wf-010", nil)
+	ctx, err := execSvc.Resume(context.Background(), "wf-010", nil, "current")
 
 	require.NoError(t, err)
 	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
@@ -572,7 +572,7 @@ func TestExecuteFromStep_DispatchesAgentStep(t *testing.T) {
 	err := mocks.StateStore.Save(context.Background(), savedState)
 	require.NoError(t, err)
 
-	ctx, err := execSvc.Resume(context.Background(), "wf-011", nil)
+	ctx, err := execSvc.Resume(context.Background(), "wf-011", nil, "current")
 
 	// This test verifies that executeFromStep dispatches to executeAgentStep
 	require.Error(t, err)
@@ -616,7 +616,7 @@ func TestExecuteFromStep_DispatchesDefaultCommandStep(t *testing.T) {
 	err := mocks.StateStore.Save(context.Background(), savedState)
 	require.NoError(t, err)
 
-	ctx, err := execSvc.Resume(context.Background(), "wf-012", nil)
+	ctx, err := execSvc.Resume(context.Background(), "wf-012", nil, "current")
 
 	require.NoError(t, err)
 	assert.Equal(t, workflow.StatusCompleted, ctx.Status)
@@ -666,7 +666,7 @@ func TestExecuteFromStep_CheckpointsAfterEachStep(t *testing.T) {
 	err := mocks.StateStore.Save(context.Background(), savedState)
 	require.NoError(t, err)
 
-	ctx, err := execSvc.Resume(context.Background(), "wf-013", nil)
+	ctx, err := execSvc.Resume(context.Background(), "wf-013", nil, "current")
 
 	require.NoError(t, err)
 	assert.Equal(t, workflow.StatusCompleted, ctx.Status)

--- a/internal/application/plugin_operation_test.go
+++ b/internal/application/plugin_operation_test.go
@@ -579,7 +579,7 @@ func TestExecutionService_Resume_WithOperationStep(t *testing.T) {
 	)
 	execSvc.SetOperationProvider(provider)
 
-	ctx, err := execSvc.Resume(context.Background(), "test-id", nil)
+	ctx, err := execSvc.Resume(context.Background(), "test-id", nil, "current")
 
 	// Should succeed after resuming at the operation step
 	require.NoError(t, err)

--- a/internal/domain/workflow/context.go
+++ b/internal/domain/workflow/context.go
@@ -117,6 +117,16 @@ func (c *ExecutionContext) SetStepState(stepName string, state StepState) { //no
 	c.UpdatedAt = time.Now()
 }
 
+// DeleteStepState removes the state of a step if it exists; no-op on missing key.
+func (c *ExecutionContext) DeleteStepState(stepName string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.States[stepName]; ok {
+		delete(c.States, stepName)
+		c.UpdatedAt = time.Now()
+	}
+}
+
 // GetStepState retrieves the state of a step.
 func (c *ExecutionContext) GetStepState(stepName string) (StepState, bool) {
 	c.mu.RLock()

--- a/internal/domain/workflow/context_test.go
+++ b/internal/domain/workflow/context_test.go
@@ -1259,3 +1259,225 @@ func TestExecutionContext_MultipleSteps_DataIsolation(t *testing.T) {
 	assert.Equal(t, "data-1", retrieved1.Data["unique"])
 	assert.Equal(t, "data-2", retrieved2.Data["unique"])
 }
+
+// DeleteStepState tests (T001)
+
+func TestDeleteStepState_RemovesExistingStep(t *testing.T) {
+	ctx := workflow.NewExecutionContext("test-id", "test-wf")
+
+	state := workflow.StepState{
+		Name:   "build",
+		Status: workflow.StatusCompleted,
+		Output: "built successfully",
+	}
+
+	ctx.SetStepState("build", state)
+	_, exists := ctx.GetStepState("build")
+	require.True(t, exists, "step should exist after SetStepState")
+
+	ctx.DeleteStepState("build")
+
+	_, exists = ctx.GetStepState("build")
+	assert.False(t, exists, "step should not exist after DeleteStepState")
+}
+
+func TestDeleteStepState_UpdatesTimestampWhenKeyExists(t *testing.T) {
+	ctx := workflow.NewExecutionContext("test-id", "test-wf")
+
+	state := workflow.StepState{
+		Name:   "build",
+		Status: workflow.StatusCompleted,
+	}
+
+	ctx.SetStepState("build", state)
+	initialUpdate := ctx.UpdatedAt
+
+	time.Sleep(time.Millisecond)
+	ctx.DeleteStepState("build")
+
+	assert.True(t, ctx.UpdatedAt.After(initialUpdate), "UpdatedAt should be updated after deleting existing step")
+}
+
+func TestDeleteStepState_NonexistentStepIsNoop(t *testing.T) {
+	ctx := workflow.NewExecutionContext("test-id", "test-wf")
+
+	assert.NotPanics(t, func() {
+		ctx.DeleteStepState("nonexistent")
+	}, "DeleteStepState should not panic on nonexistent key")
+}
+
+// TestDeleteStepState_NonexistentStepDoesNotUpdateTimestamp verifies that deleting a
+// nonexistent key is a strict no-op: neither the timestamp nor the map changes.
+// This test passes against the stub (which is also a no-op) — that is expected and
+// intentional: a "nothing should happen" assertion cannot be made RED against a stub
+// that does nothing. The complementary RED tests are TestDeleteStepState_UpdatesTimestampWhenKeyExists
+// and TestDeleteStepState_RemovesExistingStep, which verify the positive side.
+func TestDeleteStepState_NonexistentStepDoesNotUpdateTimestamp(t *testing.T) {
+	ctx := workflow.NewExecutionContext("test-id", "test-wf")
+	// Pre-populate a different key to prove the context is fully initialized.
+	ctx.SetStepState("other-step", workflow.StepState{Name: "other-step", Status: workflow.StatusCompleted})
+	initialUpdate := ctx.UpdatedAt
+
+	time.Sleep(time.Millisecond)
+	ctx.DeleteStepState("nonexistent")
+
+	// Timestamp must not advance.
+	assert.Equal(t, initialUpdate, ctx.UpdatedAt, "UpdatedAt should not change when deleting nonexistent step")
+	// Unrelated keys must be unaffected.
+	_, otherExists := ctx.GetStepState("other-step")
+	assert.True(t, otherExists, "other-step must remain after no-op deletion")
+}
+
+func TestDeleteStepState_ReturnZeroValueOnGetAfterDelete(t *testing.T) {
+	ctx := workflow.NewExecutionContext("test-id", "test-wf")
+
+	state := workflow.StepState{
+		Name:      "build",
+		Status:    workflow.StatusCompleted,
+		Output:    "success",
+		ExitCode:  0,
+		Attempt:   1,
+		StartedAt: time.Now(),
+	}
+
+	ctx.SetStepState("build", state)
+	ctx.DeleteStepState("build")
+
+	retrieved, exists := ctx.GetStepState("build")
+	assert.False(t, exists, "exists should be false after deletion")
+
+	zeroState := workflow.StepState{}
+	assert.Equal(t, zeroState, retrieved, "retrieved state should be zero-value")
+}
+
+func TestDeleteStepState_MutexProtection(t *testing.T) {
+	ctx := workflow.NewExecutionContext("test-id", "test-wf")
+
+	state := workflow.StepState{
+		Name:   "build",
+		Status: workflow.StatusCompleted,
+	}
+
+	ctx.SetStepState("build", state)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx.DeleteStepState("build")
+		}()
+	}
+
+	wg.Wait()
+
+	_, exists := ctx.GetStepState("build")
+	assert.False(t, exists, "step should be deleted after concurrent DeleteStepState calls")
+}
+
+func TestDeleteStepState_TableDriven(t *testing.T) {
+	tests := []struct {
+		name              string
+		stepName          string
+		shouldExistBefore bool
+		shouldUpdateTime  bool
+	}{
+		{
+			name:              "delete existing step updates timestamp",
+			stepName:          "existing-step",
+			shouldExistBefore: true,
+			shouldUpdateTime:  true,
+		},
+		{
+			name:              "delete nonexistent step does not update timestamp",
+			stepName:          "nonexistent-step",
+			shouldExistBefore: false,
+			shouldUpdateTime:  false,
+		},
+		{
+			name:              "delete another existing step",
+			stepName:          "compile",
+			shouldExistBefore: true,
+			shouldUpdateTime:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := workflow.NewExecutionContext("test-id", "test-wf")
+			initialUpdate := ctx.UpdatedAt
+
+			if tt.shouldExistBefore {
+				state := workflow.StepState{
+					Name:   tt.stepName,
+					Status: workflow.StatusCompleted,
+				}
+				ctx.SetStepState(tt.stepName, state)
+				initialUpdate = ctx.UpdatedAt
+			}
+
+			time.Sleep(time.Millisecond)
+			ctx.DeleteStepState(tt.stepName)
+
+			_, exists := ctx.GetStepState(tt.stepName)
+			assert.False(t, exists, "step should not exist after deletion")
+
+			if tt.shouldUpdateTime {
+				assert.True(t, ctx.UpdatedAt.After(initialUpdate), "UpdatedAt should be updated for existing step deletion")
+			} else {
+				assert.Equal(t, initialUpdate, ctx.UpdatedAt, "UpdatedAt should not change for nonexistent step deletion")
+			}
+		})
+	}
+}
+
+func TestDeleteStepState_MultipleSteps(t *testing.T) {
+	ctx := workflow.NewExecutionContext("test-id", "test-wf")
+
+	step1 := workflow.StepState{Name: "step-1", Status: workflow.StatusCompleted}
+	step2 := workflow.StepState{Name: "step-2", Status: workflow.StatusCompleted}
+	step3 := workflow.StepState{Name: "step-3", Status: workflow.StatusCompleted}
+
+	ctx.SetStepState("step-1", step1)
+	ctx.SetStepState("step-2", step2)
+	ctx.SetStepState("step-3", step3)
+
+	ctx.DeleteStepState("step-2")
+
+	_, exists1 := ctx.GetStepState("step-1")
+	_, exists2 := ctx.GetStepState("step-2")
+	_, exists3 := ctx.GetStepState("step-3")
+
+	assert.True(t, exists1, "step-1 should still exist")
+	assert.False(t, exists2, "step-2 should be deleted")
+	assert.True(t, exists3, "step-3 should still exist")
+}
+
+func TestDeleteStepState_DeleteThenRecreate(t *testing.T) {
+	ctx := workflow.NewExecutionContext("test-id", "test-wf")
+
+	state := workflow.StepState{
+		Name:   "build",
+		Status: workflow.StatusCompleted,
+		Output: "original",
+	}
+
+	ctx.SetStepState("build", state)
+	ctx.DeleteStepState("build")
+
+	_, exists := ctx.GetStepState("build")
+	assert.False(t, exists, "step should be deleted")
+
+	newState := workflow.StepState{
+		Name:   "build",
+		Status: workflow.StatusRunning,
+		Output: "recreated",
+	}
+
+	ctx.SetStepState("build", newState)
+	retrieved, exists := ctx.GetStepState("build")
+
+	assert.True(t, exists, "step should exist after recreation")
+	assert.Equal(t, workflow.StatusRunning, retrieved.Status)
+	assert.Equal(t, "recreated", retrieved.Output)
+}

--- a/internal/interfaces/cli/resume.go
+++ b/internal/interfaces/cli/resume.go
@@ -36,7 +36,10 @@ Input overrides can be provided to change input values on resume.
 Examples:
   awf resume --list
   awf resume abc123-def456
-  awf resume abc123-def456 --input max_tokens=5000`,
+  awf resume abc123-def456 --input max_tokens=5000
+  awf resume abc123-def456 --from current
+  awf resume abc123-def456 --from previous
+  awf resume abc123-def456 --from validate`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if listFlag {
@@ -59,6 +62,7 @@ Examples:
 	cmd.Flags().BoolVarP(&listFlag, "list", "l", false, "List resumable workflows")
 	cmd.Flags().StringArrayVarP(&inputFlags, "input", "i", nil, "Override input parameter (key=value)")
 	cmd.Flags().StringVarP(&outputMode, "output", "o", "silent", "Output mode: silent, streaming, buffered")
+	cmd.Flags().String("from", "current", "Step to resume from: current (default), previous, or <step-name>")
 
 	return cmd
 }
@@ -237,8 +241,10 @@ func runResume(cmd *cobra.Command, cfg *Config, workflowID string, inputFlags []
 	}
 	startTime := time.Now()
 
+	fromStep, _ := cmd.Flags().GetString("from") //nolint:errcheck // flag registered on this command; GetString cannot fail
+
 	// Resume execution
-	execCtx, execErr := execSvc.Resume(ctx, workflowID, inputs)
+	execCtx, execErr := execSvc.Resume(ctx, workflowID, inputs, fromStep)
 
 	// Flush streaming writers
 	if stdoutWriter != nil {

--- a/internal/interfaces/cli/resume_test.go
+++ b/internal/interfaces/cli/resume_test.go
@@ -1143,6 +1143,86 @@ states:
 	require.NoError(t, err, "resume should succeed with commented config")
 }
 
+// TestResumeCommand_HasFromFlag verifies --from flag is registered with default "current".
+func TestResumeCommand_HasFromFlag(t *testing.T) {
+	cmd := cli.NewRootCommand()
+
+	for _, sub := range cmd.Commands() {
+		if sub.Name() != "resume" {
+			continue
+		}
+		flag := sub.Flags().Lookup("from")
+		require.NotNil(t, flag, "expected 'resume' command to have --from flag")
+		assert.Equal(t, "current", flag.DefValue, "--from flag default must be \"current\"")
+		assert.Equal(t, "", flag.Shorthand, "--from must have no shorthand (-f is reserved for root --format)")
+		return
+	}
+
+	t.Error("resume command not found")
+}
+
+// TestResumeCommand_Help_ShowsFromFlag verifies --help output describes the --from flag
+// with references to current, previous, and step name options.
+func TestResumeCommand_Help_ShowsFromFlag(t *testing.T) {
+	cmd := cli.NewRootCommand()
+
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"resume", "--help"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "--from", "help must show --from flag")
+	assert.Contains(t, output, "current", "help description must mention 'current'")
+	assert.Contains(t, output, "previous", "help description must mention 'previous'")
+}
+
+// TestResumeCommand_FromPreviousFlag_AcceptedByCLI verifies the CLI does not reject --from previous.
+// Validation of the value belongs to the application layer (resolveFromStep), not CLI.
+func TestResumeCommand_FromPreviousFlag_AcceptedByCLI(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	statesDir := filepath.Join(tmpDir, "states")
+	require.NoError(t, os.MkdirAll(statesDir, 0o755))
+
+	cmd := cli.NewRootCommand()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	// No workflow state exists — command should fail at application layer, not flag parsing
+	cmd.SetArgs([]string{"--storage=" + tmpDir, "resume", "nonexistent-id", "--from", "previous"})
+
+	err := cmd.Execute()
+	// Must fail at application layer (workflow not found), never with "unknown flag" error
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "unknown flag", "--from previous must not be rejected by CLI flag parsing")
+	assert.NotContains(t, err.Error(), "flag provided but not defined", "--from must be a defined flag")
+}
+
+// TestResumeCommand_FromStepNameFlag_AcceptedByCLI verifies the CLI passes arbitrary step names through
+// to the application layer without transformation (FR-009).
+func TestResumeCommand_FromStepNameFlag_AcceptedByCLI(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	statesDir := filepath.Join(tmpDir, "states")
+	require.NoError(t, os.MkdirAll(statesDir, 0o755))
+
+	cmd := cli.NewRootCommand()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	// Non-existent workflow — fails at application layer, not CLI flag parsing
+	cmd.SetArgs([]string{"--storage=" + tmpDir, "resume", "nonexistent-id", "--from", "validate"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "unknown flag", "--from <step-name> must not be rejected by CLI flag parsing")
+	assert.NotContains(t, err.Error(), "flag provided but not defined", "--from must be a defined flag")
+}
+
 // TestResumeCommand_ConfigEmptyInputs tests behavior with empty inputs section.
 func TestResumeCommand_ConfigEmptyInputs(t *testing.T) {
 	tmpDir := setupTestDir(t)

--- a/tests/integration/execution/resume_test.go
+++ b/tests/integration/execution/resume_test.go
@@ -157,7 +157,7 @@ states:
 	defer cancel()
 
 	// Resume execution
-	resumedCtx, err := execSvc.Resume(ctx, "interrupted-id-123", nil)
+	resumedCtx, err := execSvc.Resume(ctx, "interrupted-id-123", nil, "current")
 
 	require.NoError(t, err, "resume should succeed")
 	assert.Equal(t, workflow.StatusCompleted, resumedCtx.Status)
@@ -347,7 +347,7 @@ states:
 
 	// Resume with overridden input
 	overrides := map[string]any{"message": "overridden-message"}
-	resumedCtx, err := execSvc.Resume(ctx, "override-id", overrides)
+	resumedCtx, err := execSvc.Resume(ctx, "override-id", overrides, "current")
 
 	require.NoError(t, err)
 	assert.Equal(t, workflow.StatusCompleted, resumedCtx.Status)
@@ -424,7 +424,7 @@ states:
 	require.NoError(t, stateStore.Save(ctx, failedState))
 
 	// Resume - this time the step should succeed
-	resumedCtx, err := execSvc.Resume(ctx, "failed-id", nil)
+	resumedCtx, err := execSvc.Resume(ctx, "failed-id", nil, "current")
 
 	require.NoError(t, err, "resume of failed workflow should succeed")
 	assert.Equal(t, workflow.StatusCompleted, resumedCtx.Status)
@@ -489,7 +489,7 @@ states:
 	require.NoError(t, stateStore.Save(ctx, staleState))
 
 	// Resume should fail because step2 doesn't exist
-	_, err := execSvc.Resume(ctx, "stale-id", nil)
+	_, err := execSvc.Resume(ctx, "stale-id", nil, "current")
 
 	require.Error(t, err, "resume should fail when step no longer exists")
 	assert.Contains(t, err.Error(), "step2", "error should mention missing step")
@@ -561,7 +561,7 @@ states:
 	require.NoError(t, stateStore.Save(ctx, interruptedState))
 
 	// Resume
-	resumedCtx, err := execSvc.Resume(ctx, "parallel-id", nil)
+	resumedCtx, err := execSvc.Resume(ctx, "parallel-id", nil, "current")
 
 	require.NoError(t, err, "resume with parallel step should succeed")
 	assert.Equal(t, workflow.StatusCompleted, resumedCtx.Status)

--- a/tests/integration/execution/signal_test.go
+++ b/tests/integration/execution/signal_test.go
@@ -386,7 +386,7 @@ func TestSignalHandling_ResumabilityAfterInterruption(t *testing.T) {
 			require.Equal(t, workflow.StatusCancelled, execCtx1.Status)
 
 			ctx2 := context.Background()
-			execCtx2, err := svc.Resume(ctx2, execCtx1.WorkflowID, nil)
+			execCtx2, err := svc.Resume(ctx2, execCtx1.WorkflowID, nil, "current")
 
 			if tt.wantErr {
 				require.Error(t, err)


### PR DESCRIPTION
## Summary

- Add `--from` flag to `awf resume` enabling users to jump back to a previous step or a specific named step before re-executing, rather than always retrying only the failed step
- Introduce `resolveFromStep` logic supporting three modes: `current` (default, backward compatible), `previous` (last completed step by timestamp), and an explicit step name from execution history
- Automatically clean up step states that occurred after the target step (`cleanupStatesAfter`) and persist the trimmed state atomically before re-execution begins
- Extend `ExecutionContext` with `GetAllStepStates` / `DeleteStepState` accessors required by the cleanup and resolution logic

## Changes

### Application — Core Logic
- `internal/application/execution_service.go`: Add `fromStep string` parameter to `Resume`, wire `resolveFromStep` and `cleanupStatesAfter` helpers, update step numbering in existing flow

### Domain
- `internal/domain/workflow/context.go`: Add `GetAllStepStates` (returns a defensive copy) and `DeleteStepState` methods to `ExecutionContext`
- `internal/domain/workflow/context_test.go`: Unit tests for both new accessors covering concurrent-safety semantics and edge cases

### CLI
- `internal/interfaces/cli/resume.go`: Register `--from` flag, default to `"current"`, pass value to `ExecutionService.Resume`
- `internal/interfaces/cli/resume_test.go`: CLI-level tests for `--from` flag parsing and propagation

### Tests
- `internal/application/execution_service_from_step_test.go`: New 959-line test file covering `--from previous`, `--from <step-name>`, cleanup verification, error cases (no prior step, unknown step name), and end-to-end integration scenarios
- `internal/application/execution_service_core_test.go`: Update all existing `Resume` call sites to pass `"current"` as the new `fromStep` argument
- `internal/application/execution_service_resume_test.go`: Same signature update
- `internal/application/agent_step_test.go`: Same signature update
- `internal/application/execution_service_on_failure_inline_test.go`: Same signature update
- `internal/application/execution_service_parallel_test.go`: Same signature update
- `internal/application/plugin_operation_test.go`: Same signature update
- `tests/integration/execution/resume_test.go`: Same signature update
- `tests/integration/execution/signal_test.go`: Same signature update

### Documentation
- `README.md`: Update `awf resume` entry to document `--from` flag and its three values
- `docs/user-guide/commands.md`: Add `--from` flag reference table, state cleanup behavior section, expanded examples, and error handling table

### Project
- `CLAUDE.md`: Add review standard requiring `make build`, `make lint`, and `make test` to pass before marking implementation complete

## Test plan

- [x] `awf resume <id>` without `--from` behaves identically to pre-F093 (resumes from `current` step)
- [x] `awf resume <id> --from previous` re-executes the last completed step and all subsequent steps
- [x] `awf resume <id> --from <step-name>` resets state to that step and re-executes forward
- [x] `make test` passes with zero failures, including the new `execution_service_from_step_test.go` suite

Closes #336

---
Generated with [awf](https://github.com/awf-project/cli) commit workflow
