### PR TITLE
fix(copilot): add `dangerously_skip_permissions` alias for `--allow-all`

### DIFF
--- a/internal/infrastructure/agents/copilot_provider.go
+++ b/internal/infrastructure/agents/copilot_provider.go
@@ -136,6 +136,9 @@ func appendCopilotOptions(args []string, options map[string]any) []string {
 	}
 	if allow, ok := getBoolOption(options, "allow_all"); ok && allow {
 		args = append(args, "--allow-all")
+	} else if skip, ok := getBoolOption(options, "dangerously_skip_permissions"); ok && skip {
+		// Alias for cross-provider compatibility: dangerously_skip_permissions maps to --allow-all
+		args = append(args, "--allow-all")
 	}
 	return args
 }

--- a/internal/infrastructure/agents/copilot_provider_unit_test.go
+++ b/internal/infrastructure/agents/copilot_provider_unit_test.go
@@ -91,6 +91,13 @@ func TestCopilotProvider_Execute_WithOptions(t *testing.T) {
 			wantCLIArgs: []string{"-p", "test", "--output-format=json", "--silent", "--allow-all"},
 		},
 		{
+			name:        "dangerously_skip_permissions alias",
+			prompt:      "test",
+			options:     map[string]any{"dangerously_skip_permissions": true},
+			mockStdout:  `{"type":"assistant.message","data":{"content":"code","messageId":"m1"}}` + "\n" + `{"type":"result","sessionId":"s1","exitCode":0}`,
+			wantCLIArgs: []string{"-p", "test", "--output-format=json", "--silent", "--allow-all"},
+		},
+		{
 			name:        "unknown options silently ignored",
 			prompt:      "test",
 			options:     map[string]any{"language": "python", "quiet": true},
@@ -475,6 +482,42 @@ func TestCopilotProvider_DeniedToolsMultiple(t *testing.T) {
 	args := calls[0].Args
 	assert.Contains(t, args, "--deny-tool=bash")
 	assert.Contains(t, args, "--deny-tool=python")
+}
+
+func TestCopilotProvider_DangerouslySkipPermissions_AllowAllTakesPrecedence(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	mockExec.SetOutput([]byte("{\"type\":\"assistant.message\",\"data\":{\"content\":\"code\",\"messageId\":\"m1\"}}\n{\"type\":\"result\",\"sessionId\":\"s1\",\"exitCode\":0}"), nil)
+	provider := NewCopilotProviderWithOptions(WithCopilotExecutor(mockExec))
+
+	options := map[string]any{"allow_all": true, "dangerously_skip_permissions": true}
+	_, err := provider.Execute(context.Background(), "test", options, nil, nil)
+
+	require.NoError(t, err)
+	calls := mockExec.GetCalls()
+	require.Len(t, calls, 1)
+	args := calls[0].Args
+	// allow_all takes precedence; --allow-all should appear exactly once
+	count := 0
+	for _, a := range args {
+		if a == "--allow-all" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "--allow-all should appear exactly once when both options are set")
+}
+
+func TestCopilotProvider_DangerouslySkipPermissions_FalseOmitsFlag(t *testing.T) {
+	mockExec := mocks.NewMockCLIExecutor()
+	mockExec.SetOutput([]byte("{\"type\":\"assistant.message\",\"data\":{\"content\":\"code\",\"messageId\":\"m1\"}}\n{\"type\":\"result\",\"sessionId\":\"s1\",\"exitCode\":0}"), nil)
+	provider := NewCopilotProviderWithOptions(WithCopilotExecutor(mockExec))
+
+	options := map[string]any{"dangerously_skip_permissions": false}
+	_, err := provider.Execute(context.Background(), "test", options, nil, nil)
+
+	require.NoError(t, err)
+	calls := mockExec.GetCalls()
+	require.Len(t, calls, 1)
+	assert.NotContains(t, calls[0].Args, "--allow-all")
 }
 
 func TestCopilotProvider_AllowAllFalseOmitsFlag(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `dangerously_skip_permissions` as a cross-provider alias for `allow_all` in the Copilot provider, mapping it to the `--allow-all` CLI flag
- Ensures workflows using the Claude-style `dangerously_skip_permissions` option work without modification when targeting Copilot, improving provider portability
- When both `allow_all` and `dangerously_skip_permissions` are set, `allow_all` takes precedence and `--allow-all` appears exactly once in the CLI args

## Changes

### Infrastructure
- `internal/infrastructure/agents/copilot_provider.go`: Add `else if` branch in `appendCopilotOptions` to handle `dangerously_skip_permissions` as an alias for `--allow-all`

### Tests
- `internal/infrastructure/agents/copilot_provider_unit_test.go`: Add table-driven test case for `dangerously_skip_permissions` alias, plus two dedicated tests — one verifying `allow_all` takes precedence (deduplication), one verifying `false` value omits the flag

## Test plan

- [x] `make test-unit` passes with no failures
- [x] Run a Copilot workflow with `dangerously_skip_permissions: true` and confirm `--allow-all` is passed to the CLI
- [x] Run with both `allow_all: true` and `dangerously_skip_permissions: true` and confirm `--allow-all` appears exactly once
- [x] Run with `dangerously_skip_permissions: false` and confirm `--allow-all` is absent from CLI args

---
Generated with [awf](https://github.com/awf-project/cli) commit workflow
