### PR TITLE
fix(registry): handle v-prefixed and dirty git versions in version checks

### DIFF
--- a/internal/infrastructure/workflowpkg/manifest_test.go
+++ b/internal/infrastructure/workflowpkg/manifest_test.go
@@ -158,7 +158,6 @@ func TestValidate_InvalidVersion(t *testing.T) {
 		invalidVersion string
 	}{
 		{name: "not semver", invalidVersion: "1.0"},
-		{name: "contains v prefix", invalidVersion: "v1.0.0"},
 		{name: "non-numeric", invalidVersion: "abc.def.ghi"},
 		{name: "empty string", invalidVersion: ""},
 	}

--- a/internal/interfaces/cli/workflow_cmd.go
+++ b/internal/interfaces/cli/workflow_cmd.go
@@ -330,8 +330,12 @@ func extractPackName(ownerRepo string) string {
 
 // effectiveCLIVersion returns Version, substituting a valid semver for "dev" builds
 // so version constraint checks (packs, plugins) work correctly outside production releases.
+// Also handles non-parseable git describe output (e.g., "v0.8.1-3-gabcdef-dirty").
 func effectiveCLIVersion() string {
 	if strings.HasPrefix(Version, "dev") {
+		return "999.0.0"
+	}
+	if _, err := registry.ParseVersion(Version); err != nil {
 		return "999.0.0"
 	}
 	return Version

--- a/internal/interfaces/cli/workflow_cmd_test.go
+++ b/internal/interfaces/cli/workflow_cmd_test.go
@@ -780,6 +780,10 @@ func TestEffectiveCLIVersion_DevPrefix(t *testing.T) {
 		{"dev dirty", "dev-abc123-dirty", "999.0.0"},
 		{"real version", "1.2.3", "1.2.3"},
 		{"pre-release", "1.0.0-rc1", "1.0.0-rc1"},
+		{"v-prefixed version", "v0.8.1", "v0.8.1"},
+		{"v-prefixed dirty", "v0.8.1-dirty", "v0.8.1-dirty"},
+		{"git describe with commits", "v0.8.1-3-gabcdef", "999.0.0"},
+		{"git describe dirty with commits", "v0.8.1-3-gabcdef-dirty", "999.0.0"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/registry/version.go
+++ b/pkg/registry/version.go
@@ -171,12 +171,13 @@ func (cs Constraints) String() string {
 }
 
 // ParseVersion parses a version string into a Version struct.
-// Accepts formats: "1.0.0", "1.0.0-alpha.1"
+// Accepts formats: "1.0.0", "1.0.0-alpha.1", "v1.0.0", "v1.0.0-alpha.1"
 func ParseVersion(s string) (Version, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return Version{}, errors.New("version: empty string")
 	}
+	s = strings.TrimPrefix(s, "v")
 
 	matches := versionRegex.FindStringSubmatch(s)
 	if matches == nil {

--- a/pkg/registry/version_test.go
+++ b/pkg/registry/version_test.go
@@ -37,6 +37,21 @@ func TestParseVersion(t *testing.T) {
 			want:  registry.Version{Major: 2, Minor: 0, Patch: 0, Prerelease: "rc.1+build.123"},
 		},
 		{
+			name:  "v prefix stripped",
+			input: "v1.2.3",
+			want:  registry.Version{Major: 1, Minor: 2, Patch: 3, Prerelease: ""},
+		},
+		{
+			name:  "v prefix with prerelease",
+			input: "v0.8.1-dirty",
+			want:  registry.Version{Major: 0, Minor: 8, Patch: 1, Prerelease: "dirty"},
+		},
+		{
+			name:  "v prefix with complex prerelease",
+			input: "v2.0.0-rc.1",
+			want:  registry.Version{Major: 2, Minor: 0, Patch: 0, Prerelease: "rc.1"},
+		},
+		{
 			name:    "invalid format - missing patch",
 			input:   "1.2",
 			wantErr: true,
@@ -551,6 +566,24 @@ func TestCheckVersionConstraint(t *testing.T) {
 			constraintStr: ">=1.0.0",
 			versionStr:    "invalid",
 			wantErr:       true,
+		},
+		{
+			name:          "v-prefixed version in range",
+			constraintStr: ">=0.8.0",
+			versionStr:    "v0.8.1",
+			want:          true,
+		},
+		{
+			name:          "v-prefixed dirty version in range",
+			constraintStr: ">=0.8.0",
+			versionStr:    "v0.8.1-dirty",
+			want:          true,
+		},
+		{
+			name:          "v-prefixed dirty version prerelease less than release",
+			constraintStr: ">=0.8.1",
+			versionStr:    "v0.8.1-dirty",
+			want:          false,
 		},
 	}
 

--- a/tests/integration/features/execution_order_determinism_test.go
+++ b/tests/integration/features/execution_order_determinism_test.go
@@ -398,8 +398,8 @@ func TestNextDefaultStep_ResolvesDefaultTransition(t *testing.T) {
 			expected: "",
 		},
 		{
-			name: "handles nil step gracefully",
-			step: nil,
+			name:     "handles nil step gracefully",
+			step:     nil,
 			expected: "",
 		},
 	}


### PR DESCRIPTION
## Summary

- Fix version constraint checks failing for CLI binaries built from git tags (`v0.8.1`) or intermediate commits (`v0.8.1-3-gabcdef-dirty`) — these are valid states during development but were rejected by the version parser
- `ParseVersion` now strips a leading `v` prefix before parsing, aligning with the common convention that git tags use `v`-prefixed semver
- `effectiveCLIVersion` falls back to `999.0.0` for any unparseable version string (e.g. `git describe` output with commit distance and hash), preventing plugin/pack version checks from hard-failing on dirty dev builds

## Changes

### Version Parsing
- `pkg/registry/version.go`: Strip leading `v` prefix in `ParseVersion` before regex match; update doc comment to reflect accepted formats
- `pkg/registry/version_test.go`: Add `ParseVersion` cases for `v`-prefixed plain, prerelease, and complex prerelease versions; add `CheckVersionConstraint` cases for `v`-prefixed and dirty versions

### CLI Version Handling
- `internal/interfaces/cli/workflow_cmd.go`: Extend `effectiveCLIVersion` to fall back to `999.0.0` when `ParseVersion` fails (covers `git describe` output like `v0.8.1-3-gabcdef-dirty`)
- `internal/interfaces/cli/workflow_cmd_test.go`: Add test cases for `v`-prefixed, `v`-prefixed dirty, and `git describe`-style version strings

### Test Fixtures
- `internal/infrastructure/workflowpkg/manifest_test.go`: Remove the `v`-prefixed invalid version test case — `v1.0.0` is now a valid input
- `tests/integration/features/execution_order_determinism_test.go`: Fix whitespace alignment in a test case struct literal

## Test plan

- [x] `make test` passes with no failures, including updated `TestParseVersion`, `TestCheckVersionConstraint`, and `TestEffectiveCLIVersion_DevPrefix`
- [x] Build a binary from a `v`-tagged commit and confirm plugin/pack version checks succeed: `awf run <workflow>`
- [x] Simulate a dirty intermediate build by setting `Version = "v0.8.1-3-gabcdef-dirty"` and confirm `effectiveCLIVersion()` returns `999.0.0`
- [x] `make lint` passes with zero violations

---
Generated with [awf](https://github.com/awf-project/cli) commit workflow
