### PR TITLE
fix(graph): handle loop body steps in graph traversal

### DIFF
--- a/internal/domain/workflow/graph.go
+++ b/internal/domain/workflow/graph.go
@@ -239,7 +239,8 @@ func formatCyclePath(path []string) string {
 }
 
 // NextDefaultStep returns the next step name following the default (unconditional) path.
-// Checks Transitions for an entry with empty When first; falls back to OnSuccess.
+// Checks Transitions for an entry with empty When first; for loop steps falls back to
+// Loop.OnComplete; otherwise falls back to OnSuccess.
 func NextDefaultStep(step *Step) string {
 	if step == nil {
 		return ""
@@ -249,11 +250,16 @@ func NextDefaultStep(step *Step) string {
 			return tr.Goto
 		}
 	}
+	if step.Loop != nil && step.Loop.OnComplete != "" {
+		return step.Loop.OnComplete
+	}
 	return step.OnSuccess
 }
 
 // ExecutionOrder returns steps in default-path order by walking the graph from Initial,
 // following default transitions (empty When) and falling back to OnSuccess.
+// For loop steps (for_each/while), body steps are included inline before continuing
+// to the loop's on_complete target.
 // Stops at terminal steps, visited steps (cycle prevention), or missing references.
 func ExecutionOrder(wf *Workflow) []Step {
 	if wf == nil || len(wf.Steps) == 0 || wf.Initial == "" {
@@ -275,6 +281,22 @@ func ExecutionOrder(wf *Workflow) []Step {
 		if step.Type == StepTypeTerminal {
 			break
 		}
+
+		// For loop steps, include body steps inline
+		if step.Loop != nil {
+			for _, bodyName := range step.Loop.Body {
+				if visited[bodyName] {
+					continue
+				}
+				bodyStep, exists := wf.Steps[bodyName]
+				if !exists {
+					continue
+				}
+				visited[bodyName] = true
+				steps = append(steps, *bodyStep)
+			}
+		}
+
 		current = NextDefaultStep(step)
 	}
 
@@ -282,8 +304,9 @@ func ExecutionOrder(wf *Workflow) []Step {
 }
 
 // GetTransitions returns all outbound transitions from a step.
-// For command/operation/loop/call_workflow steps: on_success, on_failure
+// For command/operation/call_workflow steps: on_success, on_failure
 // For parallel steps: on_success, on_failure, and all branches
+// For loop steps (for_each/while): on_success, on_failure, body steps, and on_complete
 // For terminal steps: empty
 func GetTransitions(step *Step) []string {
 	if step == nil {
@@ -310,6 +333,14 @@ func GetTransitions(step *Step) []string {
 	// For parallel steps, add branches
 	if step.Type == StepTypeParallel {
 		transitions = append(transitions, step.Branches...)
+	}
+
+	// For loop steps, add body steps and on_complete
+	if step.Loop != nil {
+		transitions = append(transitions, step.Loop.Body...)
+		if step.Loop.OnComplete != "" {
+			transitions = append(transitions, step.Loop.OnComplete)
+		}
 	}
 
 	return transitions

--- a/internal/domain/workflow/graph_test.go
+++ b/internal/domain/workflow/graph_test.go
@@ -1908,3 +1908,205 @@ func TestExecutionOrder_BothDefaultTransitionAndOnSuccess(t *testing.T) {
 	assert.Equal(t, "default_step", result[1].Name, "should follow default transition, not OnSuccess")
 	assert.Equal(t, "done", result[2].Name)
 }
+
+func TestGetTransitions_ForEachStep(t *testing.T) {
+	step := &workflow.Step{
+		Name:      "loop",
+		Type:      workflow.StepTypeForEach,
+		OnSuccess: "fallback",
+		OnFailure: "error",
+		Loop: &workflow.LoopConfig{
+			Type:       workflow.LoopTypeForEach,
+			Items:      "{{.states.prev.Output}}",
+			Body:       []string{"body1", "body2"},
+			OnComplete: "after_loop",
+		},
+	}
+
+	transitions := workflow.GetTransitions(step)
+
+	assert.Contains(t, transitions, "fallback")
+	assert.Contains(t, transitions, "error")
+	assert.Contains(t, transitions, "body1")
+	assert.Contains(t, transitions, "body2")
+	assert.Contains(t, transitions, "after_loop")
+}
+
+func TestGetTransitions_WhileStep(t *testing.T) {
+	step := &workflow.Step{
+		Name: "loop",
+		Type: workflow.StepTypeWhile,
+		Loop: &workflow.LoopConfig{
+			Type:       workflow.LoopTypeWhile,
+			Condition:  "true",
+			Body:       []string{"check"},
+			OnComplete: "done",
+		},
+	}
+
+	transitions := workflow.GetTransitions(step)
+
+	assert.Contains(t, transitions, "check")
+	assert.Contains(t, transitions, "done")
+}
+
+func TestNextDefaultStep_ForEachLoopOnComplete(t *testing.T) {
+	step := &workflow.Step{
+		Name: "loop",
+		Type: workflow.StepTypeForEach,
+		Loop: &workflow.LoopConfig{
+			Type:       workflow.LoopTypeForEach,
+			Items:      "{{.states.prev.Output}}",
+			Body:       []string{"body1"},
+			OnComplete: "after_loop",
+		},
+	}
+
+	next := workflow.NextDefaultStep(step)
+
+	assert.Equal(t, "after_loop", next)
+}
+
+func TestNextDefaultStep_ForEachFallsBackToOnSuccess(t *testing.T) {
+	step := &workflow.Step{
+		Name:      "loop",
+		Type:      workflow.StepTypeForEach,
+		OnSuccess: "fallback",
+		Loop: &workflow.LoopConfig{
+			Type:  workflow.LoopTypeForEach,
+			Items: "{{.states.prev.Output}}",
+			Body:  []string{"body1"},
+		},
+	}
+
+	next := workflow.NextDefaultStep(step)
+
+	assert.Equal(t, "fallback", next)
+}
+
+func TestExecutionOrder_ForEachWithBodySteps(t *testing.T) {
+	wf := &workflow.Workflow{
+		Initial: "setup",
+		Steps: map[string]*workflow.Step{
+			"setup": {
+				Name:      "setup",
+				Type:      workflow.StepTypeCommand,
+				OnSuccess: "loop",
+			},
+			"loop": {
+				Name: "loop",
+				Type: workflow.StepTypeForEach,
+				Loop: &workflow.LoopConfig{
+					Type:       workflow.LoopTypeForEach,
+					Items:      "{{.states.setup.Output}}",
+					Body:       []string{"body_step", "call_sub"},
+					OnComplete: "done",
+				},
+			},
+			"body_step": {
+				Name:      "body_step",
+				Type:      workflow.StepTypeCommand,
+				OnSuccess: "call_sub",
+			},
+			"call_sub": {
+				Name:      "call_sub",
+				Type:      workflow.StepTypeCallWorkflow,
+				OnSuccess: "loop",
+			},
+			"done": {
+				Name:   "done",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	result := workflow.ExecutionOrder(wf)
+
+	require.NotNil(t, result)
+	require.Len(t, result, 5)
+	assert.Equal(t, "setup", result[0].Name)
+	assert.Equal(t, "loop", result[1].Name)
+	assert.Equal(t, "body_step", result[2].Name)
+	assert.Equal(t, "call_sub", result[3].Name)
+	assert.Equal(t, "done", result[4].Name)
+}
+
+func TestExecutionOrder_WhileWithBodySteps(t *testing.T) {
+	wf := &workflow.Workflow{
+		Initial: "init",
+		Steps: map[string]*workflow.Step{
+			"init": {
+				Name:      "init",
+				Type:      workflow.StepTypeCommand,
+				OnSuccess: "retry_loop",
+			},
+			"retry_loop": {
+				Name: "retry_loop",
+				Type: workflow.StepTypeWhile,
+				Loop: &workflow.LoopConfig{
+					Type:       workflow.LoopTypeWhile,
+					Condition:  "true",
+					Body:       []string{"attempt"},
+					OnComplete: "success",
+				},
+			},
+			"attempt": {
+				Name:      "attempt",
+				Type:      workflow.StepTypeCommand,
+				OnSuccess: "retry_loop",
+			},
+			"success": {
+				Name:   "success",
+				Type:   workflow.StepTypeTerminal,
+				Status: workflow.TerminalSuccess,
+			},
+		},
+	}
+
+	result := workflow.ExecutionOrder(wf)
+
+	require.NotNil(t, result)
+	require.Len(t, result, 4)
+	assert.Equal(t, "init", result[0].Name)
+	assert.Equal(t, "retry_loop", result[1].Name)
+	assert.Equal(t, "attempt", result[2].Name)
+	assert.Equal(t, "success", result[3].Name)
+}
+
+func TestFindReachableStates_ForEachBodyAndOnComplete(t *testing.T) {
+	steps := map[string]*workflow.Step{
+		"start": {
+			Name:      "start",
+			Type:      workflow.StepTypeCommand,
+			OnSuccess: "loop",
+		},
+		"loop": {
+			Name: "loop",
+			Type: workflow.StepTypeForEach,
+			Loop: &workflow.LoopConfig{
+				Type:       workflow.LoopTypeForEach,
+				Items:      "items",
+				Body:       []string{"body1"},
+				OnComplete: "done",
+			},
+		},
+		"body1": {
+			Name:      "body1",
+			Type:      workflow.StepTypeCommand,
+			OnSuccess: "loop",
+		},
+		"done": {
+			Name:   "done",
+			Type:   workflow.StepTypeTerminal,
+			Status: workflow.TerminalSuccess,
+		},
+	}
+
+	reachable := workflow.FindReachableStates(steps, "start")
+
+	assert.True(t, reachable["start"])
+	assert.True(t, reachable["loop"])
+	assert.True(t, reachable["body1"], "loop body step should be reachable")
+	assert.True(t, reachable["done"], "on_complete target should be reachable")
+}


### PR DESCRIPTION
## Summary

- Graph traversal was blind to loop steps: `ExecutionOrder` skipped body steps entirely and `NextDefaultStep` ignored `Loop.OnComplete`, causing incorrect step ordering and reachability analysis for `for_each`/`while` workflows.
- `ExecutionOrder` now inlines loop body steps immediately after the loop step before advancing to `on_complete`, matching actual runtime execution order.
- `NextDefaultStep` now prefers `Loop.OnComplete` over `OnSuccess` as the default continuation target for loop steps, with `OnSuccess` retained as fallback when `on_complete` is absent.
- `GetTransitions` now emits body step names and `on_complete` as outbound edges for loop steps, so reachability analysis (`FindReachableStates`) correctly marks body steps and post-loop targets as reachable.

## Changes

### Graph Traversal
- `internal/domain/workflow/graph.go`: Extend `NextDefaultStep` to check `Loop.OnComplete` before `OnSuccess`; extend `ExecutionOrder` to inline loop body steps; extend `GetTransitions` to include loop body references and `on_complete` as outbound edges.

### Tests
- `internal/domain/workflow/graph_test.go`: Add 7 tests covering `GetTransitions` for `for_each` and `while` steps, `NextDefaultStep` with and without `on_complete`, `ExecutionOrder` for both loop types with body steps, and `FindReachableStates` reachability through loop bodies and `on_complete`.

## Test plan

- [x] Run `make test-unit` and confirm all new graph tests pass with zero failures
- [x] Run `make test-race` to verify no data races in graph traversal under concurrent access
- [x] Validate a `for_each` workflow with body steps: `awf validate <workflow>` should report no unreachable steps
- [x] Run `awf run <for_each_workflow>` and confirm body steps execute in the declared order before advancing to `on_complete`

---
Generated with [awf](https://github.com/awf-project/cli) commit workflow
